### PR TITLE
Configure and test more handlers

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -28,7 +28,7 @@
     "@metaplex-foundation/umi": "0.6 - 0.7"
   },
   "dependencies": {
-    "@metaplex-foundation/mpl-essentials": "^0.5.5"
+    "@metaplex-foundation/mpl-essentials": "^0.5.7"
   },
   "devDependencies": {
     "@ava/typescript": "^3.0.1",

--- a/clients/js/pnpm-lock.yaml
+++ b/clients/js/pnpm-lock.yaml
@@ -2,8 +2,8 @@ lockfileVersion: '6.0'
 
 dependencies:
   '@metaplex-foundation/mpl-essentials':
-    specifier: ^0.5.5
-    version: 0.5.5(@metaplex-foundation/umi@0.7.2)
+    specifier: ^0.5.7
+    version: 0.5.7(@metaplex-foundation/umi@0.7.2)
 
 devDependencies:
   '@ava/typescript':
@@ -1619,8 +1619,8 @@ packages:
       - supports-color
     dev: true
 
-  /@metaplex-foundation/mpl-essentials@0.5.5(@metaplex-foundation/umi@0.7.2):
-    resolution: {integrity: sha512-0zdFfhHbFF7Wygbg5TMst3ZUOz5axkQ8J+TySePd9p7RRW+Btk5bErIrVTDuiUB+KV/6eQenfWt8KliwVkhDYg==}
+  /@metaplex-foundation/mpl-essentials@0.5.7(@metaplex-foundation/umi@0.7.2):
+    resolution: {integrity: sha512-//LOSNoXMOeH/0+WWZCOmspRj4tdl7isL6U47yF6CzmNgjnLDQiNhcsrCmaYpyE/dNAjmeR3IDdA/7gCGvsKIg==}
     peerDependencies:
       '@metaplex-foundation/umi': 0.6 - 0.7
     dependencies:

--- a/clients/js/src/generated/instructions/burn.ts
+++ b/clients/js/src/generated/instructions/burn.ts
@@ -18,7 +18,11 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveMasterEdition, resolveTokenRecord } from '../../hooked';
+import {
+  resolveBurnMasterEdition,
+  resolveMasterEdition,
+  resolveTokenRecord,
+} from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { PickPartial, addObjectProperty, isWritable } from '../shared';
 import {
@@ -162,13 +166,19 @@ export function burn(
   );
   addObjectProperty(
     resolvingAccounts,
-    'masterEdition',
-    input.masterEdition ?? programId
+    'masterEditionMint',
+    input.masterEditionMint ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'masterEditionMint',
-    input.masterEditionMint ?? programId
+    'masterEdition',
+    input.masterEdition ??
+      resolveBurnMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/burnV1.ts
+++ b/clients/js/src/generated/instructions/burnV1.ts
@@ -59,7 +59,7 @@ export type BurnV1InstructionData = {
   amount: bigint;
 };
 
-export type BurnV1InstructionDataArgs = { amount: number | bigint };
+export type BurnV1InstructionDataArgs = { amount?: number | bigint };
 
 export function getBurnV1InstructionDataSerializer(
   context: Pick<Context, 'serializer'>
@@ -83,6 +83,7 @@ export function getBurnV1InstructionDataSerializer(
         ...value,
         discriminator: 41,
         burnV1Discriminator: 0,
+        amount: value.amount ?? 1,
       } as BurnV1InstructionData)
   ) as Serializer<BurnV1InstructionDataArgs, BurnV1InstructionData>;
 }

--- a/clients/js/src/generated/instructions/burnV1.ts
+++ b/clients/js/src/generated/instructions/burnV1.ts
@@ -18,7 +18,11 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveMasterEdition, resolveTokenRecord } from '../../hooked';
+import {
+  resolveBurnMasterEdition,
+  resolveMasterEdition,
+  resolveTokenRecord,
+} from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { PickPartial, addObjectProperty, isWritable } from '../shared';
 import { TokenStandardArgs } from '../types';
@@ -168,13 +172,19 @@ export function burnV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'masterEdition',
-    input.masterEdition ?? programId
+    'masterEditionMint',
+    input.masterEditionMint ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'masterEditionMint',
-    input.masterEditionMint ?? programId
+    'masterEdition',
+    input.masterEdition ??
+      resolveBurnMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/delegate.ts
+++ b/clients/js/src/generated/instructions/delegate.ts
@@ -20,6 +20,7 @@ import {
 import {
   resolveAuthorizationRulesProgram,
   resolveMasterEdition,
+  resolveTokenRecord,
 } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
@@ -141,12 +142,18 @@ export function delegate(
         programId
       )
   );
+  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
-    input.tokenRecord ?? programId
+    input.tokenRecord ??
+      resolveTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'authority',

--- a/clients/js/src/generated/instructions/delegate.ts
+++ b/clients/js/src/generated/instructions/delegate.ts
@@ -17,12 +17,16 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+} from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
   DelegateArgs,
   DelegateArgsArgs,
+  TokenStandardArgs,
   getDelegateArgsSerializer,
 } from '../types';
 
@@ -86,8 +90,12 @@ export function getDelegateInstructionDataSerializer(
   ) as Serializer<DelegateInstructionDataArgs, DelegateInstructionData>;
 }
 
+// Extra Args.
+export type DelegateInstructionExtraArgs = { tokenStandard: TokenStandardArgs };
+
 // Args.
-export type DelegateInstructionArgs = DelegateInstructionDataArgs;
+export type DelegateInstructionArgs = DelegateInstructionDataArgs &
+  DelegateInstructionExtraArgs;
 
 // Instruction.
 export function delegate(
@@ -125,7 +133,13 @@ export function delegate(
   addObjectProperty(
     resolvingAccounts,
     'masterEdition',
-    input.masterEdition ?? programId
+    input.masterEdition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/delegate.ts
+++ b/clients/js/src/generated/instructions/delegate.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
@@ -162,13 +163,19 @@ export function delegate(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/delegateCollectionV1.ts
+++ b/clients/js/src/generated/instructions/delegateCollectionV1.ts
@@ -15,6 +15,7 @@ import {
   Signer,
   TransactionBuilder,
   mapSerializer,
+  none,
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
@@ -67,7 +68,7 @@ export type DelegateCollectionV1InstructionData = {
 };
 
 export type DelegateCollectionV1InstructionDataArgs = {
-  authorizationData: Option<AuthorizationDataArgs>;
+  authorizationData?: Option<AuthorizationDataArgs>;
 };
 
 export function getDelegateCollectionV1InstructionDataSerializer(
@@ -98,6 +99,7 @@ export function getDelegateCollectionV1InstructionDataSerializer(
         ...value,
         discriminator: 44,
         delegateCollectionV1Discriminator: 0,
+        authorizationData: value.authorizationData ?? none(),
       } as DelegateCollectionV1InstructionData)
   ) as Serializer<
     DelegateCollectionV1InstructionDataArgs,

--- a/clients/js/src/generated/instructions/delegateCollectionV1.ts
+++ b/clients/js/src/generated/instructions/delegateCollectionV1.ts
@@ -18,6 +18,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
@@ -183,13 +184,19 @@ export function delegateCollectionV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/delegateCollectionV1.ts
+++ b/clients/js/src/generated/instructions/delegateCollectionV1.ts
@@ -22,6 +22,7 @@ import {
 import {
   resolveAuthorizationRulesProgram,
   resolveMasterEdition,
+  resolveTokenRecord,
 } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
@@ -166,12 +167,18 @@ export function delegateCollectionV1(
         programId
       )
   );
+  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
-    input.tokenRecord ?? programId
+    input.tokenRecord ??
+      resolveTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'authority',

--- a/clients/js/src/generated/instructions/delegateCollectionV1.ts
+++ b/clients/js/src/generated/instructions/delegateCollectionV1.ts
@@ -19,12 +19,16 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+} from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
   AuthorizationData,
   AuthorizationDataArgs,
+  TokenStandardArgs,
   getAuthorizationDataSerializer,
 } from '../types';
 
@@ -107,9 +111,15 @@ export function getDelegateCollectionV1InstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type DelegateCollectionV1InstructionExtraArgs = {
+  tokenStandard: TokenStandardArgs;
+};
+
 // Args.
 export type DelegateCollectionV1InstructionArgs =
-  DelegateCollectionV1InstructionDataArgs;
+  DelegateCollectionV1InstructionDataArgs &
+    DelegateCollectionV1InstructionExtraArgs;
 
 // Instruction.
 export function delegateCollectionV1(
@@ -148,7 +158,13 @@ export function delegateCollectionV1(
   addObjectProperty(
     resolvingAccounts,
     'masterEdition',
-    input.masterEdition ?? programId
+    input.masterEdition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/delegateLockedTransferV1.ts
+++ b/clients/js/src/generated/instructions/delegateLockedTransferV1.ts
@@ -19,12 +19,16 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+} from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
   AuthorizationData,
   AuthorizationDataArgs,
+  TokenStandardArgs,
   getAuthorizationDataSerializer,
 } from '../types';
 
@@ -113,9 +117,15 @@ export function getDelegateLockedTransferV1InstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type DelegateLockedTransferV1InstructionExtraArgs = {
+  tokenStandard: TokenStandardArgs;
+};
+
 // Args.
 export type DelegateLockedTransferV1InstructionArgs =
-  DelegateLockedTransferV1InstructionDataArgs;
+  DelegateLockedTransferV1InstructionDataArgs &
+    DelegateLockedTransferV1InstructionExtraArgs;
 
 // Instruction.
 export function delegateLockedTransferV1(
@@ -154,7 +164,13 @@ export function delegateLockedTransferV1(
   addObjectProperty(
     resolvingAccounts,
     'masterEdition',
-    input.masterEdition ?? programId
+    input.masterEdition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/delegateLockedTransferV1.ts
+++ b/clients/js/src/generated/instructions/delegateLockedTransferV1.ts
@@ -75,7 +75,7 @@ export type DelegateLockedTransferV1InstructionData = {
 };
 
 export type DelegateLockedTransferV1InstructionDataArgs = {
-  amount: number | bigint;
+  amount?: number | bigint;
   lockedAddress: PublicKey;
   authorizationData?: Option<AuthorizationDataArgs>;
 };
@@ -110,6 +110,7 @@ export function getDelegateLockedTransferV1InstructionDataSerializer(
         ...value,
         discriminator: 44,
         delegateLockedTransferV1Discriminator: 7,
+        amount: value.amount ?? 1,
         authorizationData: value.authorizationData ?? none(),
       } as DelegateLockedTransferV1InstructionData)
   ) as Serializer<

--- a/clients/js/src/generated/instructions/delegateLockedTransferV1.ts
+++ b/clients/js/src/generated/instructions/delegateLockedTransferV1.ts
@@ -15,6 +15,7 @@ import {
   Signer,
   TransactionBuilder,
   mapSerializer,
+  none,
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
@@ -71,7 +72,7 @@ export type DelegateLockedTransferV1InstructionData = {
 export type DelegateLockedTransferV1InstructionDataArgs = {
   amount: number | bigint;
   lockedAddress: PublicKey;
-  authorizationData: Option<AuthorizationDataArgs>;
+  authorizationData?: Option<AuthorizationDataArgs>;
 };
 
 export function getDelegateLockedTransferV1InstructionDataSerializer(
@@ -104,6 +105,7 @@ export function getDelegateLockedTransferV1InstructionDataSerializer(
         ...value,
         discriminator: 44,
         delegateLockedTransferV1Discriminator: 7,
+        authorizationData: value.authorizationData ?? none(),
       } as DelegateLockedTransferV1InstructionData)
   ) as Serializer<
     DelegateLockedTransferV1InstructionDataArgs,

--- a/clients/js/src/generated/instructions/delegateLockedTransferV1.ts
+++ b/clients/js/src/generated/instructions/delegateLockedTransferV1.ts
@@ -22,6 +22,7 @@ import {
 import {
   resolveAuthorizationRulesProgram,
   resolveMasterEdition,
+  resolveTokenRecord,
 } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
@@ -172,12 +173,18 @@ export function delegateLockedTransferV1(
         programId
       )
   );
+  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
-    input.tokenRecord ?? programId
+    input.tokenRecord ??
+      resolveTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'authority',

--- a/clients/js/src/generated/instructions/delegateLockedTransferV1.ts
+++ b/clients/js/src/generated/instructions/delegateLockedTransferV1.ts
@@ -6,6 +6,7 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
+import { findAssociatedTokenPda } from '@metaplex-foundation/mpl-essentials';
 import {
   AccountMeta,
   Context,
@@ -24,8 +25,8 @@ import {
   resolveMasterEdition,
   resolveTokenRecord,
 } from '../../hooked';
-import { findMetadataPda } from '../accounts';
-import { addObjectProperty, isWritable } from '../shared';
+import { findMetadataPda, findTokenRecordPda } from '../accounts';
+import { PickPartial, addObjectProperty, isWritable } from '../shared';
 import {
   AuthorizationData,
   AuthorizationDataArgs,
@@ -122,12 +123,15 @@ export function getDelegateLockedTransferV1InstructionDataSerializer(
 // Extra Args.
 export type DelegateLockedTransferV1InstructionExtraArgs = {
   tokenStandard: TokenStandardArgs;
+  tokenOwner: PublicKey;
 };
 
 // Args.
-export type DelegateLockedTransferV1InstructionArgs =
+export type DelegateLockedTransferV1InstructionArgs = PickPartial<
   DelegateLockedTransferV1InstructionDataArgs &
-    DelegateLockedTransferV1InstructionExtraArgs;
+    DelegateLockedTransferV1InstructionExtraArgs,
+  'tokenOwner'
+>;
 
 // Instruction.
 export function delegateLockedTransferV1(
@@ -154,9 +158,27 @@ export function delegateLockedTransferV1(
   const resolvingAccounts = {};
   const resolvingArgs = {};
   addObjectProperty(
+    resolvingArgs,
+    'tokenOwner',
+    input.tokenOwner ?? context.identity.publicKey
+  );
+  addObjectProperty(
+    resolvingAccounts,
+    'token',
+    input.token ??
+      findAssociatedTokenPda(context, {
+        mint: publicKey(input.mint),
+        owner: resolvingArgs.tokenOwner,
+      })
+  );
+  addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
-    input.delegateRecord ?? programId
+    input.delegateRecord ??
+      findTokenRecordPda(context, {
+        mint: publicKey(input.mint),
+        token: publicKey(resolvingAccounts.token),
+      })
   );
   addObjectProperty(
     resolvingAccounts,
@@ -174,7 +196,6 @@ export function delegateLockedTransferV1(
         programId
       )
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
@@ -212,7 +233,13 @@ export function delegateLockedTransferV1(
   addObjectProperty(
     resolvingAccounts,
     'splTokenProgram',
-    input.splTokenProgram ?? programId
+    input.splTokenProgram ?? {
+      ...context.programs.getPublicKey(
+        'splToken',
+        'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+      ),
+      isWritable: false,
+    }
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/delegateLockedTransferV1.ts
+++ b/clients/js/src/generated/instructions/delegateLockedTransferV1.ts
@@ -18,6 +18,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
@@ -189,13 +190,19 @@ export function delegateLockedTransferV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/delegateProgrammableConfigV1.ts
+++ b/clients/js/src/generated/instructions/delegateProgrammableConfigV1.ts
@@ -19,12 +19,16 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+} from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
   AuthorizationData,
   AuthorizationDataArgs,
+  TokenStandardArgs,
   getAuthorizationDataSerializer,
 } from '../types';
 
@@ -107,9 +111,15 @@ export function getDelegateProgrammableConfigV1InstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type DelegateProgrammableConfigV1InstructionExtraArgs = {
+  tokenStandard: TokenStandardArgs;
+};
+
 // Args.
 export type DelegateProgrammableConfigV1InstructionArgs =
-  DelegateProgrammableConfigV1InstructionDataArgs;
+  DelegateProgrammableConfigV1InstructionDataArgs &
+    DelegateProgrammableConfigV1InstructionExtraArgs;
 
 // Instruction.
 export function delegateProgrammableConfigV1(
@@ -148,7 +158,13 @@ export function delegateProgrammableConfigV1(
   addObjectProperty(
     resolvingAccounts,
     'masterEdition',
-    input.masterEdition ?? programId
+    input.masterEdition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/delegateProgrammableConfigV1.ts
+++ b/clients/js/src/generated/instructions/delegateProgrammableConfigV1.ts
@@ -15,6 +15,7 @@ import {
   Signer,
   TransactionBuilder,
   mapSerializer,
+  none,
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
@@ -67,7 +68,7 @@ export type DelegateProgrammableConfigV1InstructionData = {
 };
 
 export type DelegateProgrammableConfigV1InstructionDataArgs = {
-  authorizationData: Option<AuthorizationDataArgs>;
+  authorizationData?: Option<AuthorizationDataArgs>;
 };
 
 export function getDelegateProgrammableConfigV1InstructionDataSerializer(
@@ -98,6 +99,7 @@ export function getDelegateProgrammableConfigV1InstructionDataSerializer(
         ...value,
         discriminator: 44,
         delegateProgrammableConfigV1Discriminator: 8,
+        authorizationData: value.authorizationData ?? none(),
       } as DelegateProgrammableConfigV1InstructionData)
   ) as Serializer<
     DelegateProgrammableConfigV1InstructionDataArgs,

--- a/clients/js/src/generated/instructions/delegateProgrammableConfigV1.ts
+++ b/clients/js/src/generated/instructions/delegateProgrammableConfigV1.ts
@@ -22,6 +22,7 @@ import {
 import {
   resolveAuthorizationRulesProgram,
   resolveMasterEdition,
+  resolveTokenRecord,
 } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
@@ -166,12 +167,18 @@ export function delegateProgrammableConfigV1(
         programId
       )
   );
+  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
-    input.tokenRecord ?? programId
+    input.tokenRecord ??
+      resolveTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'authority',

--- a/clients/js/src/generated/instructions/delegateProgrammableConfigV1.ts
+++ b/clients/js/src/generated/instructions/delegateProgrammableConfigV1.ts
@@ -18,6 +18,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
@@ -183,13 +184,19 @@ export function delegateProgrammableConfigV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/delegateSaleV1.ts
+++ b/clients/js/src/generated/instructions/delegateSaleV1.ts
@@ -19,12 +19,16 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+} from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
   AuthorizationData,
   AuthorizationDataArgs,
+  TokenStandardArgs,
   getAuthorizationDataSerializer,
 } from '../types';
 
@@ -110,8 +114,14 @@ export function getDelegateSaleV1InstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type DelegateSaleV1InstructionExtraArgs = {
+  tokenStandard: TokenStandardArgs;
+};
+
 // Args.
-export type DelegateSaleV1InstructionArgs = DelegateSaleV1InstructionDataArgs;
+export type DelegateSaleV1InstructionArgs = DelegateSaleV1InstructionDataArgs &
+  DelegateSaleV1InstructionExtraArgs;
 
 // Instruction.
 export function delegateSaleV1(
@@ -149,7 +159,13 @@ export function delegateSaleV1(
   addObjectProperty(
     resolvingAccounts,
     'masterEdition',
-    input.masterEdition ?? programId
+    input.masterEdition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/delegateSaleV1.ts
+++ b/clients/js/src/generated/instructions/delegateSaleV1.ts
@@ -22,6 +22,7 @@ import {
 import {
   resolveAuthorizationRulesProgram,
   resolveMasterEdition,
+  resolveTokenRecord,
 } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
@@ -167,12 +168,18 @@ export function delegateSaleV1(
         programId
       )
   );
+  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
-    input.tokenRecord ?? programId
+    input.tokenRecord ??
+      resolveTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'authority',

--- a/clients/js/src/generated/instructions/delegateSaleV1.ts
+++ b/clients/js/src/generated/instructions/delegateSaleV1.ts
@@ -74,7 +74,7 @@ export type DelegateSaleV1InstructionData = {
 };
 
 export type DelegateSaleV1InstructionDataArgs = {
-  amount: number | bigint;
+  amount?: number | bigint;
   authorizationData?: Option<AuthorizationDataArgs>;
 };
 
@@ -107,6 +107,7 @@ export function getDelegateSaleV1InstructionDataSerializer(
         ...value,
         discriminator: 44,
         delegateSaleV1Discriminator: 1,
+        amount: value.amount ?? 1,
         authorizationData: value.authorizationData ?? none(),
       } as DelegateSaleV1InstructionData)
   ) as Serializer<

--- a/clients/js/src/generated/instructions/delegateSaleV1.ts
+++ b/clients/js/src/generated/instructions/delegateSaleV1.ts
@@ -18,6 +18,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
@@ -184,13 +185,19 @@ export function delegateSaleV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/delegateSaleV1.ts
+++ b/clients/js/src/generated/instructions/delegateSaleV1.ts
@@ -15,6 +15,7 @@ import {
   Signer,
   TransactionBuilder,
   mapSerializer,
+  none,
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
@@ -69,7 +70,7 @@ export type DelegateSaleV1InstructionData = {
 
 export type DelegateSaleV1InstructionDataArgs = {
   amount: number | bigint;
-  authorizationData: Option<AuthorizationDataArgs>;
+  authorizationData?: Option<AuthorizationDataArgs>;
 };
 
 export function getDelegateSaleV1InstructionDataSerializer(
@@ -101,6 +102,7 @@ export function getDelegateSaleV1InstructionDataSerializer(
         ...value,
         discriminator: 44,
         delegateSaleV1Discriminator: 1,
+        authorizationData: value.authorizationData ?? none(),
       } as DelegateSaleV1InstructionData)
   ) as Serializer<
     DelegateSaleV1InstructionDataArgs,

--- a/clients/js/src/generated/instructions/delegateStakingV1.ts
+++ b/clients/js/src/generated/instructions/delegateStakingV1.ts
@@ -6,6 +6,7 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
+import { findAssociatedTokenPda } from '@metaplex-foundation/mpl-essentials';
 import {
   AccountMeta,
   Context,
@@ -24,8 +25,8 @@ import {
   resolveMasterEdition,
   resolveTokenRecord,
 } from '../../hooked';
-import { findMetadataPda } from '../accounts';
-import { addObjectProperty, isWritable } from '../shared';
+import { findMetadataPda, findTokenRecordPda } from '../accounts';
+import { PickPartial, addObjectProperty, isWritable } from '../shared';
 import {
   AuthorizationData,
   AuthorizationDataArgs,
@@ -119,11 +120,14 @@ export function getDelegateStakingV1InstructionDataSerializer(
 // Extra Args.
 export type DelegateStakingV1InstructionExtraArgs = {
   tokenStandard: TokenStandardArgs;
+  tokenOwner: PublicKey;
 };
 
 // Args.
-export type DelegateStakingV1InstructionArgs =
-  DelegateStakingV1InstructionDataArgs & DelegateStakingV1InstructionExtraArgs;
+export type DelegateStakingV1InstructionArgs = PickPartial<
+  DelegateStakingV1InstructionDataArgs & DelegateStakingV1InstructionExtraArgs,
+  'tokenOwner'
+>;
 
 // Instruction.
 export function delegateStakingV1(
@@ -149,9 +153,27 @@ export function delegateStakingV1(
   const resolvingAccounts = {};
   const resolvingArgs = {};
   addObjectProperty(
+    resolvingArgs,
+    'tokenOwner',
+    input.tokenOwner ?? context.identity.publicKey
+  );
+  addObjectProperty(
+    resolvingAccounts,
+    'token',
+    input.token ??
+      findAssociatedTokenPda(context, {
+        mint: publicKey(input.mint),
+        owner: resolvingArgs.tokenOwner,
+      })
+  );
+  addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
-    input.delegateRecord ?? programId
+    input.delegateRecord ??
+      findTokenRecordPda(context, {
+        mint: publicKey(input.mint),
+        token: publicKey(resolvingAccounts.token),
+      })
   );
   addObjectProperty(
     resolvingAccounts,
@@ -169,7 +191,6 @@ export function delegateStakingV1(
         programId
       )
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
@@ -207,7 +228,13 @@ export function delegateStakingV1(
   addObjectProperty(
     resolvingAccounts,
     'splTokenProgram',
-    input.splTokenProgram ?? programId
+    input.splTokenProgram ?? {
+      ...context.programs.getPublicKey(
+        'splToken',
+        'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+      ),
+      isWritable: false,
+    }
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/delegateStakingV1.ts
+++ b/clients/js/src/generated/instructions/delegateStakingV1.ts
@@ -22,6 +22,7 @@ import {
 import {
   resolveAuthorizationRulesProgram,
   resolveMasterEdition,
+  resolveTokenRecord,
 } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
@@ -167,12 +168,18 @@ export function delegateStakingV1(
         programId
       )
   );
+  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
-    input.tokenRecord ?? programId
+    input.tokenRecord ??
+      resolveTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'authority',

--- a/clients/js/src/generated/instructions/delegateStakingV1.ts
+++ b/clients/js/src/generated/instructions/delegateStakingV1.ts
@@ -74,7 +74,7 @@ export type DelegateStakingV1InstructionData = {
 };
 
 export type DelegateStakingV1InstructionDataArgs = {
-  amount: number | bigint;
+  amount?: number | bigint;
   authorizationData?: Option<AuthorizationDataArgs>;
 };
 
@@ -107,6 +107,7 @@ export function getDelegateStakingV1InstructionDataSerializer(
         ...value,
         discriminator: 44,
         delegateStakingV1Discriminator: 5,
+        amount: value.amount ?? 1,
         authorizationData: value.authorizationData ?? none(),
       } as DelegateStakingV1InstructionData)
   ) as Serializer<

--- a/clients/js/src/generated/instructions/delegateStakingV1.ts
+++ b/clients/js/src/generated/instructions/delegateStakingV1.ts
@@ -19,12 +19,16 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+} from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
   AuthorizationData,
   AuthorizationDataArgs,
+  TokenStandardArgs,
   getAuthorizationDataSerializer,
 } from '../types';
 
@@ -110,9 +114,14 @@ export function getDelegateStakingV1InstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type DelegateStakingV1InstructionExtraArgs = {
+  tokenStandard: TokenStandardArgs;
+};
+
 // Args.
 export type DelegateStakingV1InstructionArgs =
-  DelegateStakingV1InstructionDataArgs;
+  DelegateStakingV1InstructionDataArgs & DelegateStakingV1InstructionExtraArgs;
 
 // Instruction.
 export function delegateStakingV1(
@@ -150,7 +159,13 @@ export function delegateStakingV1(
   addObjectProperty(
     resolvingAccounts,
     'masterEdition',
-    input.masterEdition ?? programId
+    input.masterEdition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/delegateStakingV1.ts
+++ b/clients/js/src/generated/instructions/delegateStakingV1.ts
@@ -15,6 +15,7 @@ import {
   Signer,
   TransactionBuilder,
   mapSerializer,
+  none,
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
@@ -69,7 +70,7 @@ export type DelegateStakingV1InstructionData = {
 
 export type DelegateStakingV1InstructionDataArgs = {
   amount: number | bigint;
-  authorizationData: Option<AuthorizationDataArgs>;
+  authorizationData?: Option<AuthorizationDataArgs>;
 };
 
 export function getDelegateStakingV1InstructionDataSerializer(
@@ -101,6 +102,7 @@ export function getDelegateStakingV1InstructionDataSerializer(
         ...value,
         discriminator: 44,
         delegateStakingV1Discriminator: 5,
+        authorizationData: value.authorizationData ?? none(),
       } as DelegateStakingV1InstructionData)
   ) as Serializer<
     DelegateStakingV1InstructionDataArgs,

--- a/clients/js/src/generated/instructions/delegateStakingV1.ts
+++ b/clients/js/src/generated/instructions/delegateStakingV1.ts
@@ -18,6 +18,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
@@ -185,13 +186,19 @@ export function delegateStakingV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/delegateStandardV1.ts
+++ b/clients/js/src/generated/instructions/delegateStandardV1.ts
@@ -65,7 +65,9 @@ export type DelegateStandardV1InstructionData = {
   amount: bigint;
 };
 
-export type DelegateStandardV1InstructionDataArgs = { amount: number | bigint };
+export type DelegateStandardV1InstructionDataArgs = {
+  amount?: number | bigint;
+};
 
 export function getDelegateStandardV1InstructionDataSerializer(
   context: Pick<Context, 'serializer'>
@@ -92,6 +94,7 @@ export function getDelegateStandardV1InstructionDataSerializer(
         ...value,
         discriminator: 44,
         delegateStandardV1Discriminator: 6,
+        amount: value.amount ?? 1,
       } as DelegateStandardV1InstructionData)
   ) as Serializer<
     DelegateStandardV1InstructionDataArgs,

--- a/clients/js/src/generated/instructions/delegateStandardV1.ts
+++ b/clients/js/src/generated/instructions/delegateStandardV1.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 
@@ -172,13 +173,19 @@ export function delegateStandardV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/delegateStandardV1.ts
+++ b/clients/js/src/generated/instructions/delegateStandardV1.ts
@@ -20,6 +20,7 @@ import {
 import {
   resolveAuthorizationRulesProgram,
   resolveMasterEdition,
+  resolveTokenRecord,
 } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
@@ -153,12 +154,18 @@ export function delegateStandardV1(
         programId
       )
   );
+  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
-    input.tokenRecord ?? programId
+    input.tokenRecord ??
+      resolveTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'authority',

--- a/clients/js/src/generated/instructions/delegateStandardV1.ts
+++ b/clients/js/src/generated/instructions/delegateStandardV1.ts
@@ -17,9 +17,13 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+} from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
+import { TokenStandardArgs } from '../types';
 
 // Accounts.
 export type DelegateStandardV1InstructionAccounts = {
@@ -94,9 +98,15 @@ export function getDelegateStandardV1InstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type DelegateStandardV1InstructionExtraArgs = {
+  tokenStandard: TokenStandardArgs;
+};
+
 // Args.
 export type DelegateStandardV1InstructionArgs =
-  DelegateStandardV1InstructionDataArgs;
+  DelegateStandardV1InstructionDataArgs &
+    DelegateStandardV1InstructionExtraArgs;
 
 // Instruction.
 export function delegateStandardV1(
@@ -135,7 +145,13 @@ export function delegateStandardV1(
   addObjectProperty(
     resolvingAccounts,
     'masterEdition',
-    input.masterEdition ?? programId
+    input.masterEdition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/delegateStandardV1.ts
+++ b/clients/js/src/generated/instructions/delegateStandardV1.ts
@@ -21,7 +21,6 @@ import {
 import {
   resolveAuthorizationRulesProgram,
   resolveMasterEdition,
-  resolveTokenRecord,
 } from '../../hooked';
 import { findMetadataPda, findTokenRecordPda } from '../accounts';
 import { PickPartial, addObjectProperty, isWritable } from '../shared';
@@ -182,13 +181,7 @@ export function delegateStandardV1(
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
-    input.tokenRecord ??
-      resolveTokenRecord(
-        context,
-        { ...input, ...resolvingAccounts },
-        { ...input, ...resolvingArgs },
-        programId
-      )
+    input.tokenRecord ?? programId
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/delegateTransferV1.ts
+++ b/clients/js/src/generated/instructions/delegateTransferV1.ts
@@ -22,6 +22,7 @@ import {
 import {
   resolveAuthorizationRulesProgram,
   resolveMasterEdition,
+  resolveTokenRecord,
 } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
@@ -169,12 +170,18 @@ export function delegateTransferV1(
         programId
       )
   );
+  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
-    input.tokenRecord ?? programId
+    input.tokenRecord ??
+      resolveTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'authority',

--- a/clients/js/src/generated/instructions/delegateTransferV1.ts
+++ b/clients/js/src/generated/instructions/delegateTransferV1.ts
@@ -15,6 +15,7 @@ import {
   Signer,
   TransactionBuilder,
   mapSerializer,
+  none,
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
@@ -69,7 +70,7 @@ export type DelegateTransferV1InstructionData = {
 
 export type DelegateTransferV1InstructionDataArgs = {
   amount: number | bigint;
-  authorizationData: Option<AuthorizationDataArgs>;
+  authorizationData?: Option<AuthorizationDataArgs>;
 };
 
 export function getDelegateTransferV1InstructionDataSerializer(
@@ -101,6 +102,7 @@ export function getDelegateTransferV1InstructionDataSerializer(
         ...value,
         discriminator: 44,
         delegateTransferV1Discriminator: 2,
+        authorizationData: value.authorizationData ?? none(),
       } as DelegateTransferV1InstructionData)
   ) as Serializer<
     DelegateTransferV1InstructionDataArgs,

--- a/clients/js/src/generated/instructions/delegateTransferV1.ts
+++ b/clients/js/src/generated/instructions/delegateTransferV1.ts
@@ -18,6 +18,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
@@ -186,13 +187,19 @@ export function delegateTransferV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/delegateTransferV1.ts
+++ b/clients/js/src/generated/instructions/delegateTransferV1.ts
@@ -74,7 +74,7 @@ export type DelegateTransferV1InstructionData = {
 };
 
 export type DelegateTransferV1InstructionDataArgs = {
-  amount: number | bigint;
+  amount?: number | bigint;
   authorizationData?: Option<AuthorizationDataArgs>;
 };
 
@@ -107,6 +107,7 @@ export function getDelegateTransferV1InstructionDataSerializer(
         ...value,
         discriminator: 44,
         delegateTransferV1Discriminator: 2,
+        amount: value.amount ?? 1,
         authorizationData: value.authorizationData ?? none(),
       } as DelegateTransferV1InstructionData)
   ) as Serializer<

--- a/clients/js/src/generated/instructions/delegateTransferV1.ts
+++ b/clients/js/src/generated/instructions/delegateTransferV1.ts
@@ -6,6 +6,7 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
+import { findAssociatedTokenPda } from '@metaplex-foundation/mpl-essentials';
 import {
   AccountMeta,
   Context,
@@ -24,8 +25,8 @@ import {
   resolveMasterEdition,
   resolveTokenRecord,
 } from '../../hooked';
-import { findMetadataPda } from '../accounts';
-import { addObjectProperty, isWritable } from '../shared';
+import { findMetadataPda, findTokenRecordPda } from '../accounts';
+import { PickPartial, addObjectProperty, isWritable } from '../shared';
 import {
   AuthorizationData,
   AuthorizationDataArgs,
@@ -119,12 +120,15 @@ export function getDelegateTransferV1InstructionDataSerializer(
 // Extra Args.
 export type DelegateTransferV1InstructionExtraArgs = {
   tokenStandard: TokenStandardArgs;
+  tokenOwner: PublicKey;
 };
 
 // Args.
-export type DelegateTransferV1InstructionArgs =
+export type DelegateTransferV1InstructionArgs = PickPartial<
   DelegateTransferV1InstructionDataArgs &
-    DelegateTransferV1InstructionExtraArgs;
+    DelegateTransferV1InstructionExtraArgs,
+  'tokenOwner'
+>;
 
 // Instruction.
 export function delegateTransferV1(
@@ -151,9 +155,27 @@ export function delegateTransferV1(
   const resolvingAccounts = {};
   const resolvingArgs = {};
   addObjectProperty(
+    resolvingArgs,
+    'tokenOwner',
+    input.tokenOwner ?? context.identity.publicKey
+  );
+  addObjectProperty(
+    resolvingAccounts,
+    'token',
+    input.token ??
+      findAssociatedTokenPda(context, {
+        mint: publicKey(input.mint),
+        owner: resolvingArgs.tokenOwner,
+      })
+  );
+  addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
-    input.delegateRecord ?? programId
+    input.delegateRecord ??
+      findTokenRecordPda(context, {
+        mint: publicKey(input.mint),
+        token: publicKey(resolvingAccounts.token),
+      })
   );
   addObjectProperty(
     resolvingAccounts,
@@ -171,7 +193,6 @@ export function delegateTransferV1(
         programId
       )
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
@@ -209,7 +230,13 @@ export function delegateTransferV1(
   addObjectProperty(
     resolvingAccounts,
     'splTokenProgram',
-    input.splTokenProgram ?? programId
+    input.splTokenProgram ?? {
+      ...context.programs.getPublicKey(
+        'splToken',
+        'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+      ),
+      isWritable: false,
+    }
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/delegateTransferV1.ts
+++ b/clients/js/src/generated/instructions/delegateTransferV1.ts
@@ -19,12 +19,16 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+} from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
   AuthorizationData,
   AuthorizationDataArgs,
+  TokenStandardArgs,
   getAuthorizationDataSerializer,
 } from '../types';
 
@@ -110,9 +114,15 @@ export function getDelegateTransferV1InstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type DelegateTransferV1InstructionExtraArgs = {
+  tokenStandard: TokenStandardArgs;
+};
+
 // Args.
 export type DelegateTransferV1InstructionArgs =
-  DelegateTransferV1InstructionDataArgs;
+  DelegateTransferV1InstructionDataArgs &
+    DelegateTransferV1InstructionExtraArgs;
 
 // Instruction.
 export function delegateTransferV1(
@@ -151,7 +161,13 @@ export function delegateTransferV1(
   addObjectProperty(
     resolvingAccounts,
     'masterEdition',
-    input.masterEdition ?? programId
+    input.masterEdition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/delegateUpdateV1.ts
+++ b/clients/js/src/generated/instructions/delegateUpdateV1.ts
@@ -22,6 +22,7 @@ import {
 import {
   resolveAuthorizationRulesProgram,
   resolveMasterEdition,
+  resolveTokenRecord,
 } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
@@ -164,12 +165,18 @@ export function delegateUpdateV1(
         programId
       )
   );
+  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
-    input.tokenRecord ?? programId
+    input.tokenRecord ??
+      resolveTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'authority',

--- a/clients/js/src/generated/instructions/delegateUpdateV1.ts
+++ b/clients/js/src/generated/instructions/delegateUpdateV1.ts
@@ -15,6 +15,7 @@ import {
   Signer,
   TransactionBuilder,
   mapSerializer,
+  none,
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
@@ -67,7 +68,7 @@ export type DelegateUpdateV1InstructionData = {
 };
 
 export type DelegateUpdateV1InstructionDataArgs = {
-  authorizationData: Option<AuthorizationDataArgs>;
+  authorizationData?: Option<AuthorizationDataArgs>;
 };
 
 export function getDelegateUpdateV1InstructionDataSerializer(
@@ -98,6 +99,7 @@ export function getDelegateUpdateV1InstructionDataSerializer(
         ...value,
         discriminator: 44,
         delegateUpdateV1Discriminator: 3,
+        authorizationData: value.authorizationData ?? none(),
       } as DelegateUpdateV1InstructionData)
   ) as Serializer<
     DelegateUpdateV1InstructionDataArgs,

--- a/clients/js/src/generated/instructions/delegateUpdateV1.ts
+++ b/clients/js/src/generated/instructions/delegateUpdateV1.ts
@@ -19,12 +19,16 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+} from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
   AuthorizationData,
   AuthorizationDataArgs,
+  TokenStandardArgs,
   getAuthorizationDataSerializer,
 } from '../types';
 
@@ -107,9 +111,14 @@ export function getDelegateUpdateV1InstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type DelegateUpdateV1InstructionExtraArgs = {
+  tokenStandard: TokenStandardArgs;
+};
+
 // Args.
 export type DelegateUpdateV1InstructionArgs =
-  DelegateUpdateV1InstructionDataArgs;
+  DelegateUpdateV1InstructionDataArgs & DelegateUpdateV1InstructionExtraArgs;
 
 // Instruction.
 export function delegateUpdateV1(
@@ -147,7 +156,13 @@ export function delegateUpdateV1(
   addObjectProperty(
     resolvingAccounts,
     'masterEdition',
-    input.masterEdition ?? programId
+    input.masterEdition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/delegateUpdateV1.ts
+++ b/clients/js/src/generated/instructions/delegateUpdateV1.ts
@@ -18,6 +18,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
@@ -182,13 +183,19 @@ export function delegateUpdateV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/delegateUtilityV1.ts
+++ b/clients/js/src/generated/instructions/delegateUtilityV1.ts
@@ -75,7 +75,7 @@ export type DelegateUtilityV1InstructionData = {
 };
 
 export type DelegateUtilityV1InstructionDataArgs = {
-  amount: number | bigint;
+  amount?: number | bigint;
   authorizationData?: Option<AuthorizationDataArgs>;
 };
 
@@ -108,6 +108,7 @@ export function getDelegateUtilityV1InstructionDataSerializer(
         ...value,
         discriminator: 44,
         delegateUtilityV1Discriminator: 4,
+        amount: value.amount ?? 1,
         authorizationData: value.authorizationData ?? none(),
       } as DelegateUtilityV1InstructionData)
   ) as Serializer<

--- a/clients/js/src/generated/instructions/delegateUtilityV1.ts
+++ b/clients/js/src/generated/instructions/delegateUtilityV1.ts
@@ -15,6 +15,7 @@ import {
   Signer,
   TransactionBuilder,
   mapSerializer,
+  none,
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
@@ -69,7 +70,7 @@ export type DelegateUtilityV1InstructionData = {
 
 export type DelegateUtilityV1InstructionDataArgs = {
   amount: number | bigint;
-  authorizationData: Option<AuthorizationDataArgs>;
+  authorizationData?: Option<AuthorizationDataArgs>;
 };
 
 export function getDelegateUtilityV1InstructionDataSerializer(
@@ -101,6 +102,7 @@ export function getDelegateUtilityV1InstructionDataSerializer(
         ...value,
         discriminator: 44,
         delegateUtilityV1Discriminator: 4,
+        authorizationData: value.authorizationData ?? none(),
       } as DelegateUtilityV1InstructionData)
   ) as Serializer<
     DelegateUtilityV1InstructionDataArgs,

--- a/clients/js/src/generated/instructions/delegateUtilityV1.ts
+++ b/clients/js/src/generated/instructions/delegateUtilityV1.ts
@@ -18,6 +18,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
@@ -185,13 +186,19 @@ export function delegateUtilityV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/delegateUtilityV1.ts
+++ b/clients/js/src/generated/instructions/delegateUtilityV1.ts
@@ -19,12 +19,16 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+} from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
   AuthorizationData,
   AuthorizationDataArgs,
+  TokenStandardArgs,
   getAuthorizationDataSerializer,
 } from '../types';
 
@@ -110,9 +114,14 @@ export function getDelegateUtilityV1InstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type DelegateUtilityV1InstructionExtraArgs = {
+  tokenStandard: TokenStandardArgs;
+};
+
 // Args.
 export type DelegateUtilityV1InstructionArgs =
-  DelegateUtilityV1InstructionDataArgs;
+  DelegateUtilityV1InstructionDataArgs & DelegateUtilityV1InstructionExtraArgs;
 
 // Instruction.
 export function delegateUtilityV1(
@@ -150,7 +159,13 @@ export function delegateUtilityV1(
   addObjectProperty(
     resolvingAccounts,
     'masterEdition',
-    input.masterEdition ?? programId
+    input.masterEdition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/lock.ts
+++ b/clients/js/src/generated/instructions/lock.ts
@@ -20,7 +20,8 @@ import {
 } from '@metaplex-foundation/umi';
 import {
   resolveAuthorizationRulesProgram,
-  resolveMasterEditionForProgrammables,
+  resolveMasterEdition,
+  resolveOptionalTokenOwner,
   resolveTokenProgramForNonProgrammables,
   resolveTokenRecord,
 } from '../../hooked';
@@ -126,7 +127,13 @@ export function lock(
   addObjectProperty(
     resolvingAccounts,
     'tokenOwner',
-    input.tokenOwner ?? context.identity.publicKey
+    input.tokenOwner ??
+      resolveOptionalTokenOwner(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,
@@ -146,7 +153,7 @@ export function lock(
     resolvingAccounts,
     'edition',
     input.edition ??
-      resolveMasterEditionForProgrammables(
+      resolveMasterEdition(
         context,
         { ...input, ...resolvingAccounts },
         { ...input, ...resolvingArgs },

--- a/clients/js/src/generated/instructions/lock.ts
+++ b/clients/js/src/generated/instructions/lock.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import { LockArgs, LockArgsArgs, getLockArgsSerializer } from '../types';
@@ -148,13 +149,19 @@ export function lock(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/lockV1.ts
+++ b/clients/js/src/generated/instructions/lockV1.ts
@@ -18,6 +18,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
@@ -168,13 +169,19 @@ export function lockV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/lockV1.ts
+++ b/clients/js/src/generated/instructions/lockV1.ts
@@ -15,6 +15,7 @@ import {
   Signer,
   TransactionBuilder,
   mapSerializer,
+  none,
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
@@ -65,7 +66,7 @@ export type LockV1InstructionData = {
 };
 
 export type LockV1InstructionDataArgs = {
-  authorizationData: Option<AuthorizationDataArgs>;
+  authorizationData?: Option<AuthorizationDataArgs>;
 };
 
 export function getLockV1InstructionDataSerializer(
@@ -93,6 +94,7 @@ export function getLockV1InstructionDataSerializer(
         ...value,
         discriminator: 46,
         lockV1Discriminator: 0,
+        authorizationData: value.authorizationData ?? none(),
       } as LockV1InstructionData)
   ) as Serializer<LockV1InstructionDataArgs, LockV1InstructionData>;
 }

--- a/clients/js/src/generated/instructions/lockV1.ts
+++ b/clients/js/src/generated/instructions/lockV1.ts
@@ -22,7 +22,8 @@ import {
 } from '@metaplex-foundation/umi';
 import {
   resolveAuthorizationRulesProgram,
-  resolveMasterEditionForProgrammables,
+  resolveMasterEdition,
+  resolveOptionalTokenOwner,
   resolveTokenProgramForNonProgrammables,
   resolveTokenRecord,
 } from '../../hooked';
@@ -144,7 +145,13 @@ export function lockV1(
   addObjectProperty(
     resolvingAccounts,
     'tokenOwner',
-    input.tokenOwner ?? context.identity.publicKey
+    input.tokenOwner ??
+      resolveOptionalTokenOwner(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,
@@ -164,7 +171,7 @@ export function lockV1(
     resolvingAccounts,
     'edition',
     input.edition ??
-      resolveMasterEditionForProgrammables(
+      resolveMasterEdition(
         context,
         { ...input, ...resolvingAccounts },
         { ...input, ...resolvingArgs },

--- a/clients/js/src/generated/instructions/migrate.ts
+++ b/clients/js/src/generated/instructions/migrate.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import {
   findMasterEditionPda,
   findMetadataPda,
@@ -173,13 +174,19 @@ export function migrate(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/migrateV1.ts
+++ b/clients/js/src/generated/instructions/migrateV1.ts
@@ -18,6 +18,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import {
   findMasterEditionPda,
   findMetadataPda,
@@ -186,13 +187,19 @@ export function migrateV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/mint.ts
+++ b/clients/js/src/generated/instructions/mint.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import { MintArgs, MintArgsArgs, getMintArgsSerializer } from '../types';
@@ -178,13 +179,19 @@ export function mint(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/mint.ts
+++ b/clients/js/src/generated/instructions/mint.ts
@@ -21,7 +21,7 @@ import {
 import {
   resolveAuthorizationRulesProgram,
   resolveMasterEdition,
-  resolveMintTokenOwner,
+  resolveOptionalTokenOwner,
   resolveTokenRecord,
 } from '../../hooked';
 import { findMetadataPda } from '../accounts';
@@ -126,7 +126,7 @@ export function mint(
     resolvingAccounts,
     'tokenOwner',
     input.tokenOwner ??
-      resolveMintTokenOwner(
+      resolveOptionalTokenOwner(
         context,
         { ...input, ...resolvingAccounts },
         { ...input, ...resolvingArgs },

--- a/clients/js/src/generated/instructions/mint.ts
+++ b/clients/js/src/generated/instructions/mint.ts
@@ -6,6 +6,7 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
+import { findAssociatedTokenPda } from '@metaplex-foundation/mpl-essentials';
 import {
   AccountMeta,
   Context,
@@ -17,15 +18,25 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+  resolveMintTokenOwner,
+  resolveTokenRecord,
+} from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
-import { MintArgs, MintArgsArgs, getMintArgsSerializer } from '../types';
+import {
+  MintArgs,
+  MintArgsArgs,
+  TokenStandardArgs,
+  getMintArgsSerializer,
+} from '../types';
 
 // Accounts.
 export type MintInstructionAccounts = {
   /** Token or Associated Token account */
-  token: PublicKey;
+  token?: PublicKey;
   /** Owner of the token account */
   tokenOwner?: PublicKey;
   /** Metadata account (pda of ['metadata', program id, mint id]) */
@@ -81,8 +92,12 @@ export function getMintInstructionDataSerializer(
   ) as Serializer<MintInstructionDataArgs, MintInstructionData>;
 }
 
+// Extra Args.
+export type MintInstructionExtraArgs = { tokenStandard: TokenStandardArgs };
+
 // Args.
-export type MintInstructionArgs = MintInstructionDataArgs;
+export type MintInstructionArgs = MintInstructionDataArgs &
+  MintInstructionExtraArgs;
 
 // Instruction.
 export function mint(
@@ -110,7 +125,22 @@ export function mint(
   addObjectProperty(
     resolvingAccounts,
     'tokenOwner',
-    input.tokenOwner ?? programId
+    input.tokenOwner ??
+      resolveMintTokenOwner(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
+  );
+  addObjectProperty(
+    resolvingAccounts,
+    'token',
+    input.token ??
+      findAssociatedTokenPda(context, {
+        mint: publicKey(input.mint),
+        owner: publicKey(resolvingAccounts.tokenOwner),
+      })
   );
   addObjectProperty(
     resolvingAccounts,
@@ -120,12 +150,24 @@ export function mint(
   addObjectProperty(
     resolvingAccounts,
     'masterEdition',
-    input.masterEdition ?? programId
+    input.masterEdition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
-    input.tokenRecord ?? programId
+    input.tokenRecord ??
+      resolveTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/mintV1.ts
+++ b/clients/js/src/generated/instructions/mintV1.ts
@@ -78,7 +78,7 @@ export type MintV1InstructionData = {
 };
 
 export type MintV1InstructionDataArgs = {
-  amount: number | bigint;
+  amount?: number | bigint;
   authorizationData?: Option<AuthorizationDataArgs>;
 };
 
@@ -108,6 +108,7 @@ export function getMintV1InstructionDataSerializer(
         ...value,
         discriminator: 43,
         mintV1Discriminator: 0,
+        amount: value.amount ?? 1,
         authorizationData: value.authorizationData ?? none(),
       } as MintV1InstructionData)
   ) as Serializer<MintV1InstructionDataArgs, MintV1InstructionData>;

--- a/clients/js/src/generated/instructions/mintV1.ts
+++ b/clients/js/src/generated/instructions/mintV1.ts
@@ -21,6 +21,7 @@ import {
   transactionBuilder,
 } from '@metaplex-foundation/umi';
 import {
+  resolveAuthorizationRulesProgram,
   resolveMasterEdition,
   resolveMintTokenOwner,
   resolveTokenRecord,
@@ -241,13 +242,19 @@ export function mintV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/mintV1.ts
+++ b/clients/js/src/generated/instructions/mintV1.ts
@@ -23,7 +23,7 @@ import {
 import {
   resolveAuthorizationRulesProgram,
   resolveMasterEdition,
-  resolveMintTokenOwner,
+  resolveOptionalTokenOwner,
   resolveTokenRecord,
 } from '../../hooked';
 import { findMetadataPda } from '../accounts';
@@ -148,7 +148,7 @@ export function mintV1(
     resolvingAccounts,
     'tokenOwner',
     input.tokenOwner ??
-      resolveMintTokenOwner(
+      resolveOptionalTokenOwner(
         context,
         { ...input, ...resolvingAccounts },
         { ...input, ...resolvingArgs },

--- a/clients/js/src/generated/instructions/revoke.ts
+++ b/clients/js/src/generated/instructions/revoke.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import { RevokeArgs, RevokeArgsArgs, getRevokeArgsSerializer } from '../types';
@@ -158,13 +159,19 @@ export function revoke(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/revoke.ts
+++ b/clients/js/src/generated/instructions/revoke.ts
@@ -17,10 +17,19 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+  resolveTokenRecord,
+} from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
-import { RevokeArgs, RevokeArgsArgs, getRevokeArgsSerializer } from '../types';
+import {
+  RevokeArgs,
+  RevokeArgsArgs,
+  TokenStandardArgs,
+  getRevokeArgsSerializer,
+} from '../types';
 
 // Accounts.
 export type RevokeInstructionAccounts = {
@@ -82,8 +91,12 @@ export function getRevokeInstructionDataSerializer(
   ) as Serializer<RevokeInstructionDataArgs, RevokeInstructionData>;
 }
 
+// Extra Args.
+export type RevokeInstructionExtraArgs = { tokenStandard: TokenStandardArgs };
+
 // Args.
-export type RevokeInstructionArgs = RevokeInstructionDataArgs;
+export type RevokeInstructionArgs = RevokeInstructionDataArgs &
+  RevokeInstructionExtraArgs;
 
 // Instruction.
 export function revoke(
@@ -121,14 +134,26 @@ export function revoke(
   addObjectProperty(
     resolvingAccounts,
     'masterEdition',
-    input.masterEdition ?? programId
+    input.masterEdition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
+  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
-    input.tokenRecord ?? programId
+    input.tokenRecord ??
+      resolveTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'authority',

--- a/clients/js/src/generated/instructions/revokeCollectionV1.ts
+++ b/clients/js/src/generated/instructions/revokeCollectionV1.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 
@@ -113,6 +114,7 @@ export function revokeCollectionV1(
 
   // Resolved inputs.
   const resolvingAccounts = {};
+  const resolvingArgs = {};
   addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
@@ -164,15 +166,22 @@ export function revokeCollectionV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
-  );
-  addObjectProperty(
-    resolvingAccounts,
     'authorizationRules',
     input.authorizationRules ?? programId
   );
+  addObjectProperty(
+    resolvingAccounts,
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
+  );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
+  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeCollectionV1.ts
+++ b/clients/js/src/generated/instructions/revokeCollectionV1.ts
@@ -17,9 +17,14 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
-import { findMetadataPda } from '../accounts';
-import { addObjectProperty, isWritable } from '../shared';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+  resolveTokenRecord,
+} from '../../hooked';
+import { findMetadataDelegateRecordPda, findMetadataPda } from '../accounts';
+import { PickPartial, addObjectProperty, isWritable } from '../shared';
+import { MetadataDelegateRole, TokenStandardArgs } from '../types';
 
 // Accounts.
 export type RevokeCollectionV1InstructionAccounts = {
@@ -92,13 +97,26 @@ export function getRevokeCollectionV1InstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type RevokeCollectionV1InstructionExtraArgs = {
+  tokenStandard: TokenStandardArgs;
+  updateAuthority: PublicKey;
+};
+
+// Args.
+export type RevokeCollectionV1InstructionArgs = PickPartial<
+  RevokeCollectionV1InstructionExtraArgs,
+  'updateAuthority'
+>;
+
 // Instruction.
 export function revokeCollectionV1(
   context: Pick<
     Context,
     'serializer' | 'programs' | 'eddsa' | 'identity' | 'payer'
   >,
-  input: RevokeCollectionV1InstructionAccounts
+  input: RevokeCollectionV1InstructionAccounts &
+    RevokeCollectionV1InstructionArgs
 ): TransactionBuilder {
   const signers: Signer[] = [];
   const keys: AccountMeta[] = [];
@@ -116,9 +134,20 @@ export function revokeCollectionV1(
   const resolvingAccounts = {};
   const resolvingArgs = {};
   addObjectProperty(
+    resolvingArgs,
+    'updateAuthority',
+    input.updateAuthority ?? context.identity.publicKey
+  );
+  addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
-    input.delegateRecord ?? programId
+    input.delegateRecord ??
+      findMetadataDelegateRecordPda(context, {
+        mint: publicKey(input.mint),
+        delegateRole: MetadataDelegateRole.Collection,
+        updateAuthority: resolvingArgs.updateAuthority,
+        delegate: publicKey(input.delegate),
+      })
   );
   addObjectProperty(
     resolvingAccounts,
@@ -128,14 +157,26 @@ export function revokeCollectionV1(
   addObjectProperty(
     resolvingAccounts,
     'masterEdition',
-    input.masterEdition ?? programId
+    input.masterEdition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
+  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
-    input.tokenRecord ?? programId
+    input.tokenRecord ??
+      resolveTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'authority',

--- a/clients/js/src/generated/instructions/revokeCollectionV1.ts
+++ b/clients/js/src/generated/instructions/revokeCollectionV1.ts
@@ -181,7 +181,6 @@ export function revokeCollectionV1(
       )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeLockedTransferV1.ts
+++ b/clients/js/src/generated/instructions/revokeLockedTransferV1.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 
@@ -113,6 +114,7 @@ export function revokeLockedTransferV1(
 
   // Resolved inputs.
   const resolvingAccounts = {};
+  const resolvingArgs = {};
   addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
@@ -164,15 +166,22 @@ export function revokeLockedTransferV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
-  );
-  addObjectProperty(
-    resolvingAccounts,
     'authorizationRules',
     input.authorizationRules ?? programId
   );
+  addObjectProperty(
+    resolvingAccounts,
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
+  );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
+  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeLockedTransferV1.ts
+++ b/clients/js/src/generated/instructions/revokeLockedTransferV1.ts
@@ -6,6 +6,7 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
+import { findAssociatedTokenPda } from '@metaplex-foundation/mpl-essentials';
 import {
   AccountMeta,
   Context,
@@ -17,9 +18,14 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
-import { findMetadataPda } from '../accounts';
-import { addObjectProperty, isWritable } from '../shared';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+  resolveTokenRecord,
+} from '../../hooked';
+import { findMetadataPda, findTokenRecordPda } from '../accounts';
+import { PickPartial, addObjectProperty, isWritable } from '../shared';
+import { TokenStandardArgs } from '../types';
 
 // Accounts.
 export type RevokeLockedTransferV1InstructionAccounts = {
@@ -92,13 +98,26 @@ export function getRevokeLockedTransferV1InstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type RevokeLockedTransferV1InstructionExtraArgs = {
+  tokenStandard: TokenStandardArgs;
+  tokenOwner: PublicKey;
+};
+
+// Args.
+export type RevokeLockedTransferV1InstructionArgs = PickPartial<
+  RevokeLockedTransferV1InstructionExtraArgs,
+  'tokenOwner'
+>;
+
 // Instruction.
 export function revokeLockedTransferV1(
   context: Pick<
     Context,
     'serializer' | 'programs' | 'eddsa' | 'identity' | 'payer'
   >,
-  input: RevokeLockedTransferV1InstructionAccounts
+  input: RevokeLockedTransferV1InstructionAccounts &
+    RevokeLockedTransferV1InstructionArgs
 ): TransactionBuilder {
   const signers: Signer[] = [];
   const keys: AccountMeta[] = [];
@@ -116,9 +135,27 @@ export function revokeLockedTransferV1(
   const resolvingAccounts = {};
   const resolvingArgs = {};
   addObjectProperty(
+    resolvingArgs,
+    'tokenOwner',
+    input.tokenOwner ?? context.identity.publicKey
+  );
+  addObjectProperty(
+    resolvingAccounts,
+    'token',
+    input.token ??
+      findAssociatedTokenPda(context, {
+        mint: publicKey(input.mint),
+        owner: resolvingArgs.tokenOwner,
+      })
+  );
+  addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
-    input.delegateRecord ?? programId
+    input.delegateRecord ??
+      findTokenRecordPda(context, {
+        mint: publicKey(input.mint),
+        token: publicKey(resolvingAccounts.token),
+      })
   );
   addObjectProperty(
     resolvingAccounts,
@@ -128,14 +165,25 @@ export function revokeLockedTransferV1(
   addObjectProperty(
     resolvingAccounts,
     'masterEdition',
-    input.masterEdition ?? programId
+    input.masterEdition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
-    input.tokenRecord ?? programId
+    input.tokenRecord ??
+      resolveTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'authority',
@@ -162,7 +210,13 @@ export function revokeLockedTransferV1(
   addObjectProperty(
     resolvingAccounts,
     'splTokenProgram',
-    input.splTokenProgram ?? programId
+    input.splTokenProgram ?? {
+      ...context.programs.getPublicKey(
+        'splToken',
+        'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+      ),
+      isWritable: false,
+    }
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/revokeLockedTransferV1.ts
+++ b/clients/js/src/generated/instructions/revokeLockedTransferV1.ts
@@ -181,7 +181,6 @@ export function revokeLockedTransferV1(
       )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeMigrationV1.ts
+++ b/clients/js/src/generated/instructions/revokeMigrationV1.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 
@@ -113,6 +114,7 @@ export function revokeMigrationV1(
 
   // Resolved inputs.
   const resolvingAccounts = {};
+  const resolvingArgs = {};
   addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
@@ -164,15 +166,22 @@ export function revokeMigrationV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
-  );
-  addObjectProperty(
-    resolvingAccounts,
     'authorizationRules',
     input.authorizationRules ?? programId
   );
+  addObjectProperty(
+    resolvingAccounts,
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
+  );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
+  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeMigrationV1.ts
+++ b/clients/js/src/generated/instructions/revokeMigrationV1.ts
@@ -181,7 +181,6 @@ export function revokeMigrationV1(
       )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeProgrammableConfigV1.ts
+++ b/clients/js/src/generated/instructions/revokeProgrammableConfigV1.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 
@@ -113,6 +114,7 @@ export function revokeProgrammableConfigV1(
 
   // Resolved inputs.
   const resolvingAccounts = {};
+  const resolvingArgs = {};
   addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
@@ -164,15 +166,22 @@ export function revokeProgrammableConfigV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
-  );
-  addObjectProperty(
-    resolvingAccounts,
     'authorizationRules',
     input.authorizationRules ?? programId
   );
+  addObjectProperty(
+    resolvingAccounts,
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
+  );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
+  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeProgrammableConfigV1.ts
+++ b/clients/js/src/generated/instructions/revokeProgrammableConfigV1.ts
@@ -181,7 +181,6 @@ export function revokeProgrammableConfigV1(
       )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeSaleV1.ts
+++ b/clients/js/src/generated/instructions/revokeSaleV1.ts
@@ -175,7 +175,6 @@ export function revokeSaleV1(
       )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeSaleV1.ts
+++ b/clients/js/src/generated/instructions/revokeSaleV1.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 
@@ -107,6 +108,7 @@ export function revokeSaleV1(
 
   // Resolved inputs.
   const resolvingAccounts = {};
+  const resolvingArgs = {};
   addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
@@ -158,15 +160,22 @@ export function revokeSaleV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
-  );
-  addObjectProperty(
-    resolvingAccounts,
     'authorizationRules',
     input.authorizationRules ?? programId
   );
+  addObjectProperty(
+    resolvingAccounts,
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
+  );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
+  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeStakingV1.ts
+++ b/clients/js/src/generated/instructions/revokeStakingV1.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 
@@ -113,6 +114,7 @@ export function revokeStakingV1(
 
   // Resolved inputs.
   const resolvingAccounts = {};
+  const resolvingArgs = {};
   addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
@@ -164,15 +166,22 @@ export function revokeStakingV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
-  );
-  addObjectProperty(
-    resolvingAccounts,
     'authorizationRules',
     input.authorizationRules ?? programId
   );
+  addObjectProperty(
+    resolvingAccounts,
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
+  );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
+  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeStakingV1.ts
+++ b/clients/js/src/generated/instructions/revokeStakingV1.ts
@@ -181,7 +181,6 @@ export function revokeStakingV1(
       )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeStandardV1.ts
+++ b/clients/js/src/generated/instructions/revokeStandardV1.ts
@@ -6,6 +6,7 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
+import { findAssociatedTokenPda } from '@metaplex-foundation/mpl-essentials';
 import {
   AccountMeta,
   Context,
@@ -17,9 +18,13 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
-import { findMetadataPda } from '../accounts';
-import { addObjectProperty, isWritable } from '../shared';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+} from '../../hooked';
+import { findMetadataPda, findTokenRecordPda } from '../accounts';
+import { PickPartial, addObjectProperty, isWritable } from '../shared';
+import { TokenStandardArgs } from '../types';
 
 // Accounts.
 export type RevokeStandardV1InstructionAccounts = {
@@ -92,13 +97,25 @@ export function getRevokeStandardV1InstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type RevokeStandardV1InstructionExtraArgs = {
+  tokenStandard: TokenStandardArgs;
+  tokenOwner: PublicKey;
+};
+
+// Args.
+export type RevokeStandardV1InstructionArgs = PickPartial<
+  RevokeStandardV1InstructionExtraArgs,
+  'tokenOwner'
+>;
+
 // Instruction.
 export function revokeStandardV1(
   context: Pick<
     Context,
     'serializer' | 'programs' | 'eddsa' | 'identity' | 'payer'
   >,
-  input: RevokeStandardV1InstructionAccounts
+  input: RevokeStandardV1InstructionAccounts & RevokeStandardV1InstructionArgs
 ): TransactionBuilder {
   const signers: Signer[] = [];
   const keys: AccountMeta[] = [];
@@ -116,9 +133,27 @@ export function revokeStandardV1(
   const resolvingAccounts = {};
   const resolvingArgs = {};
   addObjectProperty(
+    resolvingArgs,
+    'tokenOwner',
+    input.tokenOwner ?? context.identity.publicKey
+  );
+  addObjectProperty(
+    resolvingAccounts,
+    'token',
+    input.token ??
+      findAssociatedTokenPda(context, {
+        mint: publicKey(input.mint),
+        owner: resolvingArgs.tokenOwner,
+      })
+  );
+  addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
-    input.delegateRecord ?? programId
+    input.delegateRecord ??
+      findTokenRecordPda(context, {
+        mint: publicKey(input.mint),
+        token: publicKey(resolvingAccounts.token),
+      })
   );
   addObjectProperty(
     resolvingAccounts,
@@ -128,14 +163,19 @@ export function revokeStandardV1(
   addObjectProperty(
     resolvingAccounts,
     'masterEdition',
-    input.masterEdition ?? programId
+    input.masterEdition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
     input.tokenRecord ?? programId
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'authority',
@@ -162,7 +202,13 @@ export function revokeStandardV1(
   addObjectProperty(
     resolvingAccounts,
     'splTokenProgram',
-    input.splTokenProgram ?? programId
+    input.splTokenProgram ?? {
+      ...context.programs.getPublicKey(
+        'splToken',
+        'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+      ),
+      isWritable: false,
+    }
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/revokeStandardV1.ts
+++ b/clients/js/src/generated/instructions/revokeStandardV1.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 
@@ -113,6 +114,7 @@ export function revokeStandardV1(
 
   // Resolved inputs.
   const resolvingAccounts = {};
+  const resolvingArgs = {};
   addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
@@ -164,15 +166,22 @@ export function revokeStandardV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
-  );
-  addObjectProperty(
-    resolvingAccounts,
     'authorizationRules',
     input.authorizationRules ?? programId
   );
+  addObjectProperty(
+    resolvingAccounts,
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
+  );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
+  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeStandardV1.ts
+++ b/clients/js/src/generated/instructions/revokeStandardV1.ts
@@ -181,7 +181,6 @@ export function revokeStandardV1(
       )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeTransferV1.ts
+++ b/clients/js/src/generated/instructions/revokeTransferV1.ts
@@ -6,6 +6,7 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
+import { findAssociatedTokenPda } from '@metaplex-foundation/mpl-essentials';
 import {
   AccountMeta,
   Context,
@@ -17,9 +18,14 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
-import { findMetadataPda } from '../accounts';
-import { addObjectProperty, isWritable } from '../shared';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+  resolveTokenRecord,
+} from '../../hooked';
+import { findMetadataPda, findTokenRecordPda } from '../accounts';
+import { PickPartial, addObjectProperty, isWritable } from '../shared';
+import { TokenStandardArgs } from '../types';
 
 // Accounts.
 export type RevokeTransferV1InstructionAccounts = {
@@ -92,13 +98,25 @@ export function getRevokeTransferV1InstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type RevokeTransferV1InstructionExtraArgs = {
+  tokenStandard: TokenStandardArgs;
+  tokenOwner: PublicKey;
+};
+
+// Args.
+export type RevokeTransferV1InstructionArgs = PickPartial<
+  RevokeTransferV1InstructionExtraArgs,
+  'tokenOwner'
+>;
+
 // Instruction.
 export function revokeTransferV1(
   context: Pick<
     Context,
     'serializer' | 'programs' | 'eddsa' | 'identity' | 'payer'
   >,
-  input: RevokeTransferV1InstructionAccounts
+  input: RevokeTransferV1InstructionAccounts & RevokeTransferV1InstructionArgs
 ): TransactionBuilder {
   const signers: Signer[] = [];
   const keys: AccountMeta[] = [];
@@ -116,9 +134,27 @@ export function revokeTransferV1(
   const resolvingAccounts = {};
   const resolvingArgs = {};
   addObjectProperty(
+    resolvingArgs,
+    'tokenOwner',
+    input.tokenOwner ?? context.identity.publicKey
+  );
+  addObjectProperty(
+    resolvingAccounts,
+    'token',
+    input.token ??
+      findAssociatedTokenPda(context, {
+        mint: publicKey(input.mint),
+        owner: resolvingArgs.tokenOwner,
+      })
+  );
+  addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
-    input.delegateRecord ?? programId
+    input.delegateRecord ??
+      findTokenRecordPda(context, {
+        mint: publicKey(input.mint),
+        token: publicKey(resolvingAccounts.token),
+      })
   );
   addObjectProperty(
     resolvingAccounts,
@@ -128,14 +164,25 @@ export function revokeTransferV1(
   addObjectProperty(
     resolvingAccounts,
     'masterEdition',
-    input.masterEdition ?? programId
+    input.masterEdition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
-    input.tokenRecord ?? programId
+    input.tokenRecord ??
+      resolveTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'authority',
@@ -162,7 +209,13 @@ export function revokeTransferV1(
   addObjectProperty(
     resolvingAccounts,
     'splTokenProgram',
-    input.splTokenProgram ?? programId
+    input.splTokenProgram ?? {
+      ...context.programs.getPublicKey(
+        'splToken',
+        'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+      ),
+      isWritable: false,
+    }
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/revokeTransferV1.ts
+++ b/clients/js/src/generated/instructions/revokeTransferV1.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 
@@ -113,6 +114,7 @@ export function revokeTransferV1(
 
   // Resolved inputs.
   const resolvingAccounts = {};
+  const resolvingArgs = {};
   addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
@@ -164,15 +166,22 @@ export function revokeTransferV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
-  );
-  addObjectProperty(
-    resolvingAccounts,
     'authorizationRules',
     input.authorizationRules ?? programId
   );
+  addObjectProperty(
+    resolvingAccounts,
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
+  );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
+  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeTransferV1.ts
+++ b/clients/js/src/generated/instructions/revokeTransferV1.ts
@@ -181,7 +181,6 @@ export function revokeTransferV1(
       )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeUpdateV1.ts
+++ b/clients/js/src/generated/instructions/revokeUpdateV1.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 
@@ -113,6 +114,7 @@ export function revokeUpdateV1(
 
   // Resolved inputs.
   const resolvingAccounts = {};
+  const resolvingArgs = {};
   addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
@@ -164,15 +166,22 @@ export function revokeUpdateV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
-  );
-  addObjectProperty(
-    resolvingAccounts,
     'authorizationRules',
     input.authorizationRules ?? programId
   );
+  addObjectProperty(
+    resolvingAccounts,
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
+  );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
+  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeUpdateV1.ts
+++ b/clients/js/src/generated/instructions/revokeUpdateV1.ts
@@ -181,7 +181,6 @@ export function revokeUpdateV1(
       )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeUtilityV1.ts
+++ b/clients/js/src/generated/instructions/revokeUtilityV1.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 
@@ -113,6 +114,7 @@ export function revokeUtilityV1(
 
   // Resolved inputs.
   const resolvingAccounts = {};
+  const resolvingArgs = {};
   addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
@@ -164,15 +166,22 @@ export function revokeUtilityV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
-  );
-  addObjectProperty(
-    resolvingAccounts,
     'authorizationRules',
     input.authorizationRules ?? programId
   );
+  addObjectProperty(
+    resolvingAccounts,
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
+  );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
+  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeUtilityV1.ts
+++ b/clients/js/src/generated/instructions/revokeUtilityV1.ts
@@ -181,7 +181,6 @@ export function revokeUtilityV1(
       )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
   // Delegate Record.
   keys.push({

--- a/clients/js/src/generated/instructions/revokeUtilityV1.ts
+++ b/clients/js/src/generated/instructions/revokeUtilityV1.ts
@@ -6,6 +6,7 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
+import { findAssociatedTokenPda } from '@metaplex-foundation/mpl-essentials';
 import {
   AccountMeta,
   Context,
@@ -17,9 +18,14 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
-import { findMetadataPda } from '../accounts';
-import { addObjectProperty, isWritable } from '../shared';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+  resolveTokenRecord,
+} from '../../hooked';
+import { findMetadataPda, findTokenRecordPda } from '../accounts';
+import { PickPartial, addObjectProperty, isWritable } from '../shared';
+import { TokenStandardArgs } from '../types';
 
 // Accounts.
 export type RevokeUtilityV1InstructionAccounts = {
@@ -92,13 +98,25 @@ export function getRevokeUtilityV1InstructionDataSerializer(
   >;
 }
 
+// Extra Args.
+export type RevokeUtilityV1InstructionExtraArgs = {
+  tokenStandard: TokenStandardArgs;
+  tokenOwner: PublicKey;
+};
+
+// Args.
+export type RevokeUtilityV1InstructionArgs = PickPartial<
+  RevokeUtilityV1InstructionExtraArgs,
+  'tokenOwner'
+>;
+
 // Instruction.
 export function revokeUtilityV1(
   context: Pick<
     Context,
     'serializer' | 'programs' | 'eddsa' | 'identity' | 'payer'
   >,
-  input: RevokeUtilityV1InstructionAccounts
+  input: RevokeUtilityV1InstructionAccounts & RevokeUtilityV1InstructionArgs
 ): TransactionBuilder {
   const signers: Signer[] = [];
   const keys: AccountMeta[] = [];
@@ -116,9 +134,27 @@ export function revokeUtilityV1(
   const resolvingAccounts = {};
   const resolvingArgs = {};
   addObjectProperty(
+    resolvingArgs,
+    'tokenOwner',
+    input.tokenOwner ?? context.identity.publicKey
+  );
+  addObjectProperty(
+    resolvingAccounts,
+    'token',
+    input.token ??
+      findAssociatedTokenPda(context, {
+        mint: publicKey(input.mint),
+        owner: resolvingArgs.tokenOwner,
+      })
+  );
+  addObjectProperty(
     resolvingAccounts,
     'delegateRecord',
-    input.delegateRecord ?? programId
+    input.delegateRecord ??
+      findTokenRecordPda(context, {
+        mint: publicKey(input.mint),
+        token: publicKey(resolvingAccounts.token),
+      })
   );
   addObjectProperty(
     resolvingAccounts,
@@ -128,14 +164,25 @@ export function revokeUtilityV1(
   addObjectProperty(
     resolvingAccounts,
     'masterEdition',
-    input.masterEdition ?? programId
+    input.masterEdition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
-    input.tokenRecord ?? programId
+    input.tokenRecord ??
+      resolveTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
-  addObjectProperty(resolvingAccounts, 'token', input.token ?? programId);
   addObjectProperty(
     resolvingAccounts,
     'authority',
@@ -162,7 +209,13 @@ export function revokeUtilityV1(
   addObjectProperty(
     resolvingAccounts,
     'splTokenProgram',
-    input.splTokenProgram ?? programId
+    input.splTokenProgram ?? {
+      ...context.programs.getPublicKey(
+        'splToken',
+        'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+      ),
+      isWritable: false,
+    }
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/transfer.ts
+++ b/clients/js/src/generated/instructions/transfer.ts
@@ -6,6 +6,7 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
+import { findAssociatedTokenPda } from '@metaplex-foundation/mpl-essentials';
 import {
   AccountMeta,
   Context,
@@ -17,10 +18,16 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveDestinationTokenRecord,
+  resolveMasterEditionForProgrammables,
+  resolveTokenRecord,
+} from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
+  TokenStandardArgs,
   TransferArgs,
   TransferArgsArgs,
   getTransferArgsSerializer,
@@ -29,11 +36,11 @@ import {
 // Accounts.
 export type TransferInstructionAccounts = {
   /** Token account */
-  token: PublicKey;
+  token?: PublicKey;
   /** Token account owner */
-  tokenOwner: PublicKey;
+  tokenOwner?: PublicKey;
   /** Destination token account */
-  destination: PublicKey;
+  destinationToken?: PublicKey;
   /** Destination token account owner */
   destinationOwner: PublicKey;
   /** Mint of token asset */
@@ -43,7 +50,7 @@ export type TransferInstructionAccounts = {
   /** Edition of token asset */
   edition?: PublicKey;
   /** Owner token record account */
-  ownerTokenRecord?: PublicKey;
+  tokenRecord?: PublicKey;
   /** Destination token record account */
   destinationTokenRecord?: PublicKey;
   /** Transfer authority (token owner or delegate) */
@@ -92,8 +99,12 @@ export function getTransferInstructionDataSerializer(
   ) as Serializer<TransferInstructionDataArgs, TransferInstructionData>;
 }
 
+// Extra Args.
+export type TransferInstructionExtraArgs = { tokenStandard: TokenStandardArgs };
+
 // Args.
-export type TransferInstructionArgs = TransferInstructionDataArgs;
+export type TransferInstructionArgs = TransferInstructionDataArgs &
+  TransferInstructionExtraArgs;
 
 // Instruction.
 export function transfer(
@@ -120,19 +131,64 @@ export function transfer(
   const resolvingArgs = {};
   addObjectProperty(
     resolvingAccounts,
+    'tokenOwner',
+    input.tokenOwner ?? context.identity.publicKey
+  );
+  addObjectProperty(
+    resolvingAccounts,
+    'token',
+    input.token ??
+      findAssociatedTokenPda(context, {
+        mint: publicKey(input.mint),
+        owner: publicKey(resolvingAccounts.tokenOwner),
+      })
+  );
+  addObjectProperty(
+    resolvingAccounts,
+    'destinationToken',
+    input.destinationToken ??
+      findAssociatedTokenPda(context, {
+        mint: publicKey(input.mint),
+        owner: publicKey(input.destinationOwner),
+      })
+  );
+  addObjectProperty(
+    resolvingAccounts,
     'metadata',
     input.metadata ?? findMetadataPda(context, { mint: publicKey(input.mint) })
   );
-  addObjectProperty(resolvingAccounts, 'edition', input.edition ?? programId);
   addObjectProperty(
     resolvingAccounts,
-    'ownerTokenRecord',
-    input.ownerTokenRecord ?? programId
+    'edition',
+    input.edition ??
+      resolveMasterEditionForProgrammables(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
+  );
+  addObjectProperty(
+    resolvingAccounts,
+    'tokenRecord',
+    input.tokenRecord ??
+      resolveTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,
     'destinationTokenRecord',
-    input.destinationTokenRecord ?? programId
+    input.destinationTokenRecord ??
+      resolveDestinationTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,
@@ -212,11 +268,11 @@ export function transfer(
     isWritable: isWritable(resolvedAccounts.tokenOwner, false),
   });
 
-  // Destination.
+  // Destination Token.
   keys.push({
-    pubkey: resolvedAccounts.destination,
+    pubkey: resolvedAccounts.destinationToken,
     isSigner: false,
-    isWritable: isWritable(resolvedAccounts.destination, true),
+    isWritable: isWritable(resolvedAccounts.destinationToken, true),
   });
 
   // Destination Owner.
@@ -247,11 +303,11 @@ export function transfer(
     isWritable: isWritable(resolvedAccounts.edition, false),
   });
 
-  // Owner Token Record.
+  // Token Record.
   keys.push({
-    pubkey: resolvedAccounts.ownerTokenRecord,
+    pubkey: resolvedAccounts.tokenRecord,
     isSigner: false,
-    isWritable: isWritable(resolvedAccounts.ownerTokenRecord, true),
+    isWritable: isWritable(resolvedAccounts.tokenRecord, true),
   });
 
   // Destination Token Record.

--- a/clients/js/src/generated/instructions/transfer.ts
+++ b/clients/js/src/generated/instructions/transfer.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
@@ -180,13 +181,19 @@ export function transfer(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/transferOutOfEscrow.ts
+++ b/clients/js/src/generated/instructions/transferOutOfEscrow.ts
@@ -56,7 +56,7 @@ export type TransferOutOfEscrowInstructionData = {
 };
 
 export type TransferOutOfEscrowInstructionDataArgs = {
-  amount: number | bigint;
+  amount?: number | bigint;
 };
 
 export function getTransferOutOfEscrowInstructionDataSerializer(
@@ -79,7 +79,11 @@ export function getTransferOutOfEscrowInstructionDataSerializer(
       { description: 'TransferOutOfEscrowInstructionData' }
     ),
     (value) =>
-      ({ ...value, discriminator: 40 } as TransferOutOfEscrowInstructionData)
+      ({
+        ...value,
+        discriminator: 40,
+        amount: value.amount ?? 1,
+      } as TransferOutOfEscrowInstructionData)
   ) as Serializer<
     TransferOutOfEscrowInstructionDataArgs,
     TransferOutOfEscrowInstructionData

--- a/clients/js/src/generated/instructions/transferV1.ts
+++ b/clients/js/src/generated/instructions/transferV1.ts
@@ -37,7 +37,7 @@ export type TransferV1InstructionAccounts = {
   /** Token account owner */
   tokenOwner?: PublicKey;
   /** Destination token account */
-  destinationToken: PublicKey;
+  destinationToken?: PublicKey;
   /** Destination token account owner */
   destinationOwner: PublicKey;
   /** Mint of token asset */
@@ -157,6 +157,15 @@ export function transferV1(
       findAssociatedTokenPda(context, {
         mint: publicKey(input.mint),
         owner: publicKey(resolvingAccounts.tokenOwner),
+      })
+  );
+  addObjectProperty(
+    resolvingAccounts,
+    'destinationToken',
+    input.destinationToken ??
+      findAssociatedTokenPda(context, {
+        mint: publicKey(input.mint),
+        owner: publicKey(input.destinationOwner),
       })
   );
   addObjectProperty(

--- a/clients/js/src/generated/instructions/transferV1.ts
+++ b/clients/js/src/generated/instructions/transferV1.ts
@@ -21,6 +21,7 @@ import {
   transactionBuilder,
 } from '@metaplex-foundation/umi';
 import {
+  resolveAuthorizationRulesProgram,
   resolveDestinationTokenRecord,
   resolveMasterEditionForProgrammables,
   resolveTokenRecord,
@@ -257,13 +258,19 @@ export function transferV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/transferV1.ts
+++ b/clients/js/src/generated/instructions/transferV1.ts
@@ -20,7 +20,11 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveTokenRecord } from '../../hooked';
+import {
+  resolveDestinationTokenRecord,
+  resolveMasterEditionForProgrammables,
+  resolveTokenRecord,
+} from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
@@ -173,7 +177,17 @@ export function transferV1(
     'metadata',
     input.metadata ?? findMetadataPda(context, { mint: publicKey(input.mint) })
   );
-  addObjectProperty(resolvingAccounts, 'edition', input.edition ?? programId);
+  addObjectProperty(
+    resolvingAccounts,
+    'edition',
+    input.edition ??
+      resolveMasterEditionForProgrammables(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
+  );
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
@@ -188,7 +202,13 @@ export function transferV1(
   addObjectProperty(
     resolvingAccounts,
     'destinationTokenRecord',
-    input.destinationTokenRecord ?? programId
+    input.destinationTokenRecord ??
+      resolveDestinationTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/unlock.ts
+++ b/clients/js/src/generated/instructions/unlock.ts
@@ -6,6 +6,7 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
+import { findAssociatedTokenPda } from '@metaplex-foundation/mpl-essentials';
 import {
   AccountMeta,
   Context,
@@ -17,10 +18,21 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { resolveAuthorizationRulesProgram } from '../../hooked';
+import {
+  resolveAuthorizationRulesProgram,
+  resolveMasterEdition,
+  resolveOptionalTokenOwner,
+  resolveTokenProgramForNonProgrammables,
+  resolveTokenRecord,
+} from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
-import { UnlockArgs, UnlockArgsArgs, getUnlockArgsSerializer } from '../types';
+import {
+  TokenStandardArgs,
+  UnlockArgs,
+  UnlockArgsArgs,
+  getUnlockArgsSerializer,
+} from '../types';
 
 // Accounts.
 export type UnlockInstructionAccounts = {
@@ -29,7 +41,7 @@ export type UnlockInstructionAccounts = {
   /** Token owner account */
   tokenOwner?: PublicKey;
   /** Token account */
-  token: PublicKey;
+  token?: PublicKey;
   /** Mint account */
   mint: PublicKey;
   /** Metadata account */
@@ -80,8 +92,12 @@ export function getUnlockInstructionDataSerializer(
   ) as Serializer<UnlockInstructionDataArgs, UnlockInstructionData>;
 }
 
+// Extra Args.
+export type UnlockInstructionExtraArgs = { tokenStandard: TokenStandardArgs };
+
 // Args.
-export type UnlockInstructionArgs = UnlockInstructionDataArgs;
+export type UnlockInstructionArgs = UnlockInstructionDataArgs &
+  UnlockInstructionExtraArgs;
 
 // Instruction.
 export function unlock(
@@ -114,18 +130,49 @@ export function unlock(
   addObjectProperty(
     resolvingAccounts,
     'tokenOwner',
-    input.tokenOwner ?? programId
+    input.tokenOwner ??
+      resolveOptionalTokenOwner(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
+  );
+  addObjectProperty(
+    resolvingAccounts,
+    'token',
+    input.token ??
+      findAssociatedTokenPda(context, {
+        mint: publicKey(input.mint),
+        owner: publicKey(resolvingAccounts.tokenOwner),
+      })
   );
   addObjectProperty(
     resolvingAccounts,
     'metadata',
     input.metadata ?? findMetadataPda(context, { mint: publicKey(input.mint) })
   );
-  addObjectProperty(resolvingAccounts, 'edition', input.edition ?? programId);
+  addObjectProperty(
+    resolvingAccounts,
+    'edition',
+    input.edition ??
+      resolveMasterEdition(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
+  );
   addObjectProperty(
     resolvingAccounts,
     'tokenRecord',
-    input.tokenRecord ?? programId
+    input.tokenRecord ??
+      resolveTokenRecord(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(resolvingAccounts, 'payer', input.payer ?? context.payer);
   addObjectProperty(
@@ -148,7 +195,13 @@ export function unlock(
   addObjectProperty(
     resolvingAccounts,
     'splTokenProgram',
-    input.splTokenProgram ?? programId
+    input.splTokenProgram ??
+      resolveTokenProgramForNonProgrammables(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   addObjectProperty(
     resolvingAccounts,

--- a/clients/js/src/generated/instructions/unlock.ts
+++ b/clients/js/src/generated/instructions/unlock.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import { UnlockArgs, UnlockArgsArgs, getUnlockArgsSerializer } from '../types';
@@ -151,13 +152,19 @@ export function unlock(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/unlockV1.ts
+++ b/clients/js/src/generated/instructions/unlockV1.ts
@@ -18,6 +18,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
@@ -168,13 +169,19 @@ export function unlockV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/unlockV1.ts
+++ b/clients/js/src/generated/instructions/unlockV1.ts
@@ -15,6 +15,7 @@ import {
   Signer,
   TransactionBuilder,
   mapSerializer,
+  none,
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
@@ -65,7 +66,7 @@ export type UnlockV1InstructionData = {
 };
 
 export type UnlockV1InstructionDataArgs = {
-  authorizationData: Option<AuthorizationDataArgs>;
+  authorizationData?: Option<AuthorizationDataArgs>;
 };
 
 export function getUnlockV1InstructionDataSerializer(
@@ -93,6 +94,7 @@ export function getUnlockV1InstructionDataSerializer(
         ...value,
         discriminator: 47,
         unlockV1Discriminator: 0,
+        authorizationData: value.authorizationData ?? none(),
       } as UnlockV1InstructionData)
   ) as Serializer<UnlockV1InstructionDataArgs, UnlockV1InstructionData>;
 }

--- a/clients/js/src/generated/instructions/update.ts
+++ b/clients/js/src/generated/instructions/update.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import { UpdateArgs, UpdateArgsArgs, getUpdateArgsSerializer } from '../types';
@@ -138,13 +139,19 @@ export function update(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/updateV1.ts
+++ b/clients/js/src/generated/instructions/updateV1.ts
@@ -19,6 +19,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
@@ -232,13 +233,19 @@ export function updateV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/use.ts
+++ b/clients/js/src/generated/instructions/use.ts
@@ -17,6 +17,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import { UseArgs, UseArgsArgs, getUseArgsSerializer } from '../types';
@@ -142,13 +143,19 @@ export function use(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/instructions/useV1.ts
+++ b/clients/js/src/generated/instructions/useV1.ts
@@ -15,6 +15,7 @@ import {
   Signer,
   TransactionBuilder,
   mapSerializer,
+  none,
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
@@ -63,7 +64,7 @@ export type UseV1InstructionData = {
 };
 
 export type UseV1InstructionDataArgs = {
-  authorizationData: Option<AuthorizationDataArgs>;
+  authorizationData?: Option<AuthorizationDataArgs>;
 };
 
 export function getUseV1InstructionDataSerializer(
@@ -91,6 +92,7 @@ export function getUseV1InstructionDataSerializer(
         ...value,
         discriminator: 51,
         useV1Discriminator: 0,
+        authorizationData: value.authorizationData ?? none(),
       } as UseV1InstructionData)
   ) as Serializer<UseV1InstructionDataArgs, UseV1InstructionData>;
 }

--- a/clients/js/src/generated/instructions/useV1.ts
+++ b/clients/js/src/generated/instructions/useV1.ts
@@ -18,6 +18,7 @@ import {
   publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
+import { resolveAuthorizationRulesProgram } from '../../hooked';
 import { findMetadataPda } from '../accounts';
 import { addObjectProperty, isWritable } from '../shared';
 import {
@@ -162,13 +163,19 @@ export function useV1(
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram ?? programId
+    'authorizationRules',
+    input.authorizationRules ?? programId
   );
   addObjectProperty(
     resolvingAccounts,
-    'authorizationRules',
-    input.authorizationRules ?? programId
+    'authorizationRulesProgram',
+    input.authorizationRulesProgram ??
+      resolveAuthorizationRulesProgram(
+        context,
+        { ...input, ...resolvingAccounts },
+        { ...input, ...resolvingArgs },
+        programId
+      )
   );
   const resolvedAccounts = { ...input, ...resolvingAccounts };
   const resolvedArgs = { ...input, ...resolvingArgs };

--- a/clients/js/src/generated/types/burnArgs.ts
+++ b/clients/js/src/generated/types/burnArgs.ts
@@ -11,11 +11,12 @@ import {
   GetDataEnumKind,
   GetDataEnumKindContent,
   Serializer,
+  mapSerializer,
 } from '@metaplex-foundation/umi';
 
 export type BurnArgs = { __kind: 'V1'; amount: bigint };
 
-export type BurnArgsArgs = { __kind: 'V1'; amount: number | bigint };
+export type BurnArgsArgs = { __kind: 'V1'; amount?: number | bigint };
 
 export function getBurnArgsSerializer(
   context: Pick<Context, 'serializer'>
@@ -25,7 +26,20 @@ export function getBurnArgsSerializer(
     [
       [
         'V1',
-        s.struct<GetDataEnumKindContent<BurnArgs, 'V1'>>([['amount', s.u64()]]),
+        mapSerializer<
+          GetDataEnumKindContent<BurnArgsArgs, 'V1'>,
+          GetDataEnumKindContent<BurnArgs, 'V1'>,
+          GetDataEnumKindContent<BurnArgs, 'V1'>
+        >(
+          s.struct<GetDataEnumKindContent<BurnArgs, 'V1'>>([
+            ['amount', s.u64()],
+          ]),
+          (value) =>
+            ({ ...value, amount: value.amount ?? 1 } as GetDataEnumKindContent<
+              BurnArgs,
+              'V1'
+            >)
+        ),
       ],
     ],
     { description: 'BurnArgs' }

--- a/clients/js/src/generated/types/delegateArgs.ts
+++ b/clients/js/src/generated/types/delegateArgs.ts
@@ -64,29 +64,29 @@ export type DelegateArgsArgs =
     }
   | {
       __kind: 'SaleV1';
-      amount: number | bigint;
+      amount?: number | bigint;
       authorizationData?: Option<AuthorizationDataArgs>;
     }
   | {
       __kind: 'TransferV1';
-      amount: number | bigint;
+      amount?: number | bigint;
       authorizationData?: Option<AuthorizationDataArgs>;
     }
   | { __kind: 'UpdateV1'; authorizationData?: Option<AuthorizationDataArgs> }
   | {
       __kind: 'UtilityV1';
-      amount: number | bigint;
+      amount?: number | bigint;
       authorizationData?: Option<AuthorizationDataArgs>;
     }
   | {
       __kind: 'StakingV1';
-      amount: number | bigint;
+      amount?: number | bigint;
       authorizationData?: Option<AuthorizationDataArgs>;
     }
-  | { __kind: 'StandardV1'; amount: number | bigint }
+  | { __kind: 'StandardV1'; amount?: number | bigint }
   | {
       __kind: 'LockedTransferV1';
-      amount: number | bigint;
+      amount?: number | bigint;
       lockedAddress: PublicKey;
       authorizationData?: Option<AuthorizationDataArgs>;
     }
@@ -138,6 +138,7 @@ export function getDelegateArgsSerializer(
           (value) =>
             ({
               ...value,
+              amount: value.amount ?? 1,
               authorizationData: value.authorizationData ?? none(),
             } as GetDataEnumKindContent<DelegateArgs, 'SaleV1'>)
         ),
@@ -159,6 +160,7 @@ export function getDelegateArgsSerializer(
           (value) =>
             ({
               ...value,
+              amount: value.amount ?? 1,
               authorizationData: value.authorizationData ?? none(),
             } as GetDataEnumKindContent<DelegateArgs, 'TransferV1'>)
         ),
@@ -200,6 +202,7 @@ export function getDelegateArgsSerializer(
           (value) =>
             ({
               ...value,
+              amount: value.amount ?? 1,
               authorizationData: value.authorizationData ?? none(),
             } as GetDataEnumKindContent<DelegateArgs, 'UtilityV1'>)
         ),
@@ -221,15 +224,27 @@ export function getDelegateArgsSerializer(
           (value) =>
             ({
               ...value,
+              amount: value.amount ?? 1,
               authorizationData: value.authorizationData ?? none(),
             } as GetDataEnumKindContent<DelegateArgs, 'StakingV1'>)
         ),
       ],
       [
         'StandardV1',
-        s.struct<GetDataEnumKindContent<DelegateArgs, 'StandardV1'>>([
-          ['amount', s.u64()],
-        ]),
+        mapSerializer<
+          GetDataEnumKindContent<DelegateArgsArgs, 'StandardV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'StandardV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'StandardV1'>
+        >(
+          s.struct<GetDataEnumKindContent<DelegateArgs, 'StandardV1'>>([
+            ['amount', s.u64()],
+          ]),
+          (value) =>
+            ({ ...value, amount: value.amount ?? 1 } as GetDataEnumKindContent<
+              DelegateArgs,
+              'StandardV1'
+            >)
+        ),
       ],
       [
         'LockedTransferV1',
@@ -249,6 +264,7 @@ export function getDelegateArgsSerializer(
           (value) =>
             ({
               ...value,
+              amount: value.amount ?? 1,
               authorizationData: value.authorizationData ?? none(),
             } as GetDataEnumKindContent<DelegateArgs, 'LockedTransferV1'>)
         ),

--- a/clients/js/src/generated/types/delegateArgs.ts
+++ b/clients/js/src/generated/types/delegateArgs.ts
@@ -13,6 +13,8 @@ import {
   Option,
   PublicKey,
   Serializer,
+  mapSerializer,
+  none,
 } from '@metaplex-foundation/umi';
 import {
   AuthorizationData,
@@ -56,38 +58,41 @@ export type DelegateArgs =
     };
 
 export type DelegateArgsArgs =
-  | { __kind: 'CollectionV1'; authorizationData: Option<AuthorizationDataArgs> }
+  | {
+      __kind: 'CollectionV1';
+      authorizationData?: Option<AuthorizationDataArgs>;
+    }
   | {
       __kind: 'SaleV1';
       amount: number | bigint;
-      authorizationData: Option<AuthorizationDataArgs>;
+      authorizationData?: Option<AuthorizationDataArgs>;
     }
   | {
       __kind: 'TransferV1';
       amount: number | bigint;
-      authorizationData: Option<AuthorizationDataArgs>;
+      authorizationData?: Option<AuthorizationDataArgs>;
     }
-  | { __kind: 'UpdateV1'; authorizationData: Option<AuthorizationDataArgs> }
+  | { __kind: 'UpdateV1'; authorizationData?: Option<AuthorizationDataArgs> }
   | {
       __kind: 'UtilityV1';
       amount: number | bigint;
-      authorizationData: Option<AuthorizationDataArgs>;
+      authorizationData?: Option<AuthorizationDataArgs>;
     }
   | {
       __kind: 'StakingV1';
       amount: number | bigint;
-      authorizationData: Option<AuthorizationDataArgs>;
+      authorizationData?: Option<AuthorizationDataArgs>;
     }
   | { __kind: 'StandardV1'; amount: number | bigint }
   | {
       __kind: 'LockedTransferV1';
       amount: number | bigint;
       lockedAddress: PublicKey;
-      authorizationData: Option<AuthorizationDataArgs>;
+      authorizationData?: Option<AuthorizationDataArgs>;
     }
   | {
       __kind: 'ProgrammableConfigV1';
-      authorizationData: Option<AuthorizationDataArgs>;
+      authorizationData?: Option<AuthorizationDataArgs>;
     };
 
 export function getDelegateArgsSerializer(
@@ -98,61 +103,127 @@ export function getDelegateArgsSerializer(
     [
       [
         'CollectionV1',
-        s.struct<GetDataEnumKindContent<DelegateArgs, 'CollectionV1'>>([
-          [
-            'authorizationData',
-            s.option(getAuthorizationDataSerializer(context)),
-          ],
-        ]),
+        mapSerializer<
+          GetDataEnumKindContent<DelegateArgsArgs, 'CollectionV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'CollectionV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'CollectionV1'>
+        >(
+          s.struct<GetDataEnumKindContent<DelegateArgs, 'CollectionV1'>>([
+            [
+              'authorizationData',
+              s.option(getAuthorizationDataSerializer(context)),
+            ],
+          ]),
+          (value) =>
+            ({
+              ...value,
+              authorizationData: value.authorizationData ?? none(),
+            } as GetDataEnumKindContent<DelegateArgs, 'CollectionV1'>)
+        ),
       ],
       [
         'SaleV1',
-        s.struct<GetDataEnumKindContent<DelegateArgs, 'SaleV1'>>([
-          ['amount', s.u64()],
-          [
-            'authorizationData',
-            s.option(getAuthorizationDataSerializer(context)),
-          ],
-        ]),
+        mapSerializer<
+          GetDataEnumKindContent<DelegateArgsArgs, 'SaleV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'SaleV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'SaleV1'>
+        >(
+          s.struct<GetDataEnumKindContent<DelegateArgs, 'SaleV1'>>([
+            ['amount', s.u64()],
+            [
+              'authorizationData',
+              s.option(getAuthorizationDataSerializer(context)),
+            ],
+          ]),
+          (value) =>
+            ({
+              ...value,
+              authorizationData: value.authorizationData ?? none(),
+            } as GetDataEnumKindContent<DelegateArgs, 'SaleV1'>)
+        ),
       ],
       [
         'TransferV1',
-        s.struct<GetDataEnumKindContent<DelegateArgs, 'TransferV1'>>([
-          ['amount', s.u64()],
-          [
-            'authorizationData',
-            s.option(getAuthorizationDataSerializer(context)),
-          ],
-        ]),
+        mapSerializer<
+          GetDataEnumKindContent<DelegateArgsArgs, 'TransferV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'TransferV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'TransferV1'>
+        >(
+          s.struct<GetDataEnumKindContent<DelegateArgs, 'TransferV1'>>([
+            ['amount', s.u64()],
+            [
+              'authorizationData',
+              s.option(getAuthorizationDataSerializer(context)),
+            ],
+          ]),
+          (value) =>
+            ({
+              ...value,
+              authorizationData: value.authorizationData ?? none(),
+            } as GetDataEnumKindContent<DelegateArgs, 'TransferV1'>)
+        ),
       ],
       [
         'UpdateV1',
-        s.struct<GetDataEnumKindContent<DelegateArgs, 'UpdateV1'>>([
-          [
-            'authorizationData',
-            s.option(getAuthorizationDataSerializer(context)),
-          ],
-        ]),
+        mapSerializer<
+          GetDataEnumKindContent<DelegateArgsArgs, 'UpdateV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'UpdateV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'UpdateV1'>
+        >(
+          s.struct<GetDataEnumKindContent<DelegateArgs, 'UpdateV1'>>([
+            [
+              'authorizationData',
+              s.option(getAuthorizationDataSerializer(context)),
+            ],
+          ]),
+          (value) =>
+            ({
+              ...value,
+              authorizationData: value.authorizationData ?? none(),
+            } as GetDataEnumKindContent<DelegateArgs, 'UpdateV1'>)
+        ),
       ],
       [
         'UtilityV1',
-        s.struct<GetDataEnumKindContent<DelegateArgs, 'UtilityV1'>>([
-          ['amount', s.u64()],
-          [
-            'authorizationData',
-            s.option(getAuthorizationDataSerializer(context)),
-          ],
-        ]),
+        mapSerializer<
+          GetDataEnumKindContent<DelegateArgsArgs, 'UtilityV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'UtilityV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'UtilityV1'>
+        >(
+          s.struct<GetDataEnumKindContent<DelegateArgs, 'UtilityV1'>>([
+            ['amount', s.u64()],
+            [
+              'authorizationData',
+              s.option(getAuthorizationDataSerializer(context)),
+            ],
+          ]),
+          (value) =>
+            ({
+              ...value,
+              authorizationData: value.authorizationData ?? none(),
+            } as GetDataEnumKindContent<DelegateArgs, 'UtilityV1'>)
+        ),
       ],
       [
         'StakingV1',
-        s.struct<GetDataEnumKindContent<DelegateArgs, 'StakingV1'>>([
-          ['amount', s.u64()],
-          [
-            'authorizationData',
-            s.option(getAuthorizationDataSerializer(context)),
-          ],
-        ]),
+        mapSerializer<
+          GetDataEnumKindContent<DelegateArgsArgs, 'StakingV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'StakingV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'StakingV1'>
+        >(
+          s.struct<GetDataEnumKindContent<DelegateArgs, 'StakingV1'>>([
+            ['amount', s.u64()],
+            [
+              'authorizationData',
+              s.option(getAuthorizationDataSerializer(context)),
+            ],
+          ]),
+          (value) =>
+            ({
+              ...value,
+              authorizationData: value.authorizationData ?? none(),
+            } as GetDataEnumKindContent<DelegateArgs, 'StakingV1'>)
+        ),
       ],
       [
         'StandardV1',
@@ -162,23 +233,47 @@ export function getDelegateArgsSerializer(
       ],
       [
         'LockedTransferV1',
-        s.struct<GetDataEnumKindContent<DelegateArgs, 'LockedTransferV1'>>([
-          ['amount', s.u64()],
-          ['lockedAddress', s.publicKey()],
-          [
-            'authorizationData',
-            s.option(getAuthorizationDataSerializer(context)),
-          ],
-        ]),
+        mapSerializer<
+          GetDataEnumKindContent<DelegateArgsArgs, 'LockedTransferV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'LockedTransferV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'LockedTransferV1'>
+        >(
+          s.struct<GetDataEnumKindContent<DelegateArgs, 'LockedTransferV1'>>([
+            ['amount', s.u64()],
+            ['lockedAddress', s.publicKey()],
+            [
+              'authorizationData',
+              s.option(getAuthorizationDataSerializer(context)),
+            ],
+          ]),
+          (value) =>
+            ({
+              ...value,
+              authorizationData: value.authorizationData ?? none(),
+            } as GetDataEnumKindContent<DelegateArgs, 'LockedTransferV1'>)
+        ),
       ],
       [
         'ProgrammableConfigV1',
-        s.struct<GetDataEnumKindContent<DelegateArgs, 'ProgrammableConfigV1'>>([
-          [
-            'authorizationData',
-            s.option(getAuthorizationDataSerializer(context)),
-          ],
-        ]),
+        mapSerializer<
+          GetDataEnumKindContent<DelegateArgsArgs, 'ProgrammableConfigV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'ProgrammableConfigV1'>,
+          GetDataEnumKindContent<DelegateArgs, 'ProgrammableConfigV1'>
+        >(
+          s.struct<
+            GetDataEnumKindContent<DelegateArgs, 'ProgrammableConfigV1'>
+          >([
+            [
+              'authorizationData',
+              s.option(getAuthorizationDataSerializer(context)),
+            ],
+          ]),
+          (value) =>
+            ({
+              ...value,
+              authorizationData: value.authorizationData ?? none(),
+            } as GetDataEnumKindContent<DelegateArgs, 'ProgrammableConfigV1'>)
+        ),
       ],
     ],
     { description: 'DelegateArgs' }

--- a/clients/js/src/generated/types/lockArgs.ts
+++ b/clients/js/src/generated/types/lockArgs.ts
@@ -12,6 +12,8 @@ import {
   GetDataEnumKindContent,
   Option,
   Serializer,
+  mapSerializer,
+  none,
 } from '@metaplex-foundation/umi';
 import {
   AuthorizationData,
@@ -26,7 +28,7 @@ export type LockArgs = {
 
 export type LockArgsArgs = {
   __kind: 'V1';
-  authorizationData: Option<AuthorizationDataArgs>;
+  authorizationData?: Option<AuthorizationDataArgs>;
 };
 
 export function getLockArgsSerializer(
@@ -37,12 +39,23 @@ export function getLockArgsSerializer(
     [
       [
         'V1',
-        s.struct<GetDataEnumKindContent<LockArgs, 'V1'>>([
-          [
-            'authorizationData',
-            s.option(getAuthorizationDataSerializer(context)),
-          ],
-        ]),
+        mapSerializer<
+          GetDataEnumKindContent<LockArgsArgs, 'V1'>,
+          GetDataEnumKindContent<LockArgs, 'V1'>,
+          GetDataEnumKindContent<LockArgs, 'V1'>
+        >(
+          s.struct<GetDataEnumKindContent<LockArgs, 'V1'>>([
+            [
+              'authorizationData',
+              s.option(getAuthorizationDataSerializer(context)),
+            ],
+          ]),
+          (value) =>
+            ({
+              ...value,
+              authorizationData: value.authorizationData ?? none(),
+            } as GetDataEnumKindContent<LockArgs, 'V1'>)
+        ),
       ],
     ],
     { description: 'LockArgs' }

--- a/clients/js/src/generated/types/mintArgs.ts
+++ b/clients/js/src/generated/types/mintArgs.ts
@@ -29,7 +29,7 @@ export type MintArgs = {
 
 export type MintArgsArgs = {
   __kind: 'V1';
-  amount: number | bigint;
+  amount?: number | bigint;
   authorizationData?: Option<AuthorizationDataArgs>;
 };
 
@@ -56,6 +56,7 @@ export function getMintArgsSerializer(
           (value) =>
             ({
               ...value,
+              amount: value.amount ?? 1,
               authorizationData: value.authorizationData ?? none(),
             } as GetDataEnumKindContent<MintArgs, 'V1'>)
         ),

--- a/clients/js/src/generated/types/transferArgs.ts
+++ b/clients/js/src/generated/types/transferArgs.ts
@@ -12,6 +12,8 @@ import {
   GetDataEnumKindContent,
   Option,
   Serializer,
+  mapSerializer,
+  none,
 } from '@metaplex-foundation/umi';
 import {
   AuthorizationData,
@@ -27,8 +29,8 @@ export type TransferArgs = {
 
 export type TransferArgsArgs = {
   __kind: 'V1';
-  amount: number | bigint;
-  authorizationData: Option<AuthorizationDataArgs>;
+  amount?: number | bigint;
+  authorizationData?: Option<AuthorizationDataArgs>;
 };
 
 export function getTransferArgsSerializer(
@@ -39,13 +41,25 @@ export function getTransferArgsSerializer(
     [
       [
         'V1',
-        s.struct<GetDataEnumKindContent<TransferArgs, 'V1'>>([
-          ['amount', s.u64()],
-          [
-            'authorizationData',
-            s.option(getAuthorizationDataSerializer(context)),
-          ],
-        ]),
+        mapSerializer<
+          GetDataEnumKindContent<TransferArgsArgs, 'V1'>,
+          GetDataEnumKindContent<TransferArgs, 'V1'>,
+          GetDataEnumKindContent<TransferArgs, 'V1'>
+        >(
+          s.struct<GetDataEnumKindContent<TransferArgs, 'V1'>>([
+            ['amount', s.u64()],
+            [
+              'authorizationData',
+              s.option(getAuthorizationDataSerializer(context)),
+            ],
+          ]),
+          (value) =>
+            ({
+              ...value,
+              amount: value.amount ?? 1,
+              authorizationData: value.authorizationData ?? none(),
+            } as GetDataEnumKindContent<TransferArgs, 'V1'>)
+        ),
       ],
     ],
     { description: 'TransferArgs' }

--- a/clients/js/src/generated/types/unlockArgs.ts
+++ b/clients/js/src/generated/types/unlockArgs.ts
@@ -12,6 +12,8 @@ import {
   GetDataEnumKindContent,
   Option,
   Serializer,
+  mapSerializer,
+  none,
 } from '@metaplex-foundation/umi';
 import {
   AuthorizationData,
@@ -26,7 +28,7 @@ export type UnlockArgs = {
 
 export type UnlockArgsArgs = {
   __kind: 'V1';
-  authorizationData: Option<AuthorizationDataArgs>;
+  authorizationData?: Option<AuthorizationDataArgs>;
 };
 
 export function getUnlockArgsSerializer(
@@ -37,12 +39,23 @@ export function getUnlockArgsSerializer(
     [
       [
         'V1',
-        s.struct<GetDataEnumKindContent<UnlockArgs, 'V1'>>([
-          [
-            'authorizationData',
-            s.option(getAuthorizationDataSerializer(context)),
-          ],
-        ]),
+        mapSerializer<
+          GetDataEnumKindContent<UnlockArgsArgs, 'V1'>,
+          GetDataEnumKindContent<UnlockArgs, 'V1'>,
+          GetDataEnumKindContent<UnlockArgs, 'V1'>
+        >(
+          s.struct<GetDataEnumKindContent<UnlockArgs, 'V1'>>([
+            [
+              'authorizationData',
+              s.option(getAuthorizationDataSerializer(context)),
+            ],
+          ]),
+          (value) =>
+            ({
+              ...value,
+              authorizationData: value.authorizationData ?? none(),
+            } as GetDataEnumKindContent<UnlockArgs, 'V1'>)
+        ),
       ],
     ],
     { description: 'UnlockArgs' }

--- a/clients/js/src/generated/types/useArgs.ts
+++ b/clients/js/src/generated/types/useArgs.ts
@@ -12,6 +12,8 @@ import {
   GetDataEnumKindContent,
   Option,
   Serializer,
+  mapSerializer,
+  none,
 } from '@metaplex-foundation/umi';
 import {
   AuthorizationData,
@@ -26,7 +28,7 @@ export type UseArgs = {
 
 export type UseArgsArgs = {
   __kind: 'V1';
-  authorizationData: Option<AuthorizationDataArgs>;
+  authorizationData?: Option<AuthorizationDataArgs>;
 };
 
 export function getUseArgsSerializer(
@@ -37,12 +39,23 @@ export function getUseArgsSerializer(
     [
       [
         'V1',
-        s.struct<GetDataEnumKindContent<UseArgs, 'V1'>>([
-          [
-            'authorizationData',
-            s.option(getAuthorizationDataSerializer(context)),
-          ],
-        ]),
+        mapSerializer<
+          GetDataEnumKindContent<UseArgsArgs, 'V1'>,
+          GetDataEnumKindContent<UseArgs, 'V1'>,
+          GetDataEnumKindContent<UseArgs, 'V1'>
+        >(
+          s.struct<GetDataEnumKindContent<UseArgs, 'V1'>>([
+            [
+              'authorizationData',
+              s.option(getAuthorizationDataSerializer(context)),
+            ],
+          ]),
+          (value) =>
+            ({
+              ...value,
+              authorizationData: value.authorizationData ?? none(),
+            } as GetDataEnumKindContent<UseArgs, 'V1'>)
+        ),
       ],
     ],
     { description: 'UseArgs' }

--- a/clients/js/src/hooked/resolvers.ts
+++ b/clients/js/src/hooked/resolvers.ts
@@ -42,6 +42,16 @@ export const resolveMasterEdition = (
     ? findMasterEditionPda(context, { mint: publicKey(accounts.mint) })
     : programId;
 
+export const resolveMasterEditionForProgrammables = (
+  context: Pick<Context, 'eddsa' | 'serializer' | 'programs'>,
+  accounts: { mint: PublicKey | Signer },
+  args: { tokenStandard: TokenStandard },
+  programId: PublicKey
+): PublicKey | Pda =>
+  isNonFungible(args.tokenStandard) && isProgrammable(args.tokenStandard)
+    ? findMasterEditionPda(context, { mint: publicKey(accounts.mint) })
+    : programId;
+
 export const resolveDecimals = (
   context: any,
   accounts: any,
@@ -97,5 +107,18 @@ export const resolveTokenRecord = (
     ? findTokenRecordPda(context, {
         mint: publicKey(accounts.mint),
         token: accounts.token,
+      })
+    : programId;
+
+export const resolveDestinationTokenRecord = (
+  context: Pick<Context, 'eddsa' | 'serializer' | 'programs'>,
+  accounts: { mint: PublicKey | Signer; destinationToken: PublicKey },
+  args: { tokenStandard: TokenStandard },
+  programId: PublicKey
+): PublicKey | Pda =>
+  isProgrammable(args.tokenStandard)
+    ? findTokenRecordPda(context, {
+        mint: publicKey(accounts.mint),
+        token: accounts.destinationToken,
       })
     : programId;

--- a/clients/js/src/hooked/resolvers.ts
+++ b/clients/js/src/hooked/resolvers.ts
@@ -90,12 +90,12 @@ export const resolveCreateV1Bytes = (
   return base;
 };
 
-export const resolveMintTokenOwner = (
+export const resolveOptionalTokenOwner = (
   context: Pick<Context, 'identity'>,
   accounts: { token?: PublicKey },
   args: any,
   programId: PublicKey
-): PublicKey | Pda => (accounts.token ? programId : context.identity.publicKey);
+): PublicKey => (accounts.token ? programId : context.identity.publicKey);
 
 export const resolveTokenRecord = (
   context: Pick<Context, 'eddsa' | 'serializer' | 'programs'>,

--- a/clients/js/src/hooked/resolvers.ts
+++ b/clients/js/src/hooked/resolvers.ts
@@ -99,11 +99,11 @@ export const resolveMintTokenOwner = (
 
 export const resolveTokenRecord = (
   context: Pick<Context, 'eddsa' | 'serializer' | 'programs'>,
-  accounts: { mint: PublicKey | Signer; token: PublicKey },
+  accounts: { mint: PublicKey | Signer; token?: PublicKey },
   args: { tokenStandard: TokenStandard },
   programId: PublicKey
 ): PublicKey | Pda =>
-  isProgrammable(args.tokenStandard)
+  isProgrammable(args.tokenStandard) && accounts.token
     ? findTokenRecordPda(context, {
         mint: publicKey(accounts.mint),
         token: accounts.token,

--- a/clients/js/src/hooked/resolvers.ts
+++ b/clients/js/src/hooked/resolvers.ts
@@ -148,8 +148,8 @@ export const resolveTokenProgramForNonProgrammables = (
   !isProgrammable(args.tokenStandard)
     ? {
         ...context.programs.getPublicKey(
-          'mplTokenAuthRules',
-          'auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg'
+          'splToken',
+          'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
         ),
         isWritable: false,
       }

--- a/clients/js/src/hooked/resolvers.ts
+++ b/clients/js/src/hooked/resolvers.ts
@@ -7,6 +7,7 @@ import {
   Signer,
   none,
   publicKey,
+  samePublicKey,
   some,
 } from '@metaplex-foundation/umi';
 import { getMintSize } from '@metaplex-foundation/mpl-essentials';
@@ -154,3 +155,15 @@ export const resolveTokenProgramForNonProgrammables = (
         isWritable: false,
       }
     : programId;
+
+export const resolveBurnMasterEdition = (
+  context: Pick<Context, 'eddsa' | 'serializer' | 'programs'>,
+  accounts: { masterEditionMint: PublicKey },
+  args: any,
+  programId: PublicKey
+): PublicKey | Pda =>
+  samePublicKey(accounts.masterEditionMint, programId)
+    ? programId
+    : findMasterEditionPda(context, {
+        mint: publicKey(accounts.masterEditionMint),
+      });

--- a/clients/js/src/hooked/resolvers.ts
+++ b/clients/js/src/hooked/resolvers.ts
@@ -122,3 +122,19 @@ export const resolveDestinationTokenRecord = (
         token: accounts.destinationToken,
       })
     : programId;
+
+export const resolveAuthorizationRulesProgram = (
+  context: Pick<Context, 'eddsa' | 'serializer' | 'programs'>,
+  accounts: { authorizationRules?: PublicKey },
+  args: any,
+  programId: PublicKey
+): PublicKey & { isWritable?: false } =>
+  accounts.authorizationRules
+    ? {
+        ...context.programs.getPublicKey(
+          'mplTokenAuthRules',
+          'auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg'
+        ),
+        isWritable: false,
+      }
+    : programId;

--- a/clients/js/src/hooked/resolvers.ts
+++ b/clients/js/src/hooked/resolvers.ts
@@ -124,12 +124,28 @@ export const resolveDestinationTokenRecord = (
     : programId;
 
 export const resolveAuthorizationRulesProgram = (
-  context: Pick<Context, 'eddsa' | 'serializer' | 'programs'>,
+  context: Pick<Context, 'programs'>,
   accounts: { authorizationRules?: PublicKey },
   args: any,
   programId: PublicKey
 ): PublicKey & { isWritable?: false } =>
   accounts.authorizationRules
+    ? {
+        ...context.programs.getPublicKey(
+          'mplTokenAuthRules',
+          'auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg'
+        ),
+        isWritable: false,
+      }
+    : programId;
+
+export const resolveTokenProgramForNonProgrammables = (
+  context: Pick<Context, 'programs'>,
+  accounts: any,
+  args: { tokenStandard: TokenStandard },
+  programId: PublicKey
+): PublicKey & { isWritable?: false } =>
+  !isProgrammable(args.tokenStandard)
     ? {
         ...context.programs.getPublicKey(
           'mplTokenAuthRules',

--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -10,6 +10,30 @@ import {
 import { createUmi as baseCreateUmi } from '@metaplex-foundation/umi-bundle-tests';
 import { createV1, mintV1, mplTokenMetadata, TokenStandard } from '../src';
 
+export type TokenStandardKeys = keyof typeof TokenStandard;
+
+export const ALL_TOKEN_STANDARDS: TokenStandardKeys[] = [
+  'NonFungible',
+  'FungibleAsset',
+  'Fungible',
+  'NonFungibleEdition',
+  'ProgrammableNonFungible',
+];
+
+export const NON_EDITION_TOKEN_STANDARDS: TokenStandardKeys[] = [
+  'NonFungible',
+  'FungibleAsset',
+  'Fungible',
+  'ProgrammableNonFungible',
+];
+
+export const NON_PROGRAMMABLE_TOKEN_STANDARDS: TokenStandardKeys[] = [
+  'NonFungible',
+  'FungibleAsset',
+  'Fungible',
+  'NonFungibleEdition',
+];
+
 export const createUmi = async () =>
   (await baseCreateUmi()).use(mplTokenMetadata());
 

--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -27,11 +27,15 @@ export const NON_EDITION_TOKEN_STANDARDS: TokenStandardKeys[] = [
   'ProgrammableNonFungible',
 ];
 
-export const NON_PROGRAMMABLE_TOKEN_STANDARDS: TokenStandardKeys[] = [
+export const OG_TOKEN_STANDARDS: TokenStandardKeys[] = [
   'NonFungible',
   'FungibleAsset',
   'Fungible',
-  'NonFungibleEdition',
+];
+
+export const FUNGIBLE_TOKEN_STANDARDS: TokenStandardKeys[] = [
+  'FungibleAsset',
+  'Fungible',
 ];
 
 export const createUmi = async () =>

--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -49,6 +49,7 @@ export const createDigitalAssetWithToken = async (
     )
     .add(
       mintV1(umi, {
+        authority: input.authority,
         mint: mint.publicKey,
         token: input.token,
         tokenOwner: input.tokenOwner,

--- a/clients/js/test/burnV1.test.ts
+++ b/clients/js/test/burnV1.test.ts
@@ -41,12 +41,98 @@ test('it can burn a NonFungible', async (t) => {
   t.true(await umi.rpc.accountExists(mint));
 });
 
-test.skip('it can burn a ProgrammableNonFungible', async (t) => {
-  // ...
+test('it can burn a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+    tokenOwner: owner.publicKey,
+  });
+  const da = await fetchDigitalAssetWithAssociatedToken(
+    umi,
+    mint,
+    owner.publicKey
+  );
+
+  // When the owner burns the asset.
+  await burnV1(umi, {
+    mint,
+    authority: owner,
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then the following accounts have been deleted.
+  t.false(await umi.rpc.accountExists(da.metadata.publicKey));
+  t.false(await umi.rpc.accountExists(da.edition!.publicKey));
+  t.false(await umi.rpc.accountExists(da.token.publicKey));
+  t.false(await umi.rpc.accountExists(da.tokenRecord!.publicKey));
+
+  // But the mint account still exists.
+  t.true(await umi.rpc.accountExists(mint));
 });
 
 FUNGIBLE_TOKEN_STANDARDS.forEach((tokenStandard) => {
-  test.skip(`it can burn a ${tokenStandard}`, async (t) => {
-    // ...
+  test(`it can burn the token account of a ${tokenStandard}`, async (t) => {
+    // Given a fungible with 42 tokens.
+    const umi = await createUmi();
+    const owner = generateSigner(umi);
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      tokenStandard: TokenStandard[tokenStandard],
+      tokenOwner: owner.publicKey,
+      amount: 42,
+    });
+    const da = await fetchDigitalAssetWithAssociatedToken(
+      umi,
+      mint,
+      owner.publicKey
+    );
+
+    // When the owner burns all the tokens in the asset.
+    await burnV1(umi, {
+      mint,
+      authority: owner,
+      tokenOwner: owner.publicKey,
+      tokenStandard: TokenStandard[tokenStandard],
+      amount: 42,
+    }).sendAndConfirm(umi);
+
+    // Then the token account has been deleted.
+    t.false(await umi.rpc.accountExists(da.token.publicKey));
+
+    // But the mint and metadata accounts still exist.
+    t.true(await umi.rpc.accountExists(mint));
+    t.true(await umi.rpc.accountExists(da.metadata.publicKey));
+  });
+
+  test(`it keeps the token account of a ${tokenStandard} if there are tokens left`, async (t) => {
+    // Given a fungible with 42 tokens.
+    const umi = await createUmi();
+    const owner = generateSigner(umi);
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      tokenStandard: TokenStandard[tokenStandard],
+      tokenOwner: owner.publicKey,
+      amount: 42,
+    });
+    const da = await fetchDigitalAssetWithAssociatedToken(
+      umi,
+      mint,
+      owner.publicKey
+    );
+
+    // When the owner burns only 10 tokens in the asset.
+    await burnV1(umi, {
+      mint,
+      authority: owner,
+      tokenOwner: owner.publicKey,
+      tokenStandard: TokenStandard[tokenStandard],
+      amount: 10,
+    }).sendAndConfirm(umi);
+
+    // Then no account was deleted.
+    t.true(await umi.rpc.accountExists(mint));
+    t.true(await umi.rpc.accountExists(da.metadata.publicKey));
+    t.true(await umi.rpc.accountExists(da.token.publicKey));
   });
 });

--- a/clients/js/test/burnV1.test.ts
+++ b/clients/js/test/burnV1.test.ts
@@ -1,0 +1,41 @@
+import { generateSigner } from '@metaplex-foundation/umi';
+import test from 'ava';
+import { TokenStandard, burnV1 } from '../src';
+import {
+  FUNGIBLE_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
+
+test('it can burn a NonFungible', async (t) => {
+  // Given a NonFungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+  });
+
+  // When the owner burns the asset.
+  await burnV1(umi, {
+    mint,
+    authority: owner,
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then the following accounts have been deleted.
+  // ...
+
+  // But the mint account still exists.
+  // ...
+});
+
+test.skip('it can burn a ProgrammableNonFungible', async (t) => {
+  // ...
+});
+
+FUNGIBLE_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test.skip(`it can burn a ${tokenStandard}`, async (t) => {
+    // ...
+  });
+});

--- a/clients/js/test/burnV1.test.ts
+++ b/clients/js/test/burnV1.test.ts
@@ -1,6 +1,10 @@
 import { generateSigner } from '@metaplex-foundation/umi';
 import test from 'ava';
-import { TokenStandard, burnV1 } from '../src';
+import {
+  TokenStandard,
+  burnV1,
+  fetchDigitalAssetWithAssociatedToken,
+} from '../src';
 import {
   FUNGIBLE_TOKEN_STANDARDS,
   createDigitalAssetWithToken,
@@ -14,6 +18,11 @@ test('it can burn a NonFungible', async (t) => {
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
   });
+  const da = await fetchDigitalAssetWithAssociatedToken(
+    umi,
+    mint,
+    owner.publicKey
+  );
 
   // When the owner burns the asset.
   await burnV1(umi, {
@@ -24,10 +33,12 @@ test('it can burn a NonFungible', async (t) => {
   }).sendAndConfirm(umi);
 
   // Then the following accounts have been deleted.
-  // ...
+  t.false(await umi.rpc.accountExists(da.metadata.publicKey));
+  t.false(await umi.rpc.accountExists(da.edition!.publicKey));
+  t.false(await umi.rpc.accountExists(da.token.publicKey));
 
   // But the mint account still exists.
-  // ...
+  t.true(await umi.rpc.accountExists(mint));
 });
 
 test.skip('it can burn a ProgrammableNonFungible', async (t) => {

--- a/clients/js/test/delegateCollectionV1.test.ts
+++ b/clients/js/test/delegateCollectionV1.test.ts
@@ -8,147 +8,46 @@ import {
   fetchMetadataDelegateRecord,
   findMetadataDelegateRecordPda,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
+import {
+  NON_EDITION_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
-test('it can approve a collection delegate for a NonFungible', async (t) => {
-  // Given a NonFungible.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-  });
+NON_EDITION_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it can approve a collection delegate for a ${tokenStandard}`, async (t) => {
+    // Given an asset.
+    const umi = await createUmi();
+    const updateAuthority = generateSigner(umi);
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      authority: updateAuthority,
+      tokenStandard: TokenStandard[tokenStandard],
+    });
 
-  // When we approve a collection delegate.
-  const collectionDelegate = generateSigner(umi).publicKey;
-  await delegateCollectionV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: collectionDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then a new metadata delegate record was created.
-  const delegateRecord = await fetchMetadataDelegateRecord(
-    umi,
-    findMetadataDelegateRecordPda(umi, {
+    // When we approve a collection delegate.
+    const collectionDelegate = generateSigner(umi).publicKey;
+    await delegateCollectionV1(umi, {
       mint,
-      delegateRole: MetadataDelegateRole.Collection,
-      delegate: collectionDelegate,
       updateAuthority: updateAuthority.publicKey,
-    })
-  );
-  t.like(delegateRecord, <MetadataDelegateRecord>{
-    mint: publicKey(mint),
-    updateAuthority: publicKey(updateAuthority),
-    delegate: publicKey(collectionDelegate),
-  });
-});
-
-test('it can approve a collection delegate for a ProgrammableNonFungible', async (t) => {
-  // Given a ProgrammableNonFungible.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-  });
-
-  // When we approve a collection delegate.
-  const collectionDelegate = generateSigner(umi).publicKey;
-  await delegateCollectionV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: collectionDelegate,
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then a new metadata delegate record was created.
-  const delegateRecord = await fetchMetadataDelegateRecord(
-    umi,
-    findMetadataDelegateRecordPda(umi, {
-      mint,
-      delegateRole: MetadataDelegateRole.Collection,
+      authority: updateAuthority,
       delegate: collectionDelegate,
-      updateAuthority: updateAuthority.publicKey,
-    })
-  );
-  t.like(delegateRecord, <MetadataDelegateRecord>{
-    mint: publicKey(mint),
-    updateAuthority: publicKey(updateAuthority),
-    delegate: publicKey(collectionDelegate),
-  });
-});
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
 
-test('it can approve a collection delegate for a Fungible', async (t) => {
-  // Given a Fungible.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.Fungible,
-  });
-
-  // When we approve a collection delegate.
-  const collectionDelegate = generateSigner(umi).publicKey;
-  await delegateCollectionV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: collectionDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-
-  // Then a new metadata delegate record was created.
-  const delegateRecord = await fetchMetadataDelegateRecord(
-    umi,
-    findMetadataDelegateRecordPda(umi, {
-      mint,
-      delegateRole: MetadataDelegateRole.Collection,
-      delegate: collectionDelegate,
-      updateAuthority: updateAuthority.publicKey,
-    })
-  );
-  t.like(delegateRecord, <MetadataDelegateRecord>{
-    mint: publicKey(mint),
-    updateAuthority: publicKey(updateAuthority),
-    delegate: publicKey(collectionDelegate),
-  });
-});
-
-test('it can approve a collection delegate for a FungibleAsset', async (t) => {
-  // Given a FungibleAsset.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-
-  // When we approve a collection delegate.
-  const collectionDelegate = generateSigner(umi).publicKey;
-  await delegateCollectionV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: collectionDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-
-  // Then a new metadata delegate record was created.
-  const delegateRecord = await fetchMetadataDelegateRecord(
-    umi,
-    findMetadataDelegateRecordPda(umi, {
-      mint,
-      delegateRole: MetadataDelegateRole.Collection,
-      delegate: collectionDelegate,
-      updateAuthority: updateAuthority.publicKey,
-    })
-  );
-  t.like(delegateRecord, <MetadataDelegateRecord>{
-    mint: publicKey(mint),
-    updateAuthority: publicKey(updateAuthority),
-    delegate: publicKey(collectionDelegate),
+    // Then a new metadata delegate record was created.
+    const delegateRecord = await fetchMetadataDelegateRecord(
+      umi,
+      findMetadataDelegateRecordPda(umi, {
+        mint,
+        delegateRole: MetadataDelegateRole.Collection,
+        delegate: collectionDelegate,
+        updateAuthority: updateAuthority.publicKey,
+      })
+    );
+    t.like(delegateRecord, <MetadataDelegateRecord>{
+      mint: publicKey(mint),
+      updateAuthority: publicKey(updateAuthority),
+      delegate: publicKey(collectionDelegate),
+    });
   });
 });

--- a/clients/js/test/delegateCollectionV1.test.ts
+++ b/clients/js/test/delegateCollectionV1.test.ts
@@ -1,0 +1,42 @@
+import { generateSigner } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  MetadataDelegateRole,
+  TokenStandard,
+  delegateCollectionV1,
+  fetchMetadataDelegateRecord,
+  findMetadataDelegateRecordPda,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can approve a collection delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  });
+
+  // When we approve a collection delegate.
+  const collectionDelegate = generateSigner(umi).publicKey;
+  await delegateCollectionV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: collectionDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then a new metadata delegate record was created.
+  const delegateRecord = await fetchMetadataDelegateRecord(
+    umi,
+    findMetadataDelegateRecordPda(umi, {
+      mint,
+      delegateRole: MetadataDelegateRole.Collection,
+      delegate: collectionDelegate,
+      updateAuthority: updateAuthority.publicKey,
+    })
+  );
+  console.log(delegateRecord);
+});

--- a/clients/js/test/delegateCollectionV1.test.ts
+++ b/clients/js/test/delegateCollectionV1.test.ts
@@ -1,6 +1,7 @@
-import { generateSigner } from '@metaplex-foundation/umi';
+import { generateSigner, publicKey } from '@metaplex-foundation/umi';
 import test from 'ava';
 import {
+  MetadataDelegateRecord,
   MetadataDelegateRole,
   TokenStandard,
   delegateCollectionV1,
@@ -8,6 +9,41 @@ import {
   findMetadataDelegateRecordPda,
 } from '../src';
 import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can approve a collection delegate for a NonFungible', async (t) => {
+  // Given a NonFungible.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+  });
+
+  // When we approve a collection delegate.
+  const collectionDelegate = generateSigner(umi).publicKey;
+  await delegateCollectionV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: collectionDelegate,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then a new metadata delegate record was created.
+  const delegateRecord = await fetchMetadataDelegateRecord(
+    umi,
+    findMetadataDelegateRecordPda(umi, {
+      mint,
+      delegateRole: MetadataDelegateRole.Collection,
+      delegate: collectionDelegate,
+      updateAuthority: updateAuthority.publicKey,
+    })
+  );
+  t.like(delegateRecord, <MetadataDelegateRecord>{
+    mint: publicKey(mint),
+    updateAuthority: publicKey(updateAuthority),
+    delegate: publicKey(collectionDelegate),
+  });
+});
 
 test('it can approve a collection delegate for a ProgrammableNonFungible', async (t) => {
   // Given a ProgrammableNonFungible.
@@ -38,5 +74,9 @@ test('it can approve a collection delegate for a ProgrammableNonFungible', async
       updateAuthority: updateAuthority.publicKey,
     })
   );
-  console.log(delegateRecord);
+  t.like(delegateRecord, <MetadataDelegateRecord>{
+    mint: publicKey(mint),
+    updateAuthority: publicKey(updateAuthority),
+    delegate: publicKey(collectionDelegate),
+  });
 });

--- a/clients/js/test/delegateCollectionV1.test.ts
+++ b/clients/js/test/delegateCollectionV1.test.ts
@@ -80,3 +80,75 @@ test('it can approve a collection delegate for a ProgrammableNonFungible', async
     delegate: publicKey(collectionDelegate),
   });
 });
+
+test('it can approve a collection delegate for a Fungible', async (t) => {
+  // Given a Fungible.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.Fungible,
+  });
+
+  // When we approve a collection delegate.
+  const collectionDelegate = generateSigner(umi).publicKey;
+  await delegateCollectionV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: collectionDelegate,
+    tokenStandard: TokenStandard.Fungible,
+  }).sendAndConfirm(umi);
+
+  // Then a new metadata delegate record was created.
+  const delegateRecord = await fetchMetadataDelegateRecord(
+    umi,
+    findMetadataDelegateRecordPda(umi, {
+      mint,
+      delegateRole: MetadataDelegateRole.Collection,
+      delegate: collectionDelegate,
+      updateAuthority: updateAuthority.publicKey,
+    })
+  );
+  t.like(delegateRecord, <MetadataDelegateRecord>{
+    mint: publicKey(mint),
+    updateAuthority: publicKey(updateAuthority),
+    delegate: publicKey(collectionDelegate),
+  });
+});
+
+test('it can approve a collection delegate for a FungibleAsset', async (t) => {
+  // Given a FungibleAsset.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.FungibleAsset,
+  });
+
+  // When we approve a collection delegate.
+  const collectionDelegate = generateSigner(umi).publicKey;
+  await delegateCollectionV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: collectionDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+  }).sendAndConfirm(umi);
+
+  // Then a new metadata delegate record was created.
+  const delegateRecord = await fetchMetadataDelegateRecord(
+    umi,
+    findMetadataDelegateRecordPda(umi, {
+      mint,
+      delegateRole: MetadataDelegateRole.Collection,
+      delegate: collectionDelegate,
+      updateAuthority: updateAuthority.publicKey,
+    })
+  );
+  t.like(delegateRecord, <MetadataDelegateRecord>{
+    mint: publicKey(mint),
+    updateAuthority: publicKey(updateAuthority),
+    delegate: publicKey(collectionDelegate),
+  });
+});

--- a/clients/js/test/delegateLockedTransferV1.test.ts
+++ b/clients/js/test/delegateLockedTransferV1.test.ts
@@ -1,0 +1,123 @@
+import { generateSigner, publicKey, some } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  DigitalAssetWithToken,
+  TokenDelegateRole,
+  TokenStandard,
+  TokenState,
+  delegateLockedTransferV1,
+  fetchDigitalAssetWithAssociatedToken,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can approve a locked transfer delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  });
+
+  // When we approve a locked transfer delegate.
+  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const lockedAddress = generateSigner(umi).publicKey;
+  await delegateLockedTransferV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: lockedTransferDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+    lockedAddress,
+  }).sendAndConfirm(umi);
+
+  // Then the locked transfer delegate was successfully stored.
+  t.like(
+    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+    <DigitalAssetWithToken>{
+      mint: { publicKey: publicKey(mint), supply: 1n },
+      token: { owner: owner.publicKey, amount: 1n },
+      tokenRecord: {
+        delegate: some(lockedTransferDelegate),
+        delegateRole: some(TokenDelegateRole.LockedTransfer),
+        lockedTransfer: some(lockedAddress),
+        state: TokenState.Unlocked,
+      },
+    }
+  );
+});
+
+test('it cannot approve a locked transfer delegate for a NonFungible', async (t) => {
+  // Given a NonFungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.NonFungible,
+  });
+
+  // When we try to approve a locked transfer delegate.
+  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const lockedAddress = generateSigner(umi).publicKey;
+  const promise = delegateLockedTransferV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: lockedTransferDelegate,
+    tokenStandard: TokenStandard.NonFungible,
+    lockedAddress,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});
+
+test('it cannot approve a locked transfer delegate for a Fungible', async (t) => {
+  // Given a Fungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.Fungible,
+  });
+
+  // When we try to approve a locked transfer delegate.
+  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const lockedAddress = generateSigner(umi).publicKey;
+  const promise = delegateLockedTransferV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: lockedTransferDelegate,
+    tokenStandard: TokenStandard.Fungible,
+    lockedAddress,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});
+
+test('it cannot approve a locked transfer delegate for a FungibleAsset', async (t) => {
+  // Given a FungibleAsset.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.FungibleAsset,
+  });
+
+  // When we try to approve a locked transfer delegate.
+  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const lockedAddress = generateSigner(umi).publicKey;
+  const promise = delegateLockedTransferV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: lockedTransferDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+    lockedAddress,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});

--- a/clients/js/test/delegateLockedTransferV1.test.ts
+++ b/clients/js/test/delegateLockedTransferV1.test.ts
@@ -36,9 +36,14 @@ test('it can approve a locked transfer delegate for a ProgrammableNonFungible', 
     await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
     <DigitalAssetWithToken>{
       mint: { publicKey: publicKey(mint), supply: 1n },
-      token: { owner: owner.publicKey, amount: 1n },
+      token: {
+        owner: owner.publicKey,
+        amount: 1n,
+        delegate: some(publicKey(lockedTransferDelegate)),
+        delegatedAmount: 1n,
+      },
       tokenRecord: {
-        delegate: some(lockedTransferDelegate),
+        delegate: some(publicKey(lockedTransferDelegate)),
         delegateRole: some(TokenDelegateRole.LockedTransfer),
         lockedTransfer: some(lockedAddress),
         state: TokenState.Unlocked,

--- a/clients/js/test/delegateProgrammableConfigV1.test.ts
+++ b/clients/js/test/delegateProgrammableConfigV1.test.ts
@@ -8,147 +8,46 @@ import {
   fetchMetadataDelegateRecord,
   findMetadataDelegateRecordPda,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
+import {
+  NON_EDITION_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
-test('it can approve a programmable config delegate for a NonFungible', async (t) => {
-  // Given a NonFungible.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-  });
+NON_EDITION_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it can approve a programmable config delegate for a ${tokenStandard}`, async (t) => {
+    // Given an asset.
+    const umi = await createUmi();
+    const updateAuthority = generateSigner(umi);
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      authority: updateAuthority,
+      tokenStandard: TokenStandard[tokenStandard],
+    });
 
-  // When we approve a programmable config delegate.
-  const programmableConfigDelegate = generateSigner(umi).publicKey;
-  await delegateProgrammableConfigV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: programmableConfigDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then a new metadata delegate record was created.
-  const delegateRecord = await fetchMetadataDelegateRecord(
-    umi,
-    findMetadataDelegateRecordPda(umi, {
+    // When we approve a programmable config delegate.
+    const programmableConfigDelegate = generateSigner(umi).publicKey;
+    await delegateProgrammableConfigV1(umi, {
       mint,
-      delegateRole: MetadataDelegateRole.ProgrammableConfig,
-      delegate: programmableConfigDelegate,
       updateAuthority: updateAuthority.publicKey,
-    })
-  );
-  t.like(delegateRecord, <MetadataDelegateRecord>{
-    mint: publicKey(mint),
-    updateAuthority: publicKey(updateAuthority),
-    delegate: publicKey(programmableConfigDelegate),
-  });
-});
-
-test('it can approve a programmable config delegate for a ProgrammableNonFungible', async (t) => {
-  // Given a ProgrammableNonFungible.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-  });
-
-  // When we approve a programmable config delegate.
-  const programmableConfigDelegate = generateSigner(umi).publicKey;
-  await delegateProgrammableConfigV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: programmableConfigDelegate,
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then a new metadata delegate record was created.
-  const delegateRecord = await fetchMetadataDelegateRecord(
-    umi,
-    findMetadataDelegateRecordPda(umi, {
-      mint,
-      delegateRole: MetadataDelegateRole.ProgrammableConfig,
+      authority: updateAuthority,
       delegate: programmableConfigDelegate,
-      updateAuthority: updateAuthority.publicKey,
-    })
-  );
-  t.like(delegateRecord, <MetadataDelegateRecord>{
-    mint: publicKey(mint),
-    updateAuthority: publicKey(updateAuthority),
-    delegate: publicKey(programmableConfigDelegate),
-  });
-});
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
 
-test('it can approve a programmable config delegate for a Fungible', async (t) => {
-  // Given a Fungible.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.Fungible,
-  });
-
-  // When we approve a programmable config delegate.
-  const programmableConfigDelegate = generateSigner(umi).publicKey;
-  await delegateProgrammableConfigV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: programmableConfigDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-
-  // Then a new metadata delegate record was created.
-  const delegateRecord = await fetchMetadataDelegateRecord(
-    umi,
-    findMetadataDelegateRecordPda(umi, {
-      mint,
-      delegateRole: MetadataDelegateRole.ProgrammableConfig,
-      delegate: programmableConfigDelegate,
-      updateAuthority: updateAuthority.publicKey,
-    })
-  );
-  t.like(delegateRecord, <MetadataDelegateRecord>{
-    mint: publicKey(mint),
-    updateAuthority: publicKey(updateAuthority),
-    delegate: publicKey(programmableConfigDelegate),
-  });
-});
-
-test('it can approve a programmable config delegate for a FungibleAsset', async (t) => {
-  // Given a FungibleAsset.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-
-  // When we approve a programmable config delegate.
-  const programmableConfigDelegate = generateSigner(umi).publicKey;
-  await delegateProgrammableConfigV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: programmableConfigDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-
-  // Then a new metadata delegate record was created.
-  const delegateRecord = await fetchMetadataDelegateRecord(
-    umi,
-    findMetadataDelegateRecordPda(umi, {
-      mint,
-      delegateRole: MetadataDelegateRole.ProgrammableConfig,
-      delegate: programmableConfigDelegate,
-      updateAuthority: updateAuthority.publicKey,
-    })
-  );
-  t.like(delegateRecord, <MetadataDelegateRecord>{
-    mint: publicKey(mint),
-    updateAuthority: publicKey(updateAuthority),
-    delegate: publicKey(programmableConfigDelegate),
+    // Then a new metadata delegate record was created.
+    const delegateRecord = await fetchMetadataDelegateRecord(
+      umi,
+      findMetadataDelegateRecordPda(umi, {
+        mint,
+        delegateRole: MetadataDelegateRole.ProgrammableConfig,
+        delegate: programmableConfigDelegate,
+        updateAuthority: updateAuthority.publicKey,
+      })
+    );
+    t.like(delegateRecord, <MetadataDelegateRecord>{
+      mint: publicKey(mint),
+      updateAuthority: publicKey(updateAuthority),
+      delegate: publicKey(programmableConfigDelegate),
+    });
   });
 });

--- a/clients/js/test/delegateProgrammableConfigV1.test.ts
+++ b/clients/js/test/delegateProgrammableConfigV1.test.ts
@@ -1,0 +1,154 @@
+import { generateSigner, publicKey } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  MetadataDelegateRecord,
+  MetadataDelegateRole,
+  TokenStandard,
+  delegateProgrammableConfigV1,
+  fetchMetadataDelegateRecord,
+  findMetadataDelegateRecordPda,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can approve a programmable config delegate for a NonFungible', async (t) => {
+  // Given a NonFungible.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+  });
+
+  // When we approve a programmable config delegate.
+  const programmableConfigDelegate = generateSigner(umi).publicKey;
+  await delegateProgrammableConfigV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: programmableConfigDelegate,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then a new metadata delegate record was created.
+  const delegateRecord = await fetchMetadataDelegateRecord(
+    umi,
+    findMetadataDelegateRecordPda(umi, {
+      mint,
+      delegateRole: MetadataDelegateRole.ProgrammableConfig,
+      delegate: programmableConfigDelegate,
+      updateAuthority: updateAuthority.publicKey,
+    })
+  );
+  t.like(delegateRecord, <MetadataDelegateRecord>{
+    mint: publicKey(mint),
+    updateAuthority: publicKey(updateAuthority),
+    delegate: publicKey(programmableConfigDelegate),
+  });
+});
+
+test('it can approve a programmable config delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  });
+
+  // When we approve a programmable config delegate.
+  const programmableConfigDelegate = generateSigner(umi).publicKey;
+  await delegateProgrammableConfigV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: programmableConfigDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then a new metadata delegate record was created.
+  const delegateRecord = await fetchMetadataDelegateRecord(
+    umi,
+    findMetadataDelegateRecordPda(umi, {
+      mint,
+      delegateRole: MetadataDelegateRole.ProgrammableConfig,
+      delegate: programmableConfigDelegate,
+      updateAuthority: updateAuthority.publicKey,
+    })
+  );
+  t.like(delegateRecord, <MetadataDelegateRecord>{
+    mint: publicKey(mint),
+    updateAuthority: publicKey(updateAuthority),
+    delegate: publicKey(programmableConfigDelegate),
+  });
+});
+
+test('it can approve a programmable config delegate for a Fungible', async (t) => {
+  // Given a Fungible.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.Fungible,
+  });
+
+  // When we approve a programmable config delegate.
+  const programmableConfigDelegate = generateSigner(umi).publicKey;
+  await delegateProgrammableConfigV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: programmableConfigDelegate,
+    tokenStandard: TokenStandard.Fungible,
+  }).sendAndConfirm(umi);
+
+  // Then a new metadata delegate record was created.
+  const delegateRecord = await fetchMetadataDelegateRecord(
+    umi,
+    findMetadataDelegateRecordPda(umi, {
+      mint,
+      delegateRole: MetadataDelegateRole.ProgrammableConfig,
+      delegate: programmableConfigDelegate,
+      updateAuthority: updateAuthority.publicKey,
+    })
+  );
+  t.like(delegateRecord, <MetadataDelegateRecord>{
+    mint: publicKey(mint),
+    updateAuthority: publicKey(updateAuthority),
+    delegate: publicKey(programmableConfigDelegate),
+  });
+});
+
+test('it can approve a programmable config delegate for a FungibleAsset', async (t) => {
+  // Given a FungibleAsset.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.FungibleAsset,
+  });
+
+  // When we approve a programmable config delegate.
+  const programmableConfigDelegate = generateSigner(umi).publicKey;
+  await delegateProgrammableConfigV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: programmableConfigDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+  }).sendAndConfirm(umi);
+
+  // Then a new metadata delegate record was created.
+  const delegateRecord = await fetchMetadataDelegateRecord(
+    umi,
+    findMetadataDelegateRecordPda(umi, {
+      mint,
+      delegateRole: MetadataDelegateRole.ProgrammableConfig,
+      delegate: programmableConfigDelegate,
+      updateAuthority: updateAuthority.publicKey,
+    })
+  );
+  t.like(delegateRecord, <MetadataDelegateRecord>{
+    mint: publicKey(mint),
+    updateAuthority: publicKey(updateAuthority),
+    delegate: publicKey(programmableConfigDelegate),
+  });
+});

--- a/clients/js/test/delegateSaleV1.test.ts
+++ b/clients/js/test/delegateSaleV1.test.ts
@@ -35,9 +35,14 @@ test('it can approve a sale delegate for a ProgrammableNonFungible', async (t) =
     await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
     <DigitalAssetWithToken>{
       mint: { publicKey: publicKey(mint), supply: 1n },
-      token: { owner: owner.publicKey, amount: 1n },
+      token: {
+        owner: owner.publicKey,
+        amount: 1n,
+        delegate: some(publicKey(saleDelegate)),
+        delegatedAmount: 1n,
+      },
       tokenRecord: {
-        delegate: some(saleDelegate),
+        delegate: some(publicKey(saleDelegate)),
         delegateRole: some(TokenDelegateRole.Sale),
         state: TokenState.Listed,
       },

--- a/clients/js/test/delegateSaleV1.test.ts
+++ b/clients/js/test/delegateSaleV1.test.ts
@@ -8,7 +8,11 @@ import {
   delegateSaleV1,
   fetchDigitalAssetWithAssociatedToken,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
+import {
+  OG_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
 test('it can approve a sale delegate for a ProgrammableNonFungible', async (t) => {
   // Given a ProgrammableNonFungible.
@@ -50,71 +54,27 @@ test('it can approve a sale delegate for a ProgrammableNonFungible', async (t) =
   );
 });
 
-test('it cannot approve a sale delegate for a NonFungible', async (t) => {
-  // Given a NonFungible.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.NonFungible,
+OG_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it cannot approve a sale delegate for a ${tokenStandard}`, async (t) => {
+    // Given a non-programmable asset.
+    const umi = await createUmi();
+    const owner = generateSigner(umi);
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      tokenOwner: owner.publicKey,
+      tokenStandard: TokenStandard[tokenStandard],
+    });
+
+    // When we try to approve a sale delegate.
+    const saleDelegate = generateSigner(umi).publicKey;
+    const promise = delegateSaleV1(umi, {
+      mint,
+      tokenOwner: owner.publicKey,
+      authority: owner,
+      delegate: saleDelegate,
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
+
+    // Then we expect a program error.
+    await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
   });
-
-  // When we try to approve a sale delegate.
-  const saleDelegate = generateSigner(umi).publicKey;
-  const promise = delegateSaleV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: saleDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
-});
-
-test('it cannot approve a sale delegate for a Fungible', async (t) => {
-  // Given a Fungible.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.Fungible,
-  });
-
-  // When we try to approve a sale delegate.
-  const saleDelegate = generateSigner(umi).publicKey;
-  const promise = delegateSaleV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: saleDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
-});
-
-test('it cannot approve a sale delegate for a FungibleAsset', async (t) => {
-  // Given a FungibleAsset.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-
-  // When we try to approve a sale delegate.
-  const saleDelegate = generateSigner(umi).publicKey;
-  const promise = delegateSaleV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: saleDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });

--- a/clients/js/test/delegateSaleV1.test.ts
+++ b/clients/js/test/delegateSaleV1.test.ts
@@ -1,0 +1,115 @@
+import { generateSigner, publicKey, some } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  DigitalAssetWithToken,
+  TokenDelegateRole,
+  TokenStandard,
+  TokenState,
+  delegateSaleV1,
+  fetchDigitalAssetWithAssociatedToken,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can approve a sale delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  });
+
+  // When we approve a sale delegate.
+  const saleDelegate = generateSigner(umi).publicKey;
+  await delegateSaleV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: saleDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then the sale delegate was successfully stored
+  // and the token state was set to Listed.
+  t.like(
+    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+    <DigitalAssetWithToken>{
+      mint: { publicKey: publicKey(mint), supply: 1n },
+      token: { owner: owner.publicKey, amount: 1n },
+      tokenRecord: {
+        delegate: some(saleDelegate),
+        delegateRole: some(TokenDelegateRole.Sale),
+        state: TokenState.Listed,
+      },
+    }
+  );
+});
+
+test('it cannot approve a sale delegate for a NonFungible', async (t) => {
+  // Given a NonFungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.NonFungible,
+  });
+
+  // When we try to approve a sale delegate.
+  const saleDelegate = generateSigner(umi).publicKey;
+  const promise = delegateSaleV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: saleDelegate,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});
+
+test('it cannot approve a sale delegate for a Fungible', async (t) => {
+  // Given a Fungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.Fungible,
+  });
+
+  // When we try to approve a sale delegate.
+  const saleDelegate = generateSigner(umi).publicKey;
+  const promise = delegateSaleV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: saleDelegate,
+    tokenStandard: TokenStandard.Fungible,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});
+
+test('it cannot approve a sale delegate for a FungibleAsset', async (t) => {
+  // Given a FungibleAsset.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.FungibleAsset,
+  });
+
+  // When we try to approve a sale delegate.
+  const saleDelegate = generateSigner(umi).publicKey;
+  const promise = delegateSaleV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: saleDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});

--- a/clients/js/test/delegateStakingV1.test.ts
+++ b/clients/js/test/delegateStakingV1.test.ts
@@ -8,7 +8,11 @@ import {
   delegateStakingV1,
   fetchDigitalAssetWithAssociatedToken,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
+import {
+  OG_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
 test('it can approve a staking delegate for a ProgrammableNonFungible', async (t) => {
   // Given a ProgrammableNonFungible.
@@ -49,71 +53,27 @@ test('it can approve a staking delegate for a ProgrammableNonFungible', async (t
   );
 });
 
-test('it cannot approve a staking delegate for a NonFungible', async (t) => {
-  // Given a NonFungible.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.NonFungible,
+OG_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it cannot approve a staking delegate for a ${tokenStandard}`, async (t) => {
+    // Given a non-programmable asset.
+    const umi = await createUmi();
+    const owner = generateSigner(umi);
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      tokenOwner: owner.publicKey,
+      tokenStandard: TokenStandard[tokenStandard],
+    });
+
+    // When we try to approve a staking delegate.
+    const stakingDelegate = generateSigner(umi).publicKey;
+    const promise = delegateStakingV1(umi, {
+      mint,
+      tokenOwner: owner.publicKey,
+      authority: owner,
+      delegate: stakingDelegate,
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
+
+    // Then we expect a program error.
+    await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
   });
-
-  // When we try to approve a staking delegate.
-  const stakingDelegate = generateSigner(umi).publicKey;
-  const promise = delegateStakingV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: stakingDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
-});
-
-test('it cannot approve a staking delegate for a Fungible', async (t) => {
-  // Given a Fungible.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.Fungible,
-  });
-
-  // When we try to approve a staking delegate.
-  const stakingDelegate = generateSigner(umi).publicKey;
-  const promise = delegateStakingV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: stakingDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
-});
-
-test('it cannot approve a staking delegate for a FungibleAsset', async (t) => {
-  // Given a FungibleAsset.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-
-  // When we try to approve a staking delegate.
-  const stakingDelegate = generateSigner(umi).publicKey;
-  const promise = delegateStakingV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: stakingDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });

--- a/clients/js/test/delegateStakingV1.test.ts
+++ b/clients/js/test/delegateStakingV1.test.ts
@@ -34,9 +34,14 @@ test('it can approve a staking delegate for a ProgrammableNonFungible', async (t
     await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
     <DigitalAssetWithToken>{
       mint: { publicKey: publicKey(mint), supply: 1n },
-      token: { owner: owner.publicKey, amount: 1n },
+      token: {
+        owner: owner.publicKey,
+        amount: 1n,
+        delegate: some(publicKey(stakingDelegate)),
+        delegatedAmount: 1n,
+      },
       tokenRecord: {
-        delegate: some(stakingDelegate),
+        delegate: some(publicKey(stakingDelegate)),
         delegateRole: some(TokenDelegateRole.Staking),
         state: TokenState.Unlocked,
       },

--- a/clients/js/test/delegateStakingV1.test.ts
+++ b/clients/js/test/delegateStakingV1.test.ts
@@ -1,0 +1,114 @@
+import { generateSigner, publicKey, some } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  DigitalAssetWithToken,
+  TokenDelegateRole,
+  TokenStandard,
+  TokenState,
+  delegateStakingV1,
+  fetchDigitalAssetWithAssociatedToken,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can approve a staking delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  });
+
+  // When we approve a staking delegate.
+  const stakingDelegate = generateSigner(umi).publicKey;
+  await delegateStakingV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: stakingDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then the staking delegate was successfully stored.
+  t.like(
+    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+    <DigitalAssetWithToken>{
+      mint: { publicKey: publicKey(mint), supply: 1n },
+      token: { owner: owner.publicKey, amount: 1n },
+      tokenRecord: {
+        delegate: some(stakingDelegate),
+        delegateRole: some(TokenDelegateRole.Staking),
+        state: TokenState.Unlocked,
+      },
+    }
+  );
+});
+
+test('it cannot approve a staking delegate for a NonFungible', async (t) => {
+  // Given a NonFungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.NonFungible,
+  });
+
+  // When we try to approve a staking delegate.
+  const stakingDelegate = generateSigner(umi).publicKey;
+  const promise = delegateStakingV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: stakingDelegate,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});
+
+test('it cannot approve a staking delegate for a Fungible', async (t) => {
+  // Given a Fungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.Fungible,
+  });
+
+  // When we try to approve a staking delegate.
+  const stakingDelegate = generateSigner(umi).publicKey;
+  const promise = delegateStakingV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: stakingDelegate,
+    tokenStandard: TokenStandard.Fungible,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});
+
+test('it cannot approve a staking delegate for a FungibleAsset', async (t) => {
+  // Given a FungibleAsset.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.FungibleAsset,
+  });
+
+  // When we try to approve a staking delegate.
+  const stakingDelegate = generateSigner(umi).publicKey;
+  const promise = delegateStakingV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: stakingDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});

--- a/clients/js/test/delegateStandardV1.test.ts
+++ b/clients/js/test/delegateStandardV1.test.ts
@@ -6,41 +6,11 @@ import {
   delegateStandardV1,
   fetchDigitalAssetWithAssociatedToken,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
-
-test('it can approve a standard delegate for a NonFungible', async (t) => {
-  // Given a NonFungible.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-  });
-
-  // When we approve a standard delegate.
-  const standardDelegate = generateSigner(umi).publicKey;
-  await delegateStandardV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: standardDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then the standard delegate was successfully stored.
-  t.like(
-    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
-    <DigitalAssetWithToken>{
-      mint: { publicKey: publicKey(mint), supply: 1n },
-      token: {
-        owner: owner.publicKey,
-        amount: 1n,
-        delegate: some(standardDelegate),
-        delegatedAmount: 1n,
-      },
-      tokenRecord: undefined,
-    }
-  );
-});
+import {
+  OG_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
 test('it cannot approve a standard delegate for a ProgrammableNonFungible', async (t) => {
   // Given a ProgrammableNonFungible.
@@ -65,72 +35,39 @@ test('it cannot approve a standard delegate for a ProgrammableNonFungible', asyn
   await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });
 
-test('it can approve a standard delegate for a Fungible', async (t) => {
-  // Given a Fungible.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.Fungible,
+OG_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it can approve a standard delegate for a ${tokenStandard}`, async (t) => {
+    // Given a non-programmable asset.
+    const umi = await createUmi();
+    const owner = generateSigner(umi);
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      tokenOwner: owner.publicKey,
+      tokenStandard: TokenStandard[tokenStandard],
+    });
+
+    // When we approve a standard delegate.
+    const standardDelegate = generateSigner(umi).publicKey;
+    await delegateStandardV1(umi, {
+      mint,
+      tokenOwner: owner.publicKey,
+      authority: owner,
+      delegate: standardDelegate,
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
+
+    // Then the standard delegate was successfully stored.
+    t.like(
+      await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+      <DigitalAssetWithToken>{
+        mint: { publicKey: publicKey(mint), supply: 1n },
+        token: {
+          owner: owner.publicKey,
+          amount: 1n,
+          delegate: some(standardDelegate),
+          delegatedAmount: 1n,
+        },
+        tokenRecord: undefined,
+      }
+    );
   });
-
-  // When we approve a standard delegate.
-  const standardDelegate = generateSigner(umi).publicKey;
-  await delegateStandardV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: standardDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-
-  // Then the standard delegate was successfully stored.
-  t.like(
-    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
-    <DigitalAssetWithToken>{
-      mint: { publicKey: publicKey(mint), supply: 1n },
-      token: {
-        owner: owner.publicKey,
-        amount: 1n,
-        delegate: some(standardDelegate),
-        delegatedAmount: 1n,
-      },
-      tokenRecord: undefined,
-    }
-  );
-});
-
-test('it can approve a standard delegate for a FungibleAsset', async (t) => {
-  // Given a FungibleAsset.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-
-  // When we approve a standard delegate.
-  const standardDelegate = generateSigner(umi).publicKey;
-  await delegateStandardV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: standardDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-
-  // Then the standard delegate was successfully stored.
-  t.like(
-    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
-    <DigitalAssetWithToken>{
-      mint: { publicKey: publicKey(mint), supply: 1n },
-      token: {
-        owner: owner.publicKey,
-        amount: 1n,
-        delegate: some(standardDelegate),
-        delegatedAmount: 1n,
-      },
-      tokenRecord: undefined,
-    }
-  );
 });

--- a/clients/js/test/delegateStandardV1.test.ts
+++ b/clients/js/test/delegateStandardV1.test.ts
@@ -35,6 +35,7 @@ test('it can approve a standard delegate for a NonFungible', async (t) => {
         owner: owner.publicKey,
         amount: 1n,
         delegate: some(standardDelegate),
+        delegatedAmount: 1n,
       },
       tokenRecord: undefined,
     }
@@ -92,6 +93,7 @@ test('it can approve a standard delegate for a Fungible', async (t) => {
         owner: owner.publicKey,
         amount: 1n,
         delegate: some(standardDelegate),
+        delegatedAmount: 1n,
       },
       tokenRecord: undefined,
     }
@@ -126,6 +128,7 @@ test('it can approve a standard delegate for a FungibleAsset', async (t) => {
         owner: owner.publicKey,
         amount: 1n,
         delegate: some(standardDelegate),
+        delegatedAmount: 1n,
       },
       tokenRecord: undefined,
     }

--- a/clients/js/test/delegateStandardV1.test.ts
+++ b/clients/js/test/delegateStandardV1.test.ts
@@ -1,0 +1,133 @@
+import { generateSigner, publicKey, some } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  DigitalAssetWithToken,
+  TokenStandard,
+  delegateStandardV1,
+  fetchDigitalAssetWithAssociatedToken,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can approve a standard delegate for a NonFungible', async (t) => {
+  // Given a NonFungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+  });
+
+  // When we approve a standard delegate.
+  const standardDelegate = generateSigner(umi).publicKey;
+  await delegateStandardV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: standardDelegate,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then the standard delegate was successfully stored.
+  t.like(
+    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+    <DigitalAssetWithToken>{
+      mint: { publicKey: publicKey(mint), supply: 1n },
+      token: {
+        owner: owner.publicKey,
+        amount: 1n,
+        delegate: some(standardDelegate),
+      },
+      tokenRecord: undefined,
+    }
+  );
+});
+
+test('it cannot approve a standard delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  });
+
+  // When we try to approve a standard delegate.
+  const standardDelegate = generateSigner(umi).publicKey;
+  const promise = delegateStandardV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: standardDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});
+
+test('it can approve a standard delegate for a Fungible', async (t) => {
+  // Given a Fungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.Fungible,
+  });
+
+  // When we approve a standard delegate.
+  const standardDelegate = generateSigner(umi).publicKey;
+  await delegateStandardV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: standardDelegate,
+    tokenStandard: TokenStandard.Fungible,
+  }).sendAndConfirm(umi);
+
+  // Then the standard delegate was successfully stored.
+  t.like(
+    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+    <DigitalAssetWithToken>{
+      mint: { publicKey: publicKey(mint), supply: 1n },
+      token: {
+        owner: owner.publicKey,
+        amount: 1n,
+        delegate: some(standardDelegate),
+      },
+      tokenRecord: undefined,
+    }
+  );
+});
+
+test('it can approve a standard delegate for a FungibleAsset', async (t) => {
+  // Given a FungibleAsset.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.FungibleAsset,
+  });
+
+  // When we approve a standard delegate.
+  const standardDelegate = generateSigner(umi).publicKey;
+  await delegateStandardV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: standardDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+  }).sendAndConfirm(umi);
+
+  // Then the standard delegate was successfully stored.
+  t.like(
+    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+    <DigitalAssetWithToken>{
+      mint: { publicKey: publicKey(mint), supply: 1n },
+      token: {
+        owner: owner.publicKey,
+        amount: 1n,
+        delegate: some(standardDelegate),
+      },
+      tokenRecord: undefined,
+    }
+  );
+});

--- a/clients/js/test/delegateTransferV1.test.ts
+++ b/clients/js/test/delegateTransferV1.test.ts
@@ -1,0 +1,125 @@
+import {
+  generateSigner,
+  none,
+  publicKey,
+  some,
+} from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  DigitalAssetWithToken,
+  TokenDelegateRole,
+  TokenStandard,
+  TokenState,
+  delegateTransferV1,
+  fetchDigitalAssetWithAssociatedToken,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can approve a transfer delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  });
+
+  // When we approve a transfer delegate.
+  const transferDelegate = generateSigner(umi).publicKey;
+  await delegateTransferV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: transferDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then the transfer delegate was successfully stored.
+  t.like(
+    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+    <DigitalAssetWithToken>{
+      mint: { publicKey: publicKey(mint), supply: 1n },
+      token: {
+        owner: owner.publicKey,
+        amount: 1n,
+        delegate: some(publicKey(transferDelegate)),
+        delegatedAmount: 1n,
+      },
+      tokenRecord: {
+        delegate: some(publicKey(transferDelegate)),
+        delegateRole: some(TokenDelegateRole.Transfer),
+        lockedTransfer: none(),
+        state: TokenState.Unlocked,
+      },
+    }
+  );
+});
+
+test('it cannot approve a transfer delegate for a NonFungible', async (t) => {
+  // Given a NonFungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.NonFungible,
+  });
+
+  // When we try to approve a transfer delegate.
+  const transferDelegate = generateSigner(umi).publicKey;
+  const promise = delegateTransferV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: transferDelegate,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});
+
+test('it cannot approve a transfer delegate for a Fungible', async (t) => {
+  // Given a Fungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.Fungible,
+  });
+
+  // When we try to approve a transfer delegate.
+  const transferDelegate = generateSigner(umi).publicKey;
+  const promise = delegateTransferV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: transferDelegate,
+    tokenStandard: TokenStandard.Fungible,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});
+
+test('it cannot approve a transfer delegate for a FungibleAsset', async (t) => {
+  // Given a FungibleAsset.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.FungibleAsset,
+  });
+
+  // When we try to approve a transfer delegate.
+  const transferDelegate = generateSigner(umi).publicKey;
+  const promise = delegateTransferV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: transferDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});

--- a/clients/js/test/delegateUpdateV1.test.ts
+++ b/clients/js/test/delegateUpdateV1.test.ts
@@ -1,0 +1,154 @@
+import { generateSigner, publicKey } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  MetadataDelegateRecord,
+  MetadataDelegateRole,
+  TokenStandard,
+  delegateUpdateV1,
+  fetchMetadataDelegateRecord,
+  findMetadataDelegateRecordPda,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can approve a update delegate for a NonFungible', async (t) => {
+  // Given a NonFungible.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+  });
+
+  // When we approve a update delegate.
+  const updateDelegate = generateSigner(umi).publicKey;
+  await delegateUpdateV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: updateDelegate,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then a new metadata delegate record was created.
+  const delegateRecord = await fetchMetadataDelegateRecord(
+    umi,
+    findMetadataDelegateRecordPda(umi, {
+      mint,
+      delegateRole: MetadataDelegateRole.Update,
+      delegate: updateDelegate,
+      updateAuthority: updateAuthority.publicKey,
+    })
+  );
+  t.like(delegateRecord, <MetadataDelegateRecord>{
+    mint: publicKey(mint),
+    updateAuthority: publicKey(updateAuthority),
+    delegate: publicKey(updateDelegate),
+  });
+});
+
+test('it can approve a update delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  });
+
+  // When we approve a update delegate.
+  const updateDelegate = generateSigner(umi).publicKey;
+  await delegateUpdateV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: updateDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then a new metadata delegate record was created.
+  const delegateRecord = await fetchMetadataDelegateRecord(
+    umi,
+    findMetadataDelegateRecordPda(umi, {
+      mint,
+      delegateRole: MetadataDelegateRole.Update,
+      delegate: updateDelegate,
+      updateAuthority: updateAuthority.publicKey,
+    })
+  );
+  t.like(delegateRecord, <MetadataDelegateRecord>{
+    mint: publicKey(mint),
+    updateAuthority: publicKey(updateAuthority),
+    delegate: publicKey(updateDelegate),
+  });
+});
+
+test('it can approve a update delegate for a Fungible', async (t) => {
+  // Given a Fungible.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.Fungible,
+  });
+
+  // When we approve a update delegate.
+  const updateDelegate = generateSigner(umi).publicKey;
+  await delegateUpdateV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: updateDelegate,
+    tokenStandard: TokenStandard.Fungible,
+  }).sendAndConfirm(umi);
+
+  // Then a new metadata delegate record was created.
+  const delegateRecord = await fetchMetadataDelegateRecord(
+    umi,
+    findMetadataDelegateRecordPda(umi, {
+      mint,
+      delegateRole: MetadataDelegateRole.Update,
+      delegate: updateDelegate,
+      updateAuthority: updateAuthority.publicKey,
+    })
+  );
+  t.like(delegateRecord, <MetadataDelegateRecord>{
+    mint: publicKey(mint),
+    updateAuthority: publicKey(updateAuthority),
+    delegate: publicKey(updateDelegate),
+  });
+});
+
+test('it can approve a update delegate for a FungibleAsset', async (t) => {
+  // Given a FungibleAsset.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.FungibleAsset,
+  });
+
+  // When we approve a update delegate.
+  const updateDelegate = generateSigner(umi).publicKey;
+  await delegateUpdateV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: updateDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+  }).sendAndConfirm(umi);
+
+  // Then a new metadata delegate record was created.
+  const delegateRecord = await fetchMetadataDelegateRecord(
+    umi,
+    findMetadataDelegateRecordPda(umi, {
+      mint,
+      delegateRole: MetadataDelegateRole.Update,
+      delegate: updateDelegate,
+      updateAuthority: updateAuthority.publicKey,
+    })
+  );
+  t.like(delegateRecord, <MetadataDelegateRecord>{
+    mint: publicKey(mint),
+    updateAuthority: publicKey(updateAuthority),
+    delegate: publicKey(updateDelegate),
+  });
+});

--- a/clients/js/test/delegateUpdateV1.test.ts
+++ b/clients/js/test/delegateUpdateV1.test.ts
@@ -8,147 +8,46 @@ import {
   fetchMetadataDelegateRecord,
   findMetadataDelegateRecordPda,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
+import {
+  NON_EDITION_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
-test('it can approve a update delegate for a NonFungible', async (t) => {
-  // Given a NonFungible.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-  });
+NON_EDITION_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it can approve a update delegate for a ${tokenStandard}`, async (t) => {
+    // Given an asset.
+    const umi = await createUmi();
+    const updateAuthority = generateSigner(umi);
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      authority: updateAuthority,
+      tokenStandard: TokenStandard[tokenStandard],
+    });
 
-  // When we approve a update delegate.
-  const updateDelegate = generateSigner(umi).publicKey;
-  await delegateUpdateV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: updateDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then a new metadata delegate record was created.
-  const delegateRecord = await fetchMetadataDelegateRecord(
-    umi,
-    findMetadataDelegateRecordPda(umi, {
+    // When we approve a update delegate.
+    const updateDelegate = generateSigner(umi).publicKey;
+    await delegateUpdateV1(umi, {
       mint,
-      delegateRole: MetadataDelegateRole.Update,
-      delegate: updateDelegate,
       updateAuthority: updateAuthority.publicKey,
-    })
-  );
-  t.like(delegateRecord, <MetadataDelegateRecord>{
-    mint: publicKey(mint),
-    updateAuthority: publicKey(updateAuthority),
-    delegate: publicKey(updateDelegate),
-  });
-});
-
-test('it can approve a update delegate for a ProgrammableNonFungible', async (t) => {
-  // Given a ProgrammableNonFungible.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-  });
-
-  // When we approve a update delegate.
-  const updateDelegate = generateSigner(umi).publicKey;
-  await delegateUpdateV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: updateDelegate,
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then a new metadata delegate record was created.
-  const delegateRecord = await fetchMetadataDelegateRecord(
-    umi,
-    findMetadataDelegateRecordPda(umi, {
-      mint,
-      delegateRole: MetadataDelegateRole.Update,
+      authority: updateAuthority,
       delegate: updateDelegate,
-      updateAuthority: updateAuthority.publicKey,
-    })
-  );
-  t.like(delegateRecord, <MetadataDelegateRecord>{
-    mint: publicKey(mint),
-    updateAuthority: publicKey(updateAuthority),
-    delegate: publicKey(updateDelegate),
-  });
-});
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
 
-test('it can approve a update delegate for a Fungible', async (t) => {
-  // Given a Fungible.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.Fungible,
-  });
-
-  // When we approve a update delegate.
-  const updateDelegate = generateSigner(umi).publicKey;
-  await delegateUpdateV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: updateDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-
-  // Then a new metadata delegate record was created.
-  const delegateRecord = await fetchMetadataDelegateRecord(
-    umi,
-    findMetadataDelegateRecordPda(umi, {
-      mint,
-      delegateRole: MetadataDelegateRole.Update,
-      delegate: updateDelegate,
-      updateAuthority: updateAuthority.publicKey,
-    })
-  );
-  t.like(delegateRecord, <MetadataDelegateRecord>{
-    mint: publicKey(mint),
-    updateAuthority: publicKey(updateAuthority),
-    delegate: publicKey(updateDelegate),
-  });
-});
-
-test('it can approve a update delegate for a FungibleAsset', async (t) => {
-  // Given a FungibleAsset.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-
-  // When we approve a update delegate.
-  const updateDelegate = generateSigner(umi).publicKey;
-  await delegateUpdateV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: updateDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-
-  // Then a new metadata delegate record was created.
-  const delegateRecord = await fetchMetadataDelegateRecord(
-    umi,
-    findMetadataDelegateRecordPda(umi, {
-      mint,
-      delegateRole: MetadataDelegateRole.Update,
-      delegate: updateDelegate,
-      updateAuthority: updateAuthority.publicKey,
-    })
-  );
-  t.like(delegateRecord, <MetadataDelegateRecord>{
-    mint: publicKey(mint),
-    updateAuthority: publicKey(updateAuthority),
-    delegate: publicKey(updateDelegate),
+    // Then a new metadata delegate record was created.
+    const delegateRecord = await fetchMetadataDelegateRecord(
+      umi,
+      findMetadataDelegateRecordPda(umi, {
+        mint,
+        delegateRole: MetadataDelegateRole.Update,
+        delegate: updateDelegate,
+        updateAuthority: updateAuthority.publicKey,
+      })
+    );
+    t.like(delegateRecord, <MetadataDelegateRecord>{
+      mint: publicKey(mint),
+      updateAuthority: publicKey(updateAuthority),
+      delegate: publicKey(updateDelegate),
+    });
   });
 });

--- a/clients/js/test/delegateUtilityV1.test.ts
+++ b/clients/js/test/delegateUtilityV1.test.ts
@@ -34,9 +34,14 @@ test('it can approve a utility delegate for a ProgrammableNonFungible', async (t
     await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
     <DigitalAssetWithToken>{
       mint: { publicKey: publicKey(mint), supply: 1n },
-      token: { owner: owner.publicKey, amount: 1n },
+      token: {
+        owner: owner.publicKey,
+        amount: 1n,
+        delegate: some(publicKey(utilityDelegate)),
+        delegatedAmount: 1n,
+      },
       tokenRecord: {
-        delegate: some(utilityDelegate),
+        delegate: some(publicKey(utilityDelegate)),
         delegateRole: some(TokenDelegateRole.Utility),
         state: TokenState.Unlocked,
       },

--- a/clients/js/test/delegateUtilityV1.test.ts
+++ b/clients/js/test/delegateUtilityV1.test.ts
@@ -8,7 +8,11 @@ import {
   delegateUtilityV1,
   fetchDigitalAssetWithAssociatedToken,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
+import {
+  OG_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
 test('it can approve a utility delegate for a ProgrammableNonFungible', async (t) => {
   // Given a ProgrammableNonFungible.
@@ -49,71 +53,27 @@ test('it can approve a utility delegate for a ProgrammableNonFungible', async (t
   );
 });
 
-test('it cannot approve a utility delegate for a NonFungible', async (t) => {
-  // Given a NonFungible.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.NonFungible,
+OG_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it cannot approve a utility delegate for a ${tokenStandard}`, async (t) => {
+    // Given a non-programmable asset.
+    const umi = await createUmi();
+    const owner = generateSigner(umi);
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      tokenOwner: owner.publicKey,
+      tokenStandard: TokenStandard[tokenStandard],
+    });
+
+    // When we try to approve a utility delegate.
+    const utilityDelegate = generateSigner(umi).publicKey;
+    const promise = delegateUtilityV1(umi, {
+      mint,
+      tokenOwner: owner.publicKey,
+      authority: owner,
+      delegate: utilityDelegate,
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
+
+    // Then we expect a program error.
+    await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
   });
-
-  // When we try to approve a utility delegate.
-  const utilityDelegate = generateSigner(umi).publicKey;
-  const promise = delegateUtilityV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: utilityDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
-});
-
-test('it cannot approve a utility delegate for a Fungible', async (t) => {
-  // Given a Fungible.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.Fungible,
-  });
-
-  // When we try to approve a utility delegate.
-  const utilityDelegate = generateSigner(umi).publicKey;
-  const promise = delegateUtilityV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: utilityDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
-});
-
-test('it cannot approve a utility delegate for a FungibleAsset', async (t) => {
-  // Given a FungibleAsset.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-
-  // When we try to approve a utility delegate.
-  const utilityDelegate = generateSigner(umi).publicKey;
-  const promise = delegateUtilityV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: utilityDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });

--- a/clients/js/test/delegateUtilityV1.test.ts
+++ b/clients/js/test/delegateUtilityV1.test.ts
@@ -1,0 +1,46 @@
+import { findAssociatedTokenPda } from '@metaplex-foundation/mpl-essentials';
+import { PublicKey, generateSigner, publicKey } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  DigitalAssetWithToken,
+  TokenStandard,
+  fetchDigitalAssetWithAssociatedToken,
+  transferV1,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can delegate a NonFungible', async (t) => {
+  // Given a NonFungible that belongs to owner A.
+  const umi = await createUmi();
+  const ownerA = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: ownerA.publicKey,
+  });
+
+  // When we transfer the asset to owner B.
+  const ownerB = generateSigner(umi).publicKey;
+  await transferV1(umi, {
+    mint,
+    authority: ownerA,
+    tokenOwner: ownerA.publicKey,
+    destinationOwner: ownerB,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then the asset is now owned by owner B.
+  const da = await fetchDigitalAssetWithAssociatedToken(umi, mint, ownerB);
+  t.like(da, <DigitalAssetWithToken>{
+    mint: {
+      publicKey: publicKey(mint),
+      supply: 1n,
+    },
+    token: {
+      publicKey: findAssociatedTokenPda(umi, {
+        mint,
+        owner: ownerB,
+      }) as PublicKey,
+      owner: ownerB,
+      amount: 1n,
+    },
+  });
+});

--- a/clients/js/test/delegateUtilityV1.test.ts
+++ b/clients/js/test/delegateUtilityV1.test.ts
@@ -1,5 +1,6 @@
 import { generateSigner, publicKey } from '@metaplex-foundation/umi';
 import test from 'ava';
+import { findAssociatedTokenPda } from '@metaplex-foundation/mpl-essentials';
 import {
   DigitalAssetWithToken,
   TokenStandard,
@@ -20,6 +21,7 @@ test('it can approve a utility delegate for a NonFungible', async (t) => {
   const utilityDelegate = generateSigner(umi).publicKey;
   await delegateUtilityV1(umi, {
     mint,
+    token: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
     authority: owner,
     delegate: utilityDelegate,
     tokenStandard: TokenStandard.NonFungible,

--- a/clients/js/test/delegateUtilityV1.test.ts
+++ b/clients/js/test/delegateUtilityV1.test.ts
@@ -1,45 +1,43 @@
-import { findAssociatedTokenPda } from '@metaplex-foundation/mpl-essentials';
-import { PublicKey, generateSigner, publicKey } from '@metaplex-foundation/umi';
+import { generateSigner, publicKey } from '@metaplex-foundation/umi';
 import test from 'ava';
 import {
   DigitalAssetWithToken,
   TokenStandard,
+  delegateUtilityV1,
   fetchDigitalAssetWithAssociatedToken,
-  transferV1,
 } from '../src';
 import { createDigitalAssetWithToken, createUmi } from './_setup';
 
-test('it can delegate a NonFungible', async (t) => {
-  // Given a NonFungible that belongs to owner A.
+test('it can approve a utility delegate for a NonFungible', async (t) => {
+  // Given a NonFungible.
   const umi = await createUmi();
-  const ownerA = generateSigner(umi);
+  const owner = generateSigner(umi);
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: ownerA.publicKey,
+    tokenOwner: owner.publicKey,
   });
 
-  // When we transfer the asset to owner B.
-  const ownerB = generateSigner(umi).publicKey;
-  await transferV1(umi, {
+  // When we approve a utility delegate.
+  const utilityDelegate = generateSigner(umi).publicKey;
+  await delegateUtilityV1(umi, {
     mint,
-    authority: ownerA,
-    tokenOwner: ownerA.publicKey,
-    destinationOwner: ownerB,
+    authority: owner,
+    delegate: utilityDelegate,
     tokenStandard: TokenStandard.NonFungible,
   }).sendAndConfirm(umi);
 
   // Then the asset is now owned by owner B.
-  const da = await fetchDigitalAssetWithAssociatedToken(umi, mint, ownerB);
+  const da = await fetchDigitalAssetWithAssociatedToken(
+    umi,
+    mint,
+    owner.publicKey
+  );
   t.like(da, <DigitalAssetWithToken>{
     mint: {
       publicKey: publicKey(mint),
       supply: 1n,
     },
     token: {
-      publicKey: findAssociatedTokenPda(umi, {
-        mint,
-        owner: ownerB,
-      }) as PublicKey,
-      owner: ownerB,
+      owner: owner.publicKey,
       amount: 1n,
     },
   });

--- a/clients/js/test/delegateUtilityV1.test.ts
+++ b/clients/js/test/delegateUtilityV1.test.ts
@@ -1,19 +1,22 @@
-import { generateSigner, publicKey } from '@metaplex-foundation/umi';
+import { generateSigner, publicKey, some } from '@metaplex-foundation/umi';
 import test from 'ava';
 import {
   DigitalAssetWithToken,
+  TokenDelegateRole,
   TokenStandard,
+  TokenState,
   delegateUtilityV1,
   fetchDigitalAssetWithAssociatedToken,
 } from '../src';
 import { createDigitalAssetWithToken, createUmi } from './_setup';
 
-test('it can approve a utility delegate for a NonFungible', async (t) => {
-  // Given a NonFungible.
+test('it can approve a utility delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible.
   const umi = await createUmi();
   const owner = generateSigner(umi);
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
   });
 
   // When we approve a utility delegate.
@@ -23,24 +26,89 @@ test('it can approve a utility delegate for a NonFungible', async (t) => {
     tokenOwner: owner.publicKey,
     authority: owner,
     delegate: utilityDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then the utility delegate was successfully stored.
+  t.like(
+    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+    <DigitalAssetWithToken>{
+      mint: { publicKey: publicKey(mint), supply: 1n },
+      token: { owner: owner.publicKey, amount: 1n },
+      tokenRecord: {
+        delegate: some(utilityDelegate),
+        delegateRole: some(TokenDelegateRole.Utility),
+        state: TokenState.Unlocked,
+      },
+    }
+  );
+});
+
+test('it cannot approve a utility delegate for a NonFungible', async (t) => {
+  // Given a NonFungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.NonFungible,
+  });
+
+  // When we try to approve a utility delegate.
+  const utilityDelegate = generateSigner(umi).publicKey;
+  const promise = delegateUtilityV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: utilityDelegate,
     tokenStandard: TokenStandard.NonFungible,
   }).sendAndConfirm(umi);
 
-  // Then
-  const da = await fetchDigitalAssetWithAssociatedToken(
-    umi,
-    mint,
-    owner.publicKey
-  );
-  console.log(da);
-  t.like(da, <DigitalAssetWithToken>{
-    mint: {
-      publicKey: publicKey(mint),
-      supply: 1n,
-    },
-    token: {
-      owner: owner.publicKey,
-      amount: 1n,
-    },
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});
+
+test('it cannot approve a utility delegate for a Fungible', async (t) => {
+  // Given a Fungible.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.Fungible,
   });
+
+  // When we try to approve a utility delegate.
+  const utilityDelegate = generateSigner(umi).publicKey;
+  const promise = delegateUtilityV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: utilityDelegate,
+    tokenStandard: TokenStandard.Fungible,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});
+
+test('it cannot approve a utility delegate for a FungibleAsset', async (t) => {
+  // Given a FungibleAsset.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.FungibleAsset,
+  });
+
+  // When we try to approve a utility delegate.
+  const utilityDelegate = generateSigner(umi).publicKey;
+  const promise = delegateUtilityV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: utilityDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });

--- a/clients/js/test/delegateUtilityV1.test.ts
+++ b/clients/js/test/delegateUtilityV1.test.ts
@@ -1,6 +1,5 @@
 import { generateSigner, publicKey } from '@metaplex-foundation/umi';
 import test from 'ava';
-import { findAssociatedTokenPda } from '@metaplex-foundation/mpl-essentials';
 import {
   DigitalAssetWithToken,
   TokenStandard,
@@ -21,7 +20,7 @@ test('it can approve a utility delegate for a NonFungible', async (t) => {
   const utilityDelegate = generateSigner(umi).publicKey;
   await delegateUtilityV1(umi, {
     mint,
-    token: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
+    tokenOwner: owner.publicKey,
     authority: owner,
     delegate: utilityDelegate,
     tokenStandard: TokenStandard.NonFungible,

--- a/clients/js/test/delegateUtilityV1.test.ts
+++ b/clients/js/test/delegateUtilityV1.test.ts
@@ -24,15 +24,15 @@ test('it can approve a utility delegate for a NonFungible', async (t) => {
     authority: owner,
     delegate: utilityDelegate,
     tokenStandard: TokenStandard.NonFungible,
-    amount: 1,
   }).sendAndConfirm(umi);
 
-  // Then the asset is now owned by owner B.
+  // Then
   const da = await fetchDigitalAssetWithAssociatedToken(
     umi,
     mint,
     owner.publicKey
   );
+  console.log(da);
   t.like(da, <DigitalAssetWithToken>{
     mint: {
       publicKey: publicKey(mint),

--- a/clients/js/test/delegateUtilityV1.test.ts
+++ b/clients/js/test/delegateUtilityV1.test.ts
@@ -23,6 +23,7 @@ test('it can approve a utility delegate for a NonFungible', async (t) => {
     authority: owner,
     delegate: utilityDelegate,
     tokenStandard: TokenStandard.NonFungible,
+    amount: 1,
   }).sendAndConfirm(umi);
 
   // Then the asset is now owned by owner B.

--- a/clients/js/test/lockV1.test.ts
+++ b/clients/js/test/lockV1.test.ts
@@ -1,0 +1,41 @@
+import { generateSigner } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  DigitalAssetWithToken,
+  TokenStandard,
+  TokenState,
+  delegateUtilityV1,
+  fetchDigitalAssetWithAssociatedToken,
+  lockV1,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can lock a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible with a utility delegate.
+  const umi = await createUmi();
+  const owner = umi.identity.publicKey;
+  const utilityDelegate = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  });
+  await delegateUtilityV1(umi, {
+    mint,
+    delegate: utilityDelegate.publicKey,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+  t.like(await fetchDigitalAssetWithAssociatedToken(umi, mint, owner), <
+    DigitalAssetWithToken
+  >{ tokenRecord: { state: TokenState.Unlocked } });
+
+  // When the utility delegate locks the asset.
+  await lockV1(umi, {
+    mint,
+    authority: utilityDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then the token state was successfully updated.
+  t.like(await fetchDigitalAssetWithAssociatedToken(umi, mint, owner), <
+    DigitalAssetWithToken
+  >{ tokenRecord: { state: TokenState.Locked } });
+});

--- a/clients/js/test/lockV1.test.ts
+++ b/clients/js/test/lockV1.test.ts
@@ -1,6 +1,6 @@
+import { TokenState as SplTokenState } from '@metaplex-foundation/mpl-essentials';
 import { generateSigner } from '@metaplex-foundation/umi';
 import test from 'ava';
-import { TokenState as SplTokenState } from '@metaplex-foundation/mpl-essentials';
 import {
   DigitalAssetWithToken,
   TokenStandard,
@@ -71,26 +71,21 @@ test('it can freeze a NonFungible', async (t) => {
 });
 
 test('it can freeze a Fungible', async (t) => {
-  // Given a Fungible with a standard delegate.
+  // Given a Fungible asset with the identity as the freeze authority of the mint.
   const umi = await createUmi();
+  const freezeAuthority = umi.identity;
   const owner = umi.identity.publicKey;
-  const standardDelegate = generateSigner(umi);
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenStandard: TokenStandard.Fungible,
   });
-  await delegateStandardV1(umi, {
-    mint,
-    delegate: standardDelegate.publicKey,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
   t.like(await fetchDigitalAssetWithAssociatedToken(umi, mint, owner), <
     DigitalAssetWithToken
   >{ token: { state: SplTokenState.Initialized }, tokenRecord: undefined });
 
-  // When the standard delegate locks the asset.
+  // When the freeze authority locks the asset.
   await lockV1(umi, {
     mint,
-    authority: standardDelegate,
+    authority: freezeAuthority,
     tokenStandard: TokenStandard.Fungible,
   }).sendAndConfirm(umi);
 
@@ -101,26 +96,21 @@ test('it can freeze a Fungible', async (t) => {
 });
 
 test('it can freeze a FungibleAsset', async (t) => {
-  // Given a FungibleAsset with a standard delegate.
+  // Given a FungibleAsset asset with the identity as the freeze authority of the mint.
   const umi = await createUmi();
+  const freezeAuthority = umi.identity;
   const owner = umi.identity.publicKey;
-  const standardDelegate = generateSigner(umi);
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenStandard: TokenStandard.FungibleAsset,
   });
-  await delegateStandardV1(umi, {
-    mint,
-    delegate: standardDelegate.publicKey,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
   t.like(await fetchDigitalAssetWithAssociatedToken(umi, mint, owner), <
     DigitalAssetWithToken
   >{ token: { state: SplTokenState.Initialized }, tokenRecord: undefined });
 
-  // When the standard delegate locks the asset.
+  // When the freeze authority locks the asset.
   await lockV1(umi, {
     mint,
-    authority: standardDelegate,
+    authority: freezeAuthority,
     tokenStandard: TokenStandard.FungibleAsset,
   }).sendAndConfirm(umi);
 

--- a/clients/js/test/revokeCollectionV1.test.ts
+++ b/clients/js/test/revokeCollectionV1.test.ts
@@ -1,0 +1,157 @@
+import { generateSigner } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  MetadataDelegateRole,
+  TokenStandard,
+  delegateCollectionV1,
+  findMetadataDelegateRecordPda,
+  revokeCollectionV1,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can revoke a collection delegate for a NonFungible', async (t) => {
+  // Given a NonFungible with an approved collection delegate.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+  });
+  const collectionDelegate = generateSigner(umi).publicKey;
+  await delegateCollectionV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: collectionDelegate,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
+    mint,
+    delegateRole: MetadataDelegateRole.Collection,
+    delegate: collectionDelegate,
+    updateAuthority: updateAuthority.publicKey,
+  });
+  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
+
+  // When we revoke the collection delegate.
+  await revokeCollectionV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: collectionDelegate,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then the metadata delegate record was deleted.
+  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
+});
+
+test('it can revoke a collection delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible with an approved collection delegate.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  });
+  const collectionDelegate = generateSigner(umi).publicKey;
+  await delegateCollectionV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: collectionDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
+    mint,
+    delegateRole: MetadataDelegateRole.Collection,
+    delegate: collectionDelegate,
+    updateAuthority: updateAuthority.publicKey,
+  });
+  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
+
+  // When we revoke the collection delegate.
+  await revokeCollectionV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: collectionDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then the metadata delegate record was deleted.
+  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
+});
+
+test('it can revoke a collection delegate for a Fungible', async (t) => {
+  // Given a Fungible with an approved collection delegate.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.Fungible,
+  });
+  const collectionDelegate = generateSigner(umi).publicKey;
+  await delegateCollectionV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: collectionDelegate,
+    tokenStandard: TokenStandard.Fungible,
+  }).sendAndConfirm(umi);
+  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
+    mint,
+    delegateRole: MetadataDelegateRole.Collection,
+    delegate: collectionDelegate,
+    updateAuthority: updateAuthority.publicKey,
+  });
+  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
+
+  // When we revoke the collection delegate.
+  await revokeCollectionV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: collectionDelegate,
+    tokenStandard: TokenStandard.Fungible,
+  }).sendAndConfirm(umi);
+
+  // Then the metadata delegate record was deleted.
+  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
+});
+
+test('it can revoke a collection delegate for a FungibleAsset', async (t) => {
+  // Given a FungibleAsset with an approved collection delegate.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.FungibleAsset,
+  });
+  const collectionDelegate = generateSigner(umi).publicKey;
+  await delegateCollectionV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: collectionDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+  }).sendAndConfirm(umi);
+  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
+    mint,
+    delegateRole: MetadataDelegateRole.Collection,
+    delegate: collectionDelegate,
+    updateAuthority: updateAuthority.publicKey,
+  });
+  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
+
+  // When we revoke the collection delegate.
+  await revokeCollectionV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: collectionDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+  }).sendAndConfirm(umi);
+
+  // Then the metadata delegate record was deleted.
+  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
+});

--- a/clients/js/test/revokeCollectionV1.test.ts
+++ b/clients/js/test/revokeCollectionV1.test.ts
@@ -7,151 +7,47 @@ import {
   findMetadataDelegateRecordPda,
   revokeCollectionV1,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
+import {
+  NON_EDITION_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
-test('it can revoke a collection delegate for a NonFungible', async (t) => {
-  // Given a NonFungible with an approved collection delegate.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
+NON_EDITION_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it can revoke a collection delegate for a ${tokenStandard}`, async (t) => {
+    // Given an asset with an approved collection delegate.
+    const umi = await createUmi();
+    const updateAuthority = generateSigner(umi);
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      authority: updateAuthority,
+      tokenStandard: TokenStandard[tokenStandard],
+    });
+    const collectionDelegate = generateSigner(umi).publicKey;
+    await delegateCollectionV1(umi, {
+      mint,
+      updateAuthority: updateAuthority.publicKey,
+      authority: updateAuthority,
+      delegate: collectionDelegate,
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
+    const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
+      mint,
+      delegateRole: MetadataDelegateRole.Collection,
+      delegate: collectionDelegate,
+      updateAuthority: updateAuthority.publicKey,
+    });
+    t.true(await umi.rpc.accountExists(metadataDelegateRecord));
+
+    // When we revoke the collection delegate.
+    await revokeCollectionV1(umi, {
+      mint,
+      updateAuthority: updateAuthority.publicKey,
+      authority: updateAuthority,
+      delegate: collectionDelegate,
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
+
+    // Then the metadata delegate record was deleted.
+    t.false(await umi.rpc.accountExists(metadataDelegateRecord));
   });
-  const collectionDelegate = generateSigner(umi).publicKey;
-  await delegateCollectionV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: collectionDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
-    mint,
-    delegateRole: MetadataDelegateRole.Collection,
-    delegate: collectionDelegate,
-    updateAuthority: updateAuthority.publicKey,
-  });
-  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
-
-  // When we revoke the collection delegate.
-  await revokeCollectionV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: collectionDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then the metadata delegate record was deleted.
-  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
-});
-
-test('it can revoke a collection delegate for a ProgrammableNonFungible', async (t) => {
-  // Given a ProgrammableNonFungible with an approved collection delegate.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-  });
-  const collectionDelegate = generateSigner(umi).publicKey;
-  await delegateCollectionV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: collectionDelegate,
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-  }).sendAndConfirm(umi);
-  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
-    mint,
-    delegateRole: MetadataDelegateRole.Collection,
-    delegate: collectionDelegate,
-    updateAuthority: updateAuthority.publicKey,
-  });
-  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
-
-  // When we revoke the collection delegate.
-  await revokeCollectionV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: collectionDelegate,
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then the metadata delegate record was deleted.
-  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
-});
-
-test('it can revoke a collection delegate for a Fungible', async (t) => {
-  // Given a Fungible with an approved collection delegate.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.Fungible,
-  });
-  const collectionDelegate = generateSigner(umi).publicKey;
-  await delegateCollectionV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: collectionDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
-    mint,
-    delegateRole: MetadataDelegateRole.Collection,
-    delegate: collectionDelegate,
-    updateAuthority: updateAuthority.publicKey,
-  });
-  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
-
-  // When we revoke the collection delegate.
-  await revokeCollectionV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: collectionDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-
-  // Then the metadata delegate record was deleted.
-  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
-});
-
-test('it can revoke a collection delegate for a FungibleAsset', async (t) => {
-  // Given a FungibleAsset with an approved collection delegate.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-  const collectionDelegate = generateSigner(umi).publicKey;
-  await delegateCollectionV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: collectionDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
-    mint,
-    delegateRole: MetadataDelegateRole.Collection,
-    delegate: collectionDelegate,
-    updateAuthority: updateAuthority.publicKey,
-  });
-  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
-
-  // When we revoke the collection delegate.
-  await revokeCollectionV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: collectionDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-
-  // Then the metadata delegate record was deleted.
-  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
 });

--- a/clients/js/test/revokeLockedTransferV1.test.ts
+++ b/clients/js/test/revokeLockedTransferV1.test.ts
@@ -1,0 +1,162 @@
+import {
+  approveTokenDelegate,
+  findAssociatedTokenPda,
+} from '@metaplex-foundation/mpl-essentials';
+import {
+  generateSigner,
+  none,
+  publicKey,
+  some,
+} from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  DigitalAssetWithToken,
+  TokenDelegateRole,
+  TokenStandard,
+  TokenState,
+  delegateLockedTransferV1,
+  fetchDigitalAssetWithAssociatedToken,
+  revokeLockedTransferV1,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can revoke a lockedTransfer delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible with an approved lockedTransfer delegate.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const lockedAddress = generateSigner(umi).publicKey;
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  });
+  await delegateLockedTransferV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: lockedTransferDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+    lockedAddress,
+  }).sendAndConfirm(umi);
+  t.like(
+    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+    <DigitalAssetWithToken>{
+      token: { delegate: some(publicKey(lockedTransferDelegate)) },
+      tokenRecord: {
+        delegate: some(publicKey(lockedTransferDelegate)),
+        delegateRole: some(TokenDelegateRole.LockedTransfer),
+        lockedTransfer: some(lockedAddress),
+        state: TokenState.Unlocked,
+      },
+    }
+  );
+
+  // When we revoke the lockedTransfer delegate.
+  await revokeLockedTransferV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: lockedTransferDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then the token and token record acconts were successfully updated.
+  t.like(
+    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+    <DigitalAssetWithToken>{
+      token: { delegate: none() },
+      tokenRecord: {
+        delegate: none(),
+        delegateRole: none(),
+        lockedTransfer: none(),
+        state: TokenState.Unlocked,
+      },
+    }
+  );
+});
+
+test('it cannot revoke a lockedTransfer delegate for a NonFungible', async (t) => {
+  // Given a NonFungible with an SPL delegate.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+  });
+  await approveTokenDelegate(umi, {
+    source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
+    delegate: lockedTransferDelegate,
+    owner,
+    amount: 1,
+  }).sendAndConfirm(umi);
+
+  // When we try to revoke the lockedTransfer delegate.
+  const promise = revokeLockedTransferV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: lockedTransferDelegate,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});
+
+test('it cannot revoke a lockedTransfer delegate for a Fungible', async (t) => {
+  // Given a Fungible with an SPL delegate.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.Fungible,
+  });
+  await approveTokenDelegate(umi, {
+    source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
+    delegate: lockedTransferDelegate,
+    owner,
+    amount: 1,
+  }).sendAndConfirm(umi);
+
+  // When we try to revoke the lockedTransfer delegate.
+  const promise = revokeLockedTransferV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: lockedTransferDelegate,
+    tokenStandard: TokenStandard.Fungible,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});
+
+test('it cannot revoke a lockedTransfer delegate for a FungibleAsset', async (t) => {
+  // Given a FungibleAsset with an SPL delegate.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.FungibleAsset,
+  });
+  await approveTokenDelegate(umi, {
+    source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
+    delegate: lockedTransferDelegate,
+    owner,
+    amount: 1,
+  }).sendAndConfirm(umi);
+
+  // When we try to revoke the lockedTransfer delegate.
+  const promise = revokeLockedTransferV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: lockedTransferDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});

--- a/clients/js/test/revokeProgrammableConfigV1.test.ts
+++ b/clients/js/test/revokeProgrammableConfigV1.test.ts
@@ -1,0 +1,157 @@
+import { generateSigner } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  MetadataDelegateRole,
+  TokenStandard,
+  delegateProgrammableConfigV1,
+  findMetadataDelegateRecordPda,
+  revokeProgrammableConfigV1,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can revoke a programmable config delegate for a NonFungible', async (t) => {
+  // Given a NonFungible with an approved programmable config delegate.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+  });
+  const programmableConfigDelegate = generateSigner(umi).publicKey;
+  await delegateProgrammableConfigV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: programmableConfigDelegate,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
+    mint,
+    delegateRole: MetadataDelegateRole.ProgrammableConfig,
+    delegate: programmableConfigDelegate,
+    updateAuthority: updateAuthority.publicKey,
+  });
+  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
+
+  // When we revoke the programmable config delegate.
+  await revokeProgrammableConfigV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: programmableConfigDelegate,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then the metadata delegate record was deleted.
+  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
+});
+
+test('it can revoke a programmable config delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible with an approved programmable config delegate.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  });
+  const programmableConfigDelegate = generateSigner(umi).publicKey;
+  await delegateProgrammableConfigV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: programmableConfigDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
+    mint,
+    delegateRole: MetadataDelegateRole.ProgrammableConfig,
+    delegate: programmableConfigDelegate,
+    updateAuthority: updateAuthority.publicKey,
+  });
+  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
+
+  // When we revoke the programmable config delegate.
+  await revokeProgrammableConfigV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: programmableConfigDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then the metadata delegate record was deleted.
+  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
+});
+
+test('it can revoke a programmable config delegate for a Fungible', async (t) => {
+  // Given a Fungible with an approved programmable config delegate.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.Fungible,
+  });
+  const programmableConfigDelegate = generateSigner(umi).publicKey;
+  await delegateProgrammableConfigV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: programmableConfigDelegate,
+    tokenStandard: TokenStandard.Fungible,
+  }).sendAndConfirm(umi);
+  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
+    mint,
+    delegateRole: MetadataDelegateRole.ProgrammableConfig,
+    delegate: programmableConfigDelegate,
+    updateAuthority: updateAuthority.publicKey,
+  });
+  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
+
+  // When we revoke the programmable config delegate.
+  await revokeProgrammableConfigV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: programmableConfigDelegate,
+    tokenStandard: TokenStandard.Fungible,
+  }).sendAndConfirm(umi);
+
+  // Then the metadata delegate record was deleted.
+  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
+});
+
+test('it can revoke a programmable config delegate for a FungibleAsset', async (t) => {
+  // Given a FungibleAsset with an approved programmable config delegate.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.FungibleAsset,
+  });
+  const programmableConfigDelegate = generateSigner(umi).publicKey;
+  await delegateProgrammableConfigV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: programmableConfigDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+  }).sendAndConfirm(umi);
+  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
+    mint,
+    delegateRole: MetadataDelegateRole.ProgrammableConfig,
+    delegate: programmableConfigDelegate,
+    updateAuthority: updateAuthority.publicKey,
+  });
+  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
+
+  // When we revoke the programmable config delegate.
+  await revokeProgrammableConfigV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: programmableConfigDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+  }).sendAndConfirm(umi);
+
+  // Then the metadata delegate record was deleted.
+  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
+});

--- a/clients/js/test/revokeProgrammableConfigV1.test.ts
+++ b/clients/js/test/revokeProgrammableConfigV1.test.ts
@@ -7,151 +7,47 @@ import {
   findMetadataDelegateRecordPda,
   revokeProgrammableConfigV1,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
+import {
+  NON_EDITION_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
-test('it can revoke a programmable config delegate for a NonFungible', async (t) => {
-  // Given a NonFungible with an approved programmable config delegate.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
+NON_EDITION_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it can revoke a programmable config delegate for a ${tokenStandard}`, async (t) => {
+    // Given an asset with an approved programmable config delegate.
+    const umi = await createUmi();
+    const updateAuthority = generateSigner(umi);
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      authority: updateAuthority,
+      tokenStandard: TokenStandard[tokenStandard],
+    });
+    const programmableConfigDelegate = generateSigner(umi).publicKey;
+    await delegateProgrammableConfigV1(umi, {
+      mint,
+      updateAuthority: updateAuthority.publicKey,
+      authority: updateAuthority,
+      delegate: programmableConfigDelegate,
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
+    const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
+      mint,
+      delegateRole: MetadataDelegateRole.ProgrammableConfig,
+      delegate: programmableConfigDelegate,
+      updateAuthority: updateAuthority.publicKey,
+    });
+    t.true(await umi.rpc.accountExists(metadataDelegateRecord));
+
+    // When we revoke the programmable config delegate.
+    await revokeProgrammableConfigV1(umi, {
+      mint,
+      updateAuthority: updateAuthority.publicKey,
+      authority: updateAuthority,
+      delegate: programmableConfigDelegate,
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
+
+    // Then the metadata delegate record was deleted.
+    t.false(await umi.rpc.accountExists(metadataDelegateRecord));
   });
-  const programmableConfigDelegate = generateSigner(umi).publicKey;
-  await delegateProgrammableConfigV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: programmableConfigDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
-    mint,
-    delegateRole: MetadataDelegateRole.ProgrammableConfig,
-    delegate: programmableConfigDelegate,
-    updateAuthority: updateAuthority.publicKey,
-  });
-  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
-
-  // When we revoke the programmable config delegate.
-  await revokeProgrammableConfigV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: programmableConfigDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then the metadata delegate record was deleted.
-  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
-});
-
-test('it can revoke a programmable config delegate for a ProgrammableNonFungible', async (t) => {
-  // Given a ProgrammableNonFungible with an approved programmable config delegate.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-  });
-  const programmableConfigDelegate = generateSigner(umi).publicKey;
-  await delegateProgrammableConfigV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: programmableConfigDelegate,
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-  }).sendAndConfirm(umi);
-  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
-    mint,
-    delegateRole: MetadataDelegateRole.ProgrammableConfig,
-    delegate: programmableConfigDelegate,
-    updateAuthority: updateAuthority.publicKey,
-  });
-  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
-
-  // When we revoke the programmable config delegate.
-  await revokeProgrammableConfigV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: programmableConfigDelegate,
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then the metadata delegate record was deleted.
-  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
-});
-
-test('it can revoke a programmable config delegate for a Fungible', async (t) => {
-  // Given a Fungible with an approved programmable config delegate.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.Fungible,
-  });
-  const programmableConfigDelegate = generateSigner(umi).publicKey;
-  await delegateProgrammableConfigV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: programmableConfigDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
-    mint,
-    delegateRole: MetadataDelegateRole.ProgrammableConfig,
-    delegate: programmableConfigDelegate,
-    updateAuthority: updateAuthority.publicKey,
-  });
-  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
-
-  // When we revoke the programmable config delegate.
-  await revokeProgrammableConfigV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: programmableConfigDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-
-  // Then the metadata delegate record was deleted.
-  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
-});
-
-test('it can revoke a programmable config delegate for a FungibleAsset', async (t) => {
-  // Given a FungibleAsset with an approved programmable config delegate.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-  const programmableConfigDelegate = generateSigner(umi).publicKey;
-  await delegateProgrammableConfigV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: programmableConfigDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
-    mint,
-    delegateRole: MetadataDelegateRole.ProgrammableConfig,
-    delegate: programmableConfigDelegate,
-    updateAuthority: updateAuthority.publicKey,
-  });
-  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
-
-  // When we revoke the programmable config delegate.
-  await revokeProgrammableConfigV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: programmableConfigDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-
-  // Then the metadata delegate record was deleted.
-  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
 });

--- a/clients/js/test/revokeSaleV1.test.ts
+++ b/clients/js/test/revokeSaleV1.test.ts
@@ -14,49 +14,46 @@ import {
   TokenDelegateRole,
   TokenStandard,
   TokenState,
-  delegateLockedTransferV1,
+  delegateSaleV1,
   fetchDigitalAssetWithAssociatedToken,
-  revokeLockedTransferV1,
+  revokeSaleV1,
 } from '../src';
 import { createDigitalAssetWithToken, createUmi } from './_setup';
 
-test('it can revoke a locked transfer delegate for a ProgrammableNonFungible', async (t) => {
-  // Given a ProgrammableNonFungible with an approved locked transfer delegate.
+test('it can revoke a sale delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible with an approved sale delegate.
   const umi = await createUmi();
   const owner = generateSigner(umi);
-  const lockedTransferDelegate = generateSigner(umi).publicKey;
-  const lockedAddress = generateSigner(umi).publicKey;
+  const saleDelegate = generateSigner(umi).publicKey;
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
     tokenStandard: TokenStandard.ProgrammableNonFungible,
   });
-  await delegateLockedTransferV1(umi, {
+  await delegateSaleV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: saleDelegate,
     tokenStandard: TokenStandard.ProgrammableNonFungible,
-    lockedAddress,
   }).sendAndConfirm(umi);
   t.like(
     await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
     <DigitalAssetWithToken>{
-      token: { delegate: some(publicKey(lockedTransferDelegate)) },
+      token: { delegate: some(publicKey(saleDelegate)) },
       tokenRecord: {
-        delegate: some(publicKey(lockedTransferDelegate)),
-        delegateRole: some(TokenDelegateRole.LockedTransfer),
-        lockedTransfer: some(lockedAddress),
-        state: TokenState.Unlocked,
+        delegate: some(publicKey(saleDelegate)),
+        delegateRole: some(TokenDelegateRole.Sale),
+        state: TokenState.Listed,
       },
     }
   );
 
-  // When we revoke the locked transfer delegate.
-  await revokeLockedTransferV1(umi, {
+  // When we revoke the sale delegate.
+  await revokeSaleV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: saleDelegate,
     tokenStandard: TokenStandard.ProgrammableNonFungible,
   }).sendAndConfirm(umi);
 
@@ -68,34 +65,33 @@ test('it can revoke a locked transfer delegate for a ProgrammableNonFungible', a
       tokenRecord: {
         delegate: none(),
         delegateRole: none(),
-        lockedTransfer: none(),
         state: TokenState.Unlocked,
       },
     }
   );
 });
 
-test('it cannot revoke a locked transfer delegate for a NonFungible', async (t) => {
+test('it cannot revoke a sale delegate for a NonFungible', async (t) => {
   // Given a NonFungible with an SPL delegate.
   const umi = await createUmi();
   const owner = generateSigner(umi);
-  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const saleDelegate = generateSigner(umi).publicKey;
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
   });
   await approveTokenDelegate(umi, {
     source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: lockedTransferDelegate,
+    delegate: saleDelegate,
     owner,
     amount: 1,
   }).sendAndConfirm(umi);
 
-  // When we try to revoke the locked transfer delegate.
-  const promise = revokeLockedTransferV1(umi, {
+  // When we try to revoke the sale delegate.
+  const promise = revokeSaleV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: saleDelegate,
     tokenStandard: TokenStandard.NonFungible,
   }).sendAndConfirm(umi);
 
@@ -103,28 +99,28 @@ test('it cannot revoke a locked transfer delegate for a NonFungible', async (t) 
   await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });
 
-test('it cannot revoke a locked transfer delegate for a Fungible', async (t) => {
+test('it cannot revoke a sale delegate for a Fungible', async (t) => {
   // Given a Fungible with an SPL delegate.
   const umi = await createUmi();
   const owner = generateSigner(umi);
-  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const saleDelegate = generateSigner(umi).publicKey;
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
     tokenStandard: TokenStandard.Fungible,
   });
   await approveTokenDelegate(umi, {
     source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: lockedTransferDelegate,
+    delegate: saleDelegate,
     owner,
     amount: 1,
   }).sendAndConfirm(umi);
 
-  // When we try to revoke the locked transfer delegate.
-  const promise = revokeLockedTransferV1(umi, {
+  // When we try to revoke the sale delegate.
+  const promise = revokeSaleV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: saleDelegate,
     tokenStandard: TokenStandard.Fungible,
   }).sendAndConfirm(umi);
 
@@ -132,28 +128,28 @@ test('it cannot revoke a locked transfer delegate for a Fungible', async (t) => 
   await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });
 
-test('it cannot revoke a locked transfer delegate for a FungibleAsset', async (t) => {
+test('it cannot revoke a sale delegate for a FungibleAsset', async (t) => {
   // Given a FungibleAsset with an SPL delegate.
   const umi = await createUmi();
   const owner = generateSigner(umi);
-  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const saleDelegate = generateSigner(umi).publicKey;
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
     tokenStandard: TokenStandard.FungibleAsset,
   });
   await approveTokenDelegate(umi, {
     source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: lockedTransferDelegate,
+    delegate: saleDelegate,
     owner,
     amount: 1,
   }).sendAndConfirm(umi);
 
-  // When we try to revoke the locked transfer delegate.
-  const promise = revokeLockedTransferV1(umi, {
+  // When we try to revoke the sale delegate.
+  const promise = revokeSaleV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: saleDelegate,
     tokenStandard: TokenStandard.FungibleAsset,
   }).sendAndConfirm(umi);
 

--- a/clients/js/test/revokeSaleV1.test.ts
+++ b/clients/js/test/revokeSaleV1.test.ts
@@ -18,7 +18,11 @@ import {
   fetchDigitalAssetWithAssociatedToken,
   revokeSaleV1,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
+import {
+  OG_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
 test('it can revoke a sale delegate for a ProgrammableNonFungible', async (t) => {
   // Given a ProgrammableNonFungible with an approved sale delegate.
@@ -71,88 +75,33 @@ test('it can revoke a sale delegate for a ProgrammableNonFungible', async (t) =>
   );
 });
 
-test('it cannot revoke a sale delegate for a NonFungible', async (t) => {
-  // Given a NonFungible with an SPL delegate.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const saleDelegate = generateSigner(umi).publicKey;
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
+OG_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it cannot revoke a sale delegate for a ${tokenStandard}`, async (t) => {
+    // Given an asset with an SPL delegate.
+    const umi = await createUmi();
+    const owner = generateSigner(umi);
+    const saleDelegate = generateSigner(umi).publicKey;
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      tokenOwner: owner.publicKey,
+      tokenStandard: TokenStandard[tokenStandard],
+    });
+    await approveTokenDelegate(umi, {
+      source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
+      delegate: saleDelegate,
+      owner,
+      amount: 1,
+    }).sendAndConfirm(umi);
+
+    // When we try to revoke it as the sale delegate.
+    const promise = revokeSaleV1(umi, {
+      mint,
+      tokenOwner: owner.publicKey,
+      authority: owner,
+      delegate: saleDelegate,
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
+
+    // Then we expect a program error.
+    await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
   });
-  await approveTokenDelegate(umi, {
-    source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: saleDelegate,
-    owner,
-    amount: 1,
-  }).sendAndConfirm(umi);
-
-  // When we try to revoke the sale delegate.
-  const promise = revokeSaleV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: saleDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
-});
-
-test('it cannot revoke a sale delegate for a Fungible', async (t) => {
-  // Given a Fungible with an SPL delegate.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const saleDelegate = generateSigner(umi).publicKey;
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.Fungible,
-  });
-  await approveTokenDelegate(umi, {
-    source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: saleDelegate,
-    owner,
-    amount: 1,
-  }).sendAndConfirm(umi);
-
-  // When we try to revoke the sale delegate.
-  const promise = revokeSaleV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: saleDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
-});
-
-test('it cannot revoke a sale delegate for a FungibleAsset', async (t) => {
-  // Given a FungibleAsset with an SPL delegate.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const saleDelegate = generateSigner(umi).publicKey;
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-  await approveTokenDelegate(umi, {
-    source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: saleDelegate,
-    owner,
-    amount: 1,
-  }).sendAndConfirm(umi);
-
-  // When we try to revoke the sale delegate.
-  const promise = revokeSaleV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: saleDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });

--- a/clients/js/test/revokeStakingV1.test.ts
+++ b/clients/js/test/revokeStakingV1.test.ts
@@ -18,7 +18,11 @@ import {
   fetchDigitalAssetWithAssociatedToken,
   revokeStakingV1,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
+import {
+  OG_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
 test('it can revoke a staking delegate for a ProgrammableNonFungible', async (t) => {
   // Given a ProgrammableNonFungible with an approved staking delegate.
@@ -71,88 +75,33 @@ test('it can revoke a staking delegate for a ProgrammableNonFungible', async (t)
   );
 });
 
-test('it cannot revoke a staking delegate for a NonFungible', async (t) => {
-  // Given a NonFungible with an SPL delegate.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const stakingDelegate = generateSigner(umi).publicKey;
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
+OG_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it cannot revoke a staking delegate for a ${tokenStandard}`, async (t) => {
+    // Given an asset with an SPL delegate.
+    const umi = await createUmi();
+    const owner = generateSigner(umi);
+    const stakingDelegate = generateSigner(umi).publicKey;
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      tokenOwner: owner.publicKey,
+      tokenStandard: TokenStandard[tokenStandard],
+    });
+    await approveTokenDelegate(umi, {
+      source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
+      delegate: stakingDelegate,
+      owner,
+      amount: 1,
+    }).sendAndConfirm(umi);
+
+    // When we try to revoke it as the staking delegate.
+    const promise = revokeStakingV1(umi, {
+      mint,
+      tokenOwner: owner.publicKey,
+      authority: owner,
+      delegate: stakingDelegate,
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
+
+    // Then we expect a program error.
+    await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
   });
-  await approveTokenDelegate(umi, {
-    source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: stakingDelegate,
-    owner,
-    amount: 1,
-  }).sendAndConfirm(umi);
-
-  // When we try to revoke the staking delegate.
-  const promise = revokeStakingV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: stakingDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
-});
-
-test('it cannot revoke a staking delegate for a Fungible', async (t) => {
-  // Given a Fungible with an SPL delegate.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const stakingDelegate = generateSigner(umi).publicKey;
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.Fungible,
-  });
-  await approveTokenDelegate(umi, {
-    source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: stakingDelegate,
-    owner,
-    amount: 1,
-  }).sendAndConfirm(umi);
-
-  // When we try to revoke the staking delegate.
-  const promise = revokeStakingV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: stakingDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
-});
-
-test('it cannot revoke a staking delegate for a FungibleAsset', async (t) => {
-  // Given a FungibleAsset with an SPL delegate.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const stakingDelegate = generateSigner(umi).publicKey;
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-  await approveTokenDelegate(umi, {
-    source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: stakingDelegate,
-    owner,
-    amount: 1,
-  }).sendAndConfirm(umi);
-
-  // When we try to revoke the staking delegate.
-  const promise = revokeStakingV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: stakingDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });

--- a/clients/js/test/revokeStakingV1.test.ts
+++ b/clients/js/test/revokeStakingV1.test.ts
@@ -14,49 +14,46 @@ import {
   TokenDelegateRole,
   TokenStandard,
   TokenState,
-  delegateLockedTransferV1,
+  delegateStakingV1,
   fetchDigitalAssetWithAssociatedToken,
-  revokeLockedTransferV1,
+  revokeStakingV1,
 } from '../src';
 import { createDigitalAssetWithToken, createUmi } from './_setup';
 
-test('it can revoke a locked transfer delegate for a ProgrammableNonFungible', async (t) => {
-  // Given a ProgrammableNonFungible with an approved locked transfer delegate.
+test('it can revoke a staking delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible with an approved staking delegate.
   const umi = await createUmi();
   const owner = generateSigner(umi);
-  const lockedTransferDelegate = generateSigner(umi).publicKey;
-  const lockedAddress = generateSigner(umi).publicKey;
+  const stakingDelegate = generateSigner(umi).publicKey;
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
     tokenStandard: TokenStandard.ProgrammableNonFungible,
   });
-  await delegateLockedTransferV1(umi, {
+  await delegateStakingV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: stakingDelegate,
     tokenStandard: TokenStandard.ProgrammableNonFungible,
-    lockedAddress,
   }).sendAndConfirm(umi);
   t.like(
     await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
     <DigitalAssetWithToken>{
-      token: { delegate: some(publicKey(lockedTransferDelegate)) },
+      token: { delegate: some(publicKey(stakingDelegate)) },
       tokenRecord: {
-        delegate: some(publicKey(lockedTransferDelegate)),
-        delegateRole: some(TokenDelegateRole.LockedTransfer),
-        lockedTransfer: some(lockedAddress),
+        delegate: some(publicKey(stakingDelegate)),
+        delegateRole: some(TokenDelegateRole.Staking),
         state: TokenState.Unlocked,
       },
     }
   );
 
-  // When we revoke the locked transfer delegate.
-  await revokeLockedTransferV1(umi, {
+  // When we revoke the staking delegate.
+  await revokeStakingV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: stakingDelegate,
     tokenStandard: TokenStandard.ProgrammableNonFungible,
   }).sendAndConfirm(umi);
 
@@ -68,34 +65,33 @@ test('it can revoke a locked transfer delegate for a ProgrammableNonFungible', a
       tokenRecord: {
         delegate: none(),
         delegateRole: none(),
-        lockedTransfer: none(),
         state: TokenState.Unlocked,
       },
     }
   );
 });
 
-test('it cannot revoke a locked transfer delegate for a NonFungible', async (t) => {
+test('it cannot revoke a staking delegate for a NonFungible', async (t) => {
   // Given a NonFungible with an SPL delegate.
   const umi = await createUmi();
   const owner = generateSigner(umi);
-  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const stakingDelegate = generateSigner(umi).publicKey;
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
   });
   await approveTokenDelegate(umi, {
     source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: lockedTransferDelegate,
+    delegate: stakingDelegate,
     owner,
     amount: 1,
   }).sendAndConfirm(umi);
 
-  // When we try to revoke the locked transfer delegate.
-  const promise = revokeLockedTransferV1(umi, {
+  // When we try to revoke the staking delegate.
+  const promise = revokeStakingV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: stakingDelegate,
     tokenStandard: TokenStandard.NonFungible,
   }).sendAndConfirm(umi);
 
@@ -103,28 +99,28 @@ test('it cannot revoke a locked transfer delegate for a NonFungible', async (t) 
   await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });
 
-test('it cannot revoke a locked transfer delegate for a Fungible', async (t) => {
+test('it cannot revoke a staking delegate for a Fungible', async (t) => {
   // Given a Fungible with an SPL delegate.
   const umi = await createUmi();
   const owner = generateSigner(umi);
-  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const stakingDelegate = generateSigner(umi).publicKey;
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
     tokenStandard: TokenStandard.Fungible,
   });
   await approveTokenDelegate(umi, {
     source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: lockedTransferDelegate,
+    delegate: stakingDelegate,
     owner,
     amount: 1,
   }).sendAndConfirm(umi);
 
-  // When we try to revoke the locked transfer delegate.
-  const promise = revokeLockedTransferV1(umi, {
+  // When we try to revoke the staking delegate.
+  const promise = revokeStakingV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: stakingDelegate,
     tokenStandard: TokenStandard.Fungible,
   }).sendAndConfirm(umi);
 
@@ -132,28 +128,28 @@ test('it cannot revoke a locked transfer delegate for a Fungible', async (t) => 
   await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });
 
-test('it cannot revoke a locked transfer delegate for a FungibleAsset', async (t) => {
+test('it cannot revoke a staking delegate for a FungibleAsset', async (t) => {
   // Given a FungibleAsset with an SPL delegate.
   const umi = await createUmi();
   const owner = generateSigner(umi);
-  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const stakingDelegate = generateSigner(umi).publicKey;
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
     tokenStandard: TokenStandard.FungibleAsset,
   });
   await approveTokenDelegate(umi, {
     source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: lockedTransferDelegate,
+    delegate: stakingDelegate,
     owner,
     amount: 1,
   }).sendAndConfirm(umi);
 
-  // When we try to revoke the locked transfer delegate.
-  const promise = revokeLockedTransferV1(umi, {
+  // When we try to revoke the staking delegate.
+  const promise = revokeStakingV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: stakingDelegate,
     tokenStandard: TokenStandard.FungibleAsset,
   }).sendAndConfirm(umi);
 

--- a/clients/js/test/revokeStandardV1.test.ts
+++ b/clients/js/test/revokeStandardV1.test.ts
@@ -8,49 +8,11 @@ import {
   fetchDigitalAssetWithAssociatedToken,
   revokeStandardV1,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
-
-test('it can revoke a standard delegate for a NonFungible', async (t) => {
-  // Given a NonFungible with a standard delegate.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const standardDelegate = generateSigner(umi).publicKey;
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-  });
-  await delegateStandardV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: standardDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-  t.like(
-    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
-    <DigitalAssetWithToken>{
-      token: { delegate: some(standardDelegate), delegatedAmount: 1n },
-      tokenRecord: undefined,
-    }
-  );
-
-  // When we revoke the standard delegate.
-  await revokeStandardV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: standardDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then the token account was successfully updated.
-  t.like(
-    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
-    <DigitalAssetWithToken>{
-      token: { delegate: none(), delegatedAmount: 0n },
-      tokenRecord: undefined,
-    }
-  );
-});
+import {
+  OG_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
 test('it cannot revoke a standard delegate for a ProgrammableNonFungible', async (t) => {
   // Given a ProgrammableNonFungible with any token delegate.
@@ -82,88 +44,47 @@ test('it cannot revoke a standard delegate for a ProgrammableNonFungible', async
   await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });
 
-test('it can revoke a standard delegate for a Fungible', async (t) => {
-  // Given a Fungible with a standard delegate.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const standardDelegate = generateSigner(umi).publicKey;
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.Fungible,
+OG_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it can revoke a standard delegate for a ${tokenStandard}`, async (t) => {
+    // Given an asset with a standard delegate.
+    const umi = await createUmi();
+    const owner = generateSigner(umi);
+    const standardDelegate = generateSigner(umi).publicKey;
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      tokenOwner: owner.publicKey,
+      tokenStandard: TokenStandard[tokenStandard],
+    });
+    await delegateStandardV1(umi, {
+      mint,
+      tokenOwner: owner.publicKey,
+      authority: owner,
+      delegate: standardDelegate,
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
+    t.like(
+      await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+      <DigitalAssetWithToken>{
+        token: { delegate: some(standardDelegate), delegatedAmount: 1n },
+        tokenRecord: undefined,
+      }
+    );
+
+    // When we revoke the standard delegate.
+    await revokeStandardV1(umi, {
+      mint,
+      tokenOwner: owner.publicKey,
+      authority: owner,
+      delegate: standardDelegate,
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
+
+    // Then the token account was successfully updated.
+    t.like(
+      await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+      <DigitalAssetWithToken>{
+        token: { delegate: none(), delegatedAmount: 0n },
+        tokenRecord: undefined,
+      }
+    );
   });
-  await delegateStandardV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: standardDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-  t.like(
-    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
-    <DigitalAssetWithToken>{
-      token: { delegate: some(standardDelegate), delegatedAmount: 1n },
-      tokenRecord: undefined,
-    }
-  );
-
-  // When we revoke the standard delegate.
-  await revokeStandardV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: standardDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-
-  // Then the token account was successfully updated.
-  t.like(
-    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
-    <DigitalAssetWithToken>{
-      token: { delegate: none(), delegatedAmount: 0n },
-      tokenRecord: undefined,
-    }
-  );
-});
-
-test('it can revoke a standard delegate for a FungibleAsset', async (t) => {
-  // Given a FungibleAsset with a standard delegate.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const standardDelegate = generateSigner(umi).publicKey;
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-  await delegateStandardV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: standardDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-  t.like(
-    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
-    <DigitalAssetWithToken>{
-      token: { delegate: some(standardDelegate), delegatedAmount: 1n },
-      tokenRecord: undefined,
-    }
-  );
-
-  // When we revoke the standard delegate.
-  await revokeStandardV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: standardDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-
-  // Then the token account was successfully updated.
-  t.like(
-    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
-    <DigitalAssetWithToken>{
-      token: { delegate: none(), delegatedAmount: 0n },
-      tokenRecord: undefined,
-    }
-  );
 });

--- a/clients/js/test/revokeStandardV1.test.ts
+++ b/clients/js/test/revokeStandardV1.test.ts
@@ -1,0 +1,169 @@
+import { generateSigner, none, some } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  DigitalAssetWithToken,
+  TokenStandard,
+  delegateStandardV1,
+  delegateUtilityV1,
+  fetchDigitalAssetWithAssociatedToken,
+  revokeStandardV1,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can revoke a standard delegate for a NonFungible', async (t) => {
+  // Given a NonFungible with a standard delegate.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const standardDelegate = generateSigner(umi).publicKey;
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+  });
+  await delegateStandardV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: standardDelegate,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+  t.like(
+    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+    <DigitalAssetWithToken>{
+      token: { delegate: some(standardDelegate), delegatedAmount: 1n },
+      tokenRecord: undefined,
+    }
+  );
+
+  // When we revoke the standard delegate.
+  await revokeStandardV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: standardDelegate,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then the token account was successfully updated.
+  t.like(
+    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+    <DigitalAssetWithToken>{
+      token: { delegate: none(), delegatedAmount: 0n },
+      tokenRecord: undefined,
+    }
+  );
+});
+
+test('it cannot revoke a standard delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible with any token delegate.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const utilityDelegate = generateSigner(umi).publicKey;
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  });
+  await delegateUtilityV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: utilityDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+
+  // When we try to revoke the delegate using a standard revoke.
+  const promise = revokeStandardV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: utilityDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
+});
+
+test('it can revoke a standard delegate for a Fungible', async (t) => {
+  // Given a Fungible with a standard delegate.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const standardDelegate = generateSigner(umi).publicKey;
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.Fungible,
+  });
+  await delegateStandardV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: standardDelegate,
+    tokenStandard: TokenStandard.Fungible,
+  }).sendAndConfirm(umi);
+  t.like(
+    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+    <DigitalAssetWithToken>{
+      token: { delegate: some(standardDelegate), delegatedAmount: 1n },
+      tokenRecord: undefined,
+    }
+  );
+
+  // When we revoke the standard delegate.
+  await revokeStandardV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: standardDelegate,
+    tokenStandard: TokenStandard.Fungible,
+  }).sendAndConfirm(umi);
+
+  // Then the token account was successfully updated.
+  t.like(
+    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+    <DigitalAssetWithToken>{
+      token: { delegate: none(), delegatedAmount: 0n },
+      tokenRecord: undefined,
+    }
+  );
+});
+
+test('it can revoke a standard delegate for a FungibleAsset', async (t) => {
+  // Given a FungibleAsset with a standard delegate.
+  const umi = await createUmi();
+  const owner = generateSigner(umi);
+  const standardDelegate = generateSigner(umi).publicKey;
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: owner.publicKey,
+    tokenStandard: TokenStandard.FungibleAsset,
+  });
+  await delegateStandardV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: standardDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+  }).sendAndConfirm(umi);
+  t.like(
+    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+    <DigitalAssetWithToken>{
+      token: { delegate: some(standardDelegate), delegatedAmount: 1n },
+      tokenRecord: undefined,
+    }
+  );
+
+  // When we revoke the standard delegate.
+  await revokeStandardV1(umi, {
+    mint,
+    tokenOwner: owner.publicKey,
+    authority: owner,
+    delegate: standardDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+  }).sendAndConfirm(umi);
+
+  // Then the token account was successfully updated.
+  t.like(
+    await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
+    <DigitalAssetWithToken>{
+      token: { delegate: none(), delegatedAmount: 0n },
+      tokenRecord: undefined,
+    }
+  );
+});

--- a/clients/js/test/revokeTransferV1.test.ts
+++ b/clients/js/test/revokeTransferV1.test.ts
@@ -14,49 +14,46 @@ import {
   TokenDelegateRole,
   TokenStandard,
   TokenState,
-  delegateLockedTransferV1,
+  delegateTransferV1,
   fetchDigitalAssetWithAssociatedToken,
-  revokeLockedTransferV1,
+  revokeTransferV1,
 } from '../src';
 import { createDigitalAssetWithToken, createUmi } from './_setup';
 
-test('it can revoke a locked transfer delegate for a ProgrammableNonFungible', async (t) => {
-  // Given a ProgrammableNonFungible with an approved locked transfer delegate.
+test('it can revoke a transfer delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible with an approved transfer delegate.
   const umi = await createUmi();
   const owner = generateSigner(umi);
-  const lockedTransferDelegate = generateSigner(umi).publicKey;
-  const lockedAddress = generateSigner(umi).publicKey;
+  const transferDelegate = generateSigner(umi).publicKey;
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
     tokenStandard: TokenStandard.ProgrammableNonFungible,
   });
-  await delegateLockedTransferV1(umi, {
+  await delegateTransferV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: transferDelegate,
     tokenStandard: TokenStandard.ProgrammableNonFungible,
-    lockedAddress,
   }).sendAndConfirm(umi);
   t.like(
     await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
     <DigitalAssetWithToken>{
-      token: { delegate: some(publicKey(lockedTransferDelegate)) },
+      token: { delegate: some(publicKey(transferDelegate)) },
       tokenRecord: {
-        delegate: some(publicKey(lockedTransferDelegate)),
-        delegateRole: some(TokenDelegateRole.LockedTransfer),
-        lockedTransfer: some(lockedAddress),
+        delegate: some(publicKey(transferDelegate)),
+        delegateRole: some(TokenDelegateRole.Transfer),
         state: TokenState.Unlocked,
       },
     }
   );
 
-  // When we revoke the locked transfer delegate.
-  await revokeLockedTransferV1(umi, {
+  // When we revoke the transfer delegate.
+  await revokeTransferV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: transferDelegate,
     tokenStandard: TokenStandard.ProgrammableNonFungible,
   }).sendAndConfirm(umi);
 
@@ -68,34 +65,33 @@ test('it can revoke a locked transfer delegate for a ProgrammableNonFungible', a
       tokenRecord: {
         delegate: none(),
         delegateRole: none(),
-        lockedTransfer: none(),
         state: TokenState.Unlocked,
       },
     }
   );
 });
 
-test('it cannot revoke a locked transfer delegate for a NonFungible', async (t) => {
+test('it cannot revoke a transfer delegate for a NonFungible', async (t) => {
   // Given a NonFungible with an SPL delegate.
   const umi = await createUmi();
   const owner = generateSigner(umi);
-  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const transferDelegate = generateSigner(umi).publicKey;
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
   });
   await approveTokenDelegate(umi, {
     source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: lockedTransferDelegate,
+    delegate: transferDelegate,
     owner,
     amount: 1,
   }).sendAndConfirm(umi);
 
-  // When we try to revoke the locked transfer delegate.
-  const promise = revokeLockedTransferV1(umi, {
+  // When we try to revoke the transfer delegate.
+  const promise = revokeTransferV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: transferDelegate,
     tokenStandard: TokenStandard.NonFungible,
   }).sendAndConfirm(umi);
 
@@ -103,28 +99,28 @@ test('it cannot revoke a locked transfer delegate for a NonFungible', async (t) 
   await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });
 
-test('it cannot revoke a locked transfer delegate for a Fungible', async (t) => {
+test('it cannot revoke a transfer delegate for a Fungible', async (t) => {
   // Given a Fungible with an SPL delegate.
   const umi = await createUmi();
   const owner = generateSigner(umi);
-  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const transferDelegate = generateSigner(umi).publicKey;
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
     tokenStandard: TokenStandard.Fungible,
   });
   await approveTokenDelegate(umi, {
     source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: lockedTransferDelegate,
+    delegate: transferDelegate,
     owner,
     amount: 1,
   }).sendAndConfirm(umi);
 
-  // When we try to revoke the locked transfer delegate.
-  const promise = revokeLockedTransferV1(umi, {
+  // When we try to revoke the transfer delegate.
+  const promise = revokeTransferV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: transferDelegate,
     tokenStandard: TokenStandard.Fungible,
   }).sendAndConfirm(umi);
 
@@ -132,28 +128,28 @@ test('it cannot revoke a locked transfer delegate for a Fungible', async (t) => 
   await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });
 
-test('it cannot revoke a locked transfer delegate for a FungibleAsset', async (t) => {
+test('it cannot revoke a transfer delegate for a FungibleAsset', async (t) => {
   // Given a FungibleAsset with an SPL delegate.
   const umi = await createUmi();
   const owner = generateSigner(umi);
-  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const transferDelegate = generateSigner(umi).publicKey;
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
     tokenStandard: TokenStandard.FungibleAsset,
   });
   await approveTokenDelegate(umi, {
     source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: lockedTransferDelegate,
+    delegate: transferDelegate,
     owner,
     amount: 1,
   }).sendAndConfirm(umi);
 
-  // When we try to revoke the locked transfer delegate.
-  const promise = revokeLockedTransferV1(umi, {
+  // When we try to revoke the transfer delegate.
+  const promise = revokeTransferV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: transferDelegate,
     tokenStandard: TokenStandard.FungibleAsset,
   }).sendAndConfirm(umi);
 

--- a/clients/js/test/revokeTransferV1.test.ts
+++ b/clients/js/test/revokeTransferV1.test.ts
@@ -18,7 +18,11 @@ import {
   fetchDigitalAssetWithAssociatedToken,
   revokeTransferV1,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
+import {
+  OG_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
 test('it can revoke a transfer delegate for a ProgrammableNonFungible', async (t) => {
   // Given a ProgrammableNonFungible with an approved transfer delegate.
@@ -71,88 +75,33 @@ test('it can revoke a transfer delegate for a ProgrammableNonFungible', async (t
   );
 });
 
-test('it cannot revoke a transfer delegate for a NonFungible', async (t) => {
-  // Given a NonFungible with an SPL delegate.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const transferDelegate = generateSigner(umi).publicKey;
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
+OG_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it cannot revoke a transfer delegate for a ${tokenStandard}`, async (t) => {
+    // Given an asset with an SPL delegate.
+    const umi = await createUmi();
+    const owner = generateSigner(umi);
+    const transferDelegate = generateSigner(umi).publicKey;
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      tokenOwner: owner.publicKey,
+      tokenStandard: TokenStandard[tokenStandard],
+    });
+    await approveTokenDelegate(umi, {
+      source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
+      delegate: transferDelegate,
+      owner,
+      amount: 1,
+    }).sendAndConfirm(umi);
+
+    // When we try to revoke it as the transfer delegate.
+    const promise = revokeTransferV1(umi, {
+      mint,
+      tokenOwner: owner.publicKey,
+      authority: owner,
+      delegate: transferDelegate,
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
+
+    // Then we expect a program error.
+    await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
   });
-  await approveTokenDelegate(umi, {
-    source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: transferDelegate,
-    owner,
-    amount: 1,
-  }).sendAndConfirm(umi);
-
-  // When we try to revoke the transfer delegate.
-  const promise = revokeTransferV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: transferDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
-});
-
-test('it cannot revoke a transfer delegate for a Fungible', async (t) => {
-  // Given a Fungible with an SPL delegate.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const transferDelegate = generateSigner(umi).publicKey;
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.Fungible,
-  });
-  await approveTokenDelegate(umi, {
-    source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: transferDelegate,
-    owner,
-    amount: 1,
-  }).sendAndConfirm(umi);
-
-  // When we try to revoke the transfer delegate.
-  const promise = revokeTransferV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: transferDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
-});
-
-test('it cannot revoke a transfer delegate for a FungibleAsset', async (t) => {
-  // Given a FungibleAsset with an SPL delegate.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const transferDelegate = generateSigner(umi).publicKey;
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-  await approveTokenDelegate(umi, {
-    source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: transferDelegate,
-    owner,
-    amount: 1,
-  }).sendAndConfirm(umi);
-
-  // When we try to revoke the transfer delegate.
-  const promise = revokeTransferV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: transferDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });

--- a/clients/js/test/revokeUpdateV1.test.ts
+++ b/clients/js/test/revokeUpdateV1.test.ts
@@ -1,0 +1,157 @@
+import { generateSigner } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  MetadataDelegateRole,
+  TokenStandard,
+  delegateUpdateV1,
+  findMetadataDelegateRecordPda,
+  revokeUpdateV1,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can revoke a update delegate for a NonFungible', async (t) => {
+  // Given a NonFungible with an approved update delegate.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+  });
+  const updateDelegate = generateSigner(umi).publicKey;
+  await delegateUpdateV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: updateDelegate,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
+    mint,
+    delegateRole: MetadataDelegateRole.Update,
+    delegate: updateDelegate,
+    updateAuthority: updateAuthority.publicKey,
+  });
+  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
+
+  // When we revoke the update delegate.
+  await revokeUpdateV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: updateDelegate,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then the metadata delegate record was deleted.
+  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
+});
+
+test('it can revoke a update delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible with an approved update delegate.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  });
+  const updateDelegate = generateSigner(umi).publicKey;
+  await delegateUpdateV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: updateDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
+    mint,
+    delegateRole: MetadataDelegateRole.Update,
+    delegate: updateDelegate,
+    updateAuthority: updateAuthority.publicKey,
+  });
+  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
+
+  // When we revoke the update delegate.
+  await revokeUpdateV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: updateDelegate,
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then the metadata delegate record was deleted.
+  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
+});
+
+test('it can revoke a update delegate for a Fungible', async (t) => {
+  // Given a Fungible with an approved update delegate.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.Fungible,
+  });
+  const updateDelegate = generateSigner(umi).publicKey;
+  await delegateUpdateV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: updateDelegate,
+    tokenStandard: TokenStandard.Fungible,
+  }).sendAndConfirm(umi);
+  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
+    mint,
+    delegateRole: MetadataDelegateRole.Update,
+    delegate: updateDelegate,
+    updateAuthority: updateAuthority.publicKey,
+  });
+  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
+
+  // When we revoke the update delegate.
+  await revokeUpdateV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: updateDelegate,
+    tokenStandard: TokenStandard.Fungible,
+  }).sendAndConfirm(umi);
+
+  // Then the metadata delegate record was deleted.
+  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
+});
+
+test('it can revoke a update delegate for a FungibleAsset', async (t) => {
+  // Given a FungibleAsset with an approved update delegate.
+  const umi = await createUmi();
+  const updateAuthority = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    authority: updateAuthority,
+    tokenStandard: TokenStandard.FungibleAsset,
+  });
+  const updateDelegate = generateSigner(umi).publicKey;
+  await delegateUpdateV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: updateDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+  }).sendAndConfirm(umi);
+  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
+    mint,
+    delegateRole: MetadataDelegateRole.Update,
+    delegate: updateDelegate,
+    updateAuthority: updateAuthority.publicKey,
+  });
+  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
+
+  // When we revoke the update delegate.
+  await revokeUpdateV1(umi, {
+    mint,
+    updateAuthority: updateAuthority.publicKey,
+    authority: updateAuthority,
+    delegate: updateDelegate,
+    tokenStandard: TokenStandard.FungibleAsset,
+  }).sendAndConfirm(umi);
+
+  // Then the metadata delegate record was deleted.
+  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
+});

--- a/clients/js/test/revokeUpdateV1.test.ts
+++ b/clients/js/test/revokeUpdateV1.test.ts
@@ -7,151 +7,47 @@ import {
   findMetadataDelegateRecordPda,
   revokeUpdateV1,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
+import {
+  NON_EDITION_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
-test('it can revoke a update delegate for a NonFungible', async (t) => {
-  // Given a NonFungible with an approved update delegate.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
+NON_EDITION_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it can revoke a update delegate for a ${tokenStandard}`, async (t) => {
+    // Given an asset with an approved update delegate.
+    const umi = await createUmi();
+    const updateAuthority = generateSigner(umi);
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      authority: updateAuthority,
+      tokenStandard: TokenStandard[tokenStandard],
+    });
+    const updateDelegate = generateSigner(umi).publicKey;
+    await delegateUpdateV1(umi, {
+      mint,
+      updateAuthority: updateAuthority.publicKey,
+      authority: updateAuthority,
+      delegate: updateDelegate,
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
+    const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
+      mint,
+      delegateRole: MetadataDelegateRole.Update,
+      delegate: updateDelegate,
+      updateAuthority: updateAuthority.publicKey,
+    });
+    t.true(await umi.rpc.accountExists(metadataDelegateRecord));
+
+    // When we revoke the update delegate.
+    await revokeUpdateV1(umi, {
+      mint,
+      updateAuthority: updateAuthority.publicKey,
+      authority: updateAuthority,
+      delegate: updateDelegate,
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
+
+    // Then the metadata delegate record was deleted.
+    t.false(await umi.rpc.accountExists(metadataDelegateRecord));
   });
-  const updateDelegate = generateSigner(umi).publicKey;
-  await delegateUpdateV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: updateDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
-    mint,
-    delegateRole: MetadataDelegateRole.Update,
-    delegate: updateDelegate,
-    updateAuthority: updateAuthority.publicKey,
-  });
-  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
-
-  // When we revoke the update delegate.
-  await revokeUpdateV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: updateDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then the metadata delegate record was deleted.
-  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
-});
-
-test('it can revoke a update delegate for a ProgrammableNonFungible', async (t) => {
-  // Given a ProgrammableNonFungible with an approved update delegate.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-  });
-  const updateDelegate = generateSigner(umi).publicKey;
-  await delegateUpdateV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: updateDelegate,
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-  }).sendAndConfirm(umi);
-  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
-    mint,
-    delegateRole: MetadataDelegateRole.Update,
-    delegate: updateDelegate,
-    updateAuthority: updateAuthority.publicKey,
-  });
-  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
-
-  // When we revoke the update delegate.
-  await revokeUpdateV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: updateDelegate,
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then the metadata delegate record was deleted.
-  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
-});
-
-test('it can revoke a update delegate for a Fungible', async (t) => {
-  // Given a Fungible with an approved update delegate.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.Fungible,
-  });
-  const updateDelegate = generateSigner(umi).publicKey;
-  await delegateUpdateV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: updateDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
-    mint,
-    delegateRole: MetadataDelegateRole.Update,
-    delegate: updateDelegate,
-    updateAuthority: updateAuthority.publicKey,
-  });
-  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
-
-  // When we revoke the update delegate.
-  await revokeUpdateV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: updateDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-
-  // Then the metadata delegate record was deleted.
-  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
-});
-
-test('it can revoke a update delegate for a FungibleAsset', async (t) => {
-  // Given a FungibleAsset with an approved update delegate.
-  const umi = await createUmi();
-  const updateAuthority = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    authority: updateAuthority,
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-  const updateDelegate = generateSigner(umi).publicKey;
-  await delegateUpdateV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: updateDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-  const metadataDelegateRecord = findMetadataDelegateRecordPda(umi, {
-    mint,
-    delegateRole: MetadataDelegateRole.Update,
-    delegate: updateDelegate,
-    updateAuthority: updateAuthority.publicKey,
-  });
-  t.true(await umi.rpc.accountExists(metadataDelegateRecord));
-
-  // When we revoke the update delegate.
-  await revokeUpdateV1(umi, {
-    mint,
-    updateAuthority: updateAuthority.publicKey,
-    authority: updateAuthority,
-    delegate: updateDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-
-  // Then the metadata delegate record was deleted.
-  t.false(await umi.rpc.accountExists(metadataDelegateRecord));
 });

--- a/clients/js/test/revokeUtilityV1.test.ts
+++ b/clients/js/test/revokeUtilityV1.test.ts
@@ -14,49 +14,46 @@ import {
   TokenDelegateRole,
   TokenStandard,
   TokenState,
-  delegateLockedTransferV1,
+  delegateUtilityV1,
   fetchDigitalAssetWithAssociatedToken,
-  revokeLockedTransferV1,
+  revokeUtilityV1,
 } from '../src';
 import { createDigitalAssetWithToken, createUmi } from './_setup';
 
-test('it can revoke a locked transfer delegate for a ProgrammableNonFungible', async (t) => {
-  // Given a ProgrammableNonFungible with an approved locked transfer delegate.
+test('it can revoke a utility delegate for a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible with an approved utility delegate.
   const umi = await createUmi();
   const owner = generateSigner(umi);
-  const lockedTransferDelegate = generateSigner(umi).publicKey;
-  const lockedAddress = generateSigner(umi).publicKey;
+  const utilityDelegate = generateSigner(umi).publicKey;
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
     tokenStandard: TokenStandard.ProgrammableNonFungible,
   });
-  await delegateLockedTransferV1(umi, {
+  await delegateUtilityV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: utilityDelegate,
     tokenStandard: TokenStandard.ProgrammableNonFungible,
-    lockedAddress,
   }).sendAndConfirm(umi);
   t.like(
     await fetchDigitalAssetWithAssociatedToken(umi, mint, owner.publicKey),
     <DigitalAssetWithToken>{
-      token: { delegate: some(publicKey(lockedTransferDelegate)) },
+      token: { delegate: some(publicKey(utilityDelegate)) },
       tokenRecord: {
-        delegate: some(publicKey(lockedTransferDelegate)),
-        delegateRole: some(TokenDelegateRole.LockedTransfer),
-        lockedTransfer: some(lockedAddress),
+        delegate: some(publicKey(utilityDelegate)),
+        delegateRole: some(TokenDelegateRole.Utility),
         state: TokenState.Unlocked,
       },
     }
   );
 
-  // When we revoke the locked transfer delegate.
-  await revokeLockedTransferV1(umi, {
+  // When we revoke the utility delegate.
+  await revokeUtilityV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: utilityDelegate,
     tokenStandard: TokenStandard.ProgrammableNonFungible,
   }).sendAndConfirm(umi);
 
@@ -68,34 +65,33 @@ test('it can revoke a locked transfer delegate for a ProgrammableNonFungible', a
       tokenRecord: {
         delegate: none(),
         delegateRole: none(),
-        lockedTransfer: none(),
         state: TokenState.Unlocked,
       },
     }
   );
 });
 
-test('it cannot revoke a locked transfer delegate for a NonFungible', async (t) => {
+test('it cannot revoke a utility delegate for a NonFungible', async (t) => {
   // Given a NonFungible with an SPL delegate.
   const umi = await createUmi();
   const owner = generateSigner(umi);
-  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const utilityDelegate = generateSigner(umi).publicKey;
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
   });
   await approveTokenDelegate(umi, {
     source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: lockedTransferDelegate,
+    delegate: utilityDelegate,
     owner,
     amount: 1,
   }).sendAndConfirm(umi);
 
-  // When we try to revoke the locked transfer delegate.
-  const promise = revokeLockedTransferV1(umi, {
+  // When we try to revoke the utility delegate.
+  const promise = revokeUtilityV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: utilityDelegate,
     tokenStandard: TokenStandard.NonFungible,
   }).sendAndConfirm(umi);
 
@@ -103,28 +99,28 @@ test('it cannot revoke a locked transfer delegate for a NonFungible', async (t) 
   await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });
 
-test('it cannot revoke a locked transfer delegate for a Fungible', async (t) => {
+test('it cannot revoke a utility delegate for a Fungible', async (t) => {
   // Given a Fungible with an SPL delegate.
   const umi = await createUmi();
   const owner = generateSigner(umi);
-  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const utilityDelegate = generateSigner(umi).publicKey;
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
     tokenStandard: TokenStandard.Fungible,
   });
   await approveTokenDelegate(umi, {
     source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: lockedTransferDelegate,
+    delegate: utilityDelegate,
     owner,
     amount: 1,
   }).sendAndConfirm(umi);
 
-  // When we try to revoke the locked transfer delegate.
-  const promise = revokeLockedTransferV1(umi, {
+  // When we try to revoke the utility delegate.
+  const promise = revokeUtilityV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: utilityDelegate,
     tokenStandard: TokenStandard.Fungible,
   }).sendAndConfirm(umi);
 
@@ -132,28 +128,28 @@ test('it cannot revoke a locked transfer delegate for a Fungible', async (t) => 
   await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });
 
-test('it cannot revoke a locked transfer delegate for a FungibleAsset', async (t) => {
+test('it cannot revoke a utility delegate for a FungibleAsset', async (t) => {
   // Given a FungibleAsset with an SPL delegate.
   const umi = await createUmi();
   const owner = generateSigner(umi);
-  const lockedTransferDelegate = generateSigner(umi).publicKey;
+  const utilityDelegate = generateSigner(umi).publicKey;
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     tokenOwner: owner.publicKey,
     tokenStandard: TokenStandard.FungibleAsset,
   });
   await approveTokenDelegate(umi, {
     source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: lockedTransferDelegate,
+    delegate: utilityDelegate,
     owner,
     amount: 1,
   }).sendAndConfirm(umi);
 
-  // When we try to revoke the locked transfer delegate.
-  const promise = revokeLockedTransferV1(umi, {
+  // When we try to revoke the utility delegate.
+  const promise = revokeUtilityV1(umi, {
     mint,
     tokenOwner: owner.publicKey,
     authority: owner,
-    delegate: lockedTransferDelegate,
+    delegate: utilityDelegate,
     tokenStandard: TokenStandard.FungibleAsset,
   }).sendAndConfirm(umi);
 

--- a/clients/js/test/revokeUtilityV1.test.ts
+++ b/clients/js/test/revokeUtilityV1.test.ts
@@ -18,7 +18,11 @@ import {
   fetchDigitalAssetWithAssociatedToken,
   revokeUtilityV1,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
+import {
+  OG_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
 test('it can revoke a utility delegate for a ProgrammableNonFungible', async (t) => {
   // Given a ProgrammableNonFungible with an approved utility delegate.
@@ -71,88 +75,33 @@ test('it can revoke a utility delegate for a ProgrammableNonFungible', async (t)
   );
 });
 
-test('it cannot revoke a utility delegate for a NonFungible', async (t) => {
-  // Given a NonFungible with an SPL delegate.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const utilityDelegate = generateSigner(umi).publicKey;
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
+OG_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it cannot revoke a utility delegate for a ${tokenStandard}`, async (t) => {
+    // Given an asset with an SPL delegate.
+    const umi = await createUmi();
+    const owner = generateSigner(umi);
+    const utilityDelegate = generateSigner(umi).publicKey;
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      tokenOwner: owner.publicKey,
+      tokenStandard: TokenStandard[tokenStandard],
+    });
+    await approveTokenDelegate(umi, {
+      source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
+      delegate: utilityDelegate,
+      owner,
+      amount: 1,
+    }).sendAndConfirm(umi);
+
+    // When we try to revoke it as the utility delegate.
+    const promise = revokeUtilityV1(umi, {
+      mint,
+      tokenOwner: owner.publicKey,
+      authority: owner,
+      delegate: utilityDelegate,
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
+
+    // Then we expect a program error.
+    await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
   });
-  await approveTokenDelegate(umi, {
-    source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: utilityDelegate,
-    owner,
-    amount: 1,
-  }).sendAndConfirm(umi);
-
-  // When we try to revoke the utility delegate.
-  const promise = revokeUtilityV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: utilityDelegate,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
-});
-
-test('it cannot revoke a utility delegate for a Fungible', async (t) => {
-  // Given a Fungible with an SPL delegate.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const utilityDelegate = generateSigner(umi).publicKey;
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.Fungible,
-  });
-  await approveTokenDelegate(umi, {
-    source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: utilityDelegate,
-    owner,
-    amount: 1,
-  }).sendAndConfirm(umi);
-
-  // When we try to revoke the utility delegate.
-  const promise = revokeUtilityV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: utilityDelegate,
-    tokenStandard: TokenStandard.Fungible,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
-});
-
-test('it cannot revoke a utility delegate for a FungibleAsset', async (t) => {
-  // Given a FungibleAsset with an SPL delegate.
-  const umi = await createUmi();
-  const owner = generateSigner(umi);
-  const utilityDelegate = generateSigner(umi).publicKey;
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: owner.publicKey,
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-  await approveTokenDelegate(umi, {
-    source: findAssociatedTokenPda(umi, { mint, owner: owner.publicKey }),
-    delegate: utilityDelegate,
-    owner,
-    amount: 1,
-  }).sendAndConfirm(umi);
-
-  // When we try to revoke the utility delegate.
-  const promise = revokeUtilityV1(umi, {
-    mint,
-    tokenOwner: owner.publicKey,
-    authority: owner,
-    delegate: utilityDelegate,
-    tokenStandard: TokenStandard.FungibleAsset,
-  }).sendAndConfirm(umi);
-
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'InvalidDelegateRole' });
 });

--- a/clients/js/test/transferV1.test.ts
+++ b/clients/js/test/transferV1.test.ts
@@ -85,3 +85,83 @@ test('it can transfer a ProgrammableNonFungible', async (t) => {
     },
   });
 });
+
+test('it can transfer a Fungible', async (t) => {
+  // Given a Fungible such that owner A owns 42 tokens.
+  const umi = await createUmi();
+  const ownerA = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: ownerA.publicKey,
+    tokenStandard: TokenStandard.Fungible,
+    amount: 42,
+  });
+
+  // When we transfer 10 tokens to owner B.
+  const ownerB = generateSigner(umi).publicKey;
+  await transferV1(umi, {
+    mint,
+    authority: ownerA,
+    tokenOwner: ownerA.publicKey,
+    destinationOwner: ownerB,
+    tokenStandard: TokenStandard.Fungible,
+    amount: 10,
+  }).sendAndConfirm(umi);
+
+  // Then owner A has 32 tokens
+  const assetA = await fetchDigitalAssetWithAssociatedToken(
+    umi,
+    mint,
+    ownerA.publicKey
+  );
+  t.like(assetA, <DigitalAssetWithToken>{
+    mint: { publicKey: publicKey(mint), supply: 42n },
+    token: { owner: publicKey(ownerA), amount: 32n },
+  });
+
+  // And owner B has 10 tokens.
+  const assetB = await fetchDigitalAssetWithAssociatedToken(umi, mint, ownerB);
+  t.like(assetB, <DigitalAssetWithToken>{
+    mint: { publicKey: publicKey(mint), supply: 42n },
+    token: { owner: publicKey(ownerB), amount: 10n },
+  });
+});
+
+test('it can transfer a FungibleAsset', async (t) => {
+  // Given a FungibleAsset such that owner A owns 42 tokens.
+  const umi = await createUmi();
+  const ownerA = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: ownerA.publicKey,
+    tokenStandard: TokenStandard.FungibleAsset,
+    amount: 42,
+  });
+
+  // When we transfer 10 tokens to owner B.
+  const ownerB = generateSigner(umi).publicKey;
+  await transferV1(umi, {
+    mint,
+    authority: ownerA,
+    tokenOwner: ownerA.publicKey,
+    destinationOwner: ownerB,
+    tokenStandard: TokenStandard.FungibleAsset,
+    amount: 10,
+  }).sendAndConfirm(umi);
+
+  // Then owner A has 32 tokens
+  const assetA = await fetchDigitalAssetWithAssociatedToken(
+    umi,
+    mint,
+    ownerA.publicKey
+  );
+  t.like(assetA, <DigitalAssetWithToken>{
+    mint: { publicKey: publicKey(mint), supply: 42n },
+    token: { owner: publicKey(ownerA), amount: 32n },
+  });
+
+  // And owner B has 10 tokens.
+  const assetB = await fetchDigitalAssetWithAssociatedToken(umi, mint, ownerB);
+  t.like(assetB, <DigitalAssetWithToken>{
+    mint: { publicKey: publicKey(mint), supply: 42n },
+    token: { owner: publicKey(ownerB), amount: 10n },
+  });
+});

--- a/clients/js/test/transferV1.test.ts
+++ b/clients/js/test/transferV1.test.ts
@@ -8,7 +8,11 @@ import {
   fetchDigitalAssetWithAssociatedToken,
   transferV1,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
+import {
+  FUNGIBLE_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
 test('it can transfer a NonFungible', async (t) => {
   // Given a NonFungible that belongs to owner A.
@@ -86,82 +90,48 @@ test('it can transfer a ProgrammableNonFungible', async (t) => {
   });
 });
 
-test('it can transfer a Fungible', async (t) => {
-  // Given a Fungible such that owner A owns 42 tokens.
-  const umi = await createUmi();
-  const ownerA = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: ownerA.publicKey,
-    tokenStandard: TokenStandard.Fungible,
-    amount: 42,
-  });
+FUNGIBLE_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it can transfer a ${tokenStandard}`, async (t) => {
+    // Given a fungible such that owner A owns 42 tokens.
+    const umi = await createUmi();
+    const ownerA = generateSigner(umi);
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      tokenOwner: ownerA.publicKey,
+      tokenStandard: TokenStandard[tokenStandard],
+      amount: 42,
+    });
 
-  // When we transfer 10 tokens to owner B.
-  const ownerB = generateSigner(umi).publicKey;
-  await transferV1(umi, {
-    mint,
-    authority: ownerA,
-    tokenOwner: ownerA.publicKey,
-    destinationOwner: ownerB,
-    tokenStandard: TokenStandard.Fungible,
-    amount: 10,
-  }).sendAndConfirm(umi);
+    // When we transfer 10 tokens to owner B.
+    const ownerB = generateSigner(umi).publicKey;
+    await transferV1(umi, {
+      mint,
+      authority: ownerA,
+      tokenOwner: ownerA.publicKey,
+      destinationOwner: ownerB,
+      tokenStandard: TokenStandard[tokenStandard],
+      amount: 10,
+    }).sendAndConfirm(umi);
 
-  // Then owner A has 32 tokens
-  const assetA = await fetchDigitalAssetWithAssociatedToken(
-    umi,
-    mint,
-    ownerA.publicKey
-  );
-  t.like(assetA, <DigitalAssetWithToken>{
-    mint: { publicKey: publicKey(mint), supply: 42n },
-    token: { owner: publicKey(ownerA), amount: 32n },
-  });
+    // Then owner A has 32 tokens
+    const assetA = await fetchDigitalAssetWithAssociatedToken(
+      umi,
+      mint,
+      ownerA.publicKey
+    );
+    t.like(assetA, <DigitalAssetWithToken>{
+      mint: { publicKey: publicKey(mint), supply: 42n },
+      token: { owner: publicKey(ownerA), amount: 32n },
+    });
 
-  // And owner B has 10 tokens.
-  const assetB = await fetchDigitalAssetWithAssociatedToken(umi, mint, ownerB);
-  t.like(assetB, <DigitalAssetWithToken>{
-    mint: { publicKey: publicKey(mint), supply: 42n },
-    token: { owner: publicKey(ownerB), amount: 10n },
-  });
-});
-
-test('it can transfer a FungibleAsset', async (t) => {
-  // Given a FungibleAsset such that owner A owns 42 tokens.
-  const umi = await createUmi();
-  const ownerA = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenOwner: ownerA.publicKey,
-    tokenStandard: TokenStandard.FungibleAsset,
-    amount: 42,
-  });
-
-  // When we transfer 10 tokens to owner B.
-  const ownerB = generateSigner(umi).publicKey;
-  await transferV1(umi, {
-    mint,
-    authority: ownerA,
-    tokenOwner: ownerA.publicKey,
-    destinationOwner: ownerB,
-    tokenStandard: TokenStandard.FungibleAsset,
-    amount: 10,
-  }).sendAndConfirm(umi);
-
-  // Then owner A has 32 tokens
-  const assetA = await fetchDigitalAssetWithAssociatedToken(
-    umi,
-    mint,
-    ownerA.publicKey
-  );
-  t.like(assetA, <DigitalAssetWithToken>{
-    mint: { publicKey: publicKey(mint), supply: 42n },
-    token: { owner: publicKey(ownerA), amount: 32n },
-  });
-
-  // And owner B has 10 tokens.
-  const assetB = await fetchDigitalAssetWithAssociatedToken(umi, mint, ownerB);
-  t.like(assetB, <DigitalAssetWithToken>{
-    mint: { publicKey: publicKey(mint), supply: 42n },
-    token: { owner: publicKey(ownerB), amount: 10n },
+    // And owner B has 10 tokens.
+    const assetB = await fetchDigitalAssetWithAssociatedToken(
+      umi,
+      mint,
+      ownerB
+    );
+    t.like(assetB, <DigitalAssetWithToken>{
+      mint: { publicKey: publicKey(mint), supply: 42n },
+      token: { owner: publicKey(ownerB), amount: 10n },
+    });
   });
 });

--- a/clients/js/test/transferV1.test.ts
+++ b/clients/js/test/transferV1.test.ts
@@ -1,0 +1,45 @@
+import {
+  Mint,
+  Token,
+  fetchMint,
+  fetchToken,
+  findAssociatedTokenPda,
+} from '@metaplex-foundation/mpl-essentials';
+import { generateSigner, publicKey } from '@metaplex-foundation/umi';
+import test from 'ava';
+import { TokenStandard, mintV1, transferV1 } from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can transfer a NonFungible to another wallet', async (t) => {
+  // Given a NonFungible that belongs to owner A.
+  const umi = await createUmi();
+  const ownerA = generateSigner(umi).publicKey;
+  const mint = await createDigitalAssetWithToken(umi, { tokenOwner: ownerA });
+
+  // When we transfer the NonFungible to owner B.
+  const ownerB = generateSigner(umi).publicKey;
+  await transferV1(umi, {
+    mint: mint.publicKey,
+    amount: 1,
+  }).sendAndConfirm(umi);
+
+  // Then a token was minted to the associated token account.
+  const mintAccount = await fetchMint(umi, mint.publicKey);
+  t.like(mintAccount, <Mint>{ publicKey: publicKey(mint), supply: 1n });
+  const token = findAssociatedTokenPda(umi, {
+    mint: mint.publicKey,
+    owner: umi.identity.publicKey,
+  });
+  const tokenAccount = await fetchToken(umi, token);
+  t.like(tokenAccount, <Token>{ publicKey: publicKey(token), amount: 1n });
+
+  // But when we try to mint another token.
+  const promise = mintV1(umi, {
+    mint: mint.publicKey,
+    amount: 1,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+
+  // Then we expect a program error.
+  await t.throwsAsync(promise, { name: 'EditionsMustHaveExactlyOneToken' });
+});

--- a/clients/js/test/transferV1.test.ts
+++ b/clients/js/test/transferV1.test.ts
@@ -1,45 +1,46 @@
-import {
-  Mint,
-  Token,
-  fetchMint,
-  fetchToken,
-  findAssociatedTokenPda,
-} from '@metaplex-foundation/mpl-essentials';
-import { generateSigner, publicKey } from '@metaplex-foundation/umi';
+import { PublicKey, generateSigner, publicKey } from '@metaplex-foundation/umi';
 import test from 'ava';
-import { TokenStandard, mintV1, transferV1 } from '../src';
+import { findAssociatedTokenPda } from '@metaplex-foundation/mpl-essentials';
+import {
+  DigitalAssetWithToken,
+  TokenStandard,
+  fetchDigitalAssetWithAssociatedToken,
+  transferV1,
+} from '../src';
 import { createDigitalAssetWithToken, createUmi } from './_setup';
 
 test('it can transfer a NonFungible to another wallet', async (t) => {
   // Given a NonFungible that belongs to owner A.
   const umi = await createUmi();
-  const ownerA = generateSigner(umi).publicKey;
-  const mint = await createDigitalAssetWithToken(umi, { tokenOwner: ownerA });
+  const ownerA = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenOwner: ownerA.publicKey,
+  });
 
-  // When we transfer the NonFungible to owner B.
+  // When we transfer the asset to owner B.
   const ownerB = generateSigner(umi).publicKey;
   await transferV1(umi, {
-    mint: mint.publicKey,
-    amount: 1,
-  }).sendAndConfirm(umi);
-
-  // Then a token was minted to the associated token account.
-  const mintAccount = await fetchMint(umi, mint.publicKey);
-  t.like(mintAccount, <Mint>{ publicKey: publicKey(mint), supply: 1n });
-  const token = findAssociatedTokenPda(umi, {
-    mint: mint.publicKey,
-    owner: umi.identity.publicKey,
-  });
-  const tokenAccount = await fetchToken(umi, token);
-  t.like(tokenAccount, <Token>{ publicKey: publicKey(token), amount: 1n });
-
-  // But when we try to mint another token.
-  const promise = mintV1(umi, {
-    mint: mint.publicKey,
-    amount: 1,
+    mint,
+    authority: ownerA,
+    tokenOwner: ownerA.publicKey,
+    destinationOwner: ownerB,
     tokenStandard: TokenStandard.NonFungible,
   }).sendAndConfirm(umi);
 
-  // Then we expect a program error.
-  await t.throwsAsync(promise, { name: 'EditionsMustHaveExactlyOneToken' });
+  // Then the asset is now owned by owner B.
+  const da = await fetchDigitalAssetWithAssociatedToken(umi, mint, ownerB);
+  t.like(da, <DigitalAssetWithToken>{
+    mint: {
+      publicKey: publicKey(mint),
+      supply: 1n,
+    },
+    token: {
+      publicKey: findAssociatedTokenPda(umi, {
+        mint,
+        owner: ownerB,
+      }) as PublicKey,
+      owner: ownerB,
+      amount: 1n,
+    },
+  });
 });

--- a/clients/js/test/unlockV1.test.ts
+++ b/clients/js/test/unlockV1.test.ts
@@ -1,0 +1,150 @@
+import { TokenState as SplTokenState } from '@metaplex-foundation/mpl-essentials';
+import { generateSigner, transactionBuilder } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  DigitalAssetWithToken,
+  TokenStandard,
+  TokenState,
+  delegateStandardV1,
+  delegateUtilityV1,
+  fetchDigitalAssetWithAssociatedToken,
+  lockV1,
+  unlockV1,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can unlock a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible with a utility delegate that has locked the asset.
+  const umi = await createUmi();
+  const owner = umi.identity.publicKey;
+  const tokenStandard = TokenStandard.ProgrammableNonFungible;
+  const utilityDelegate = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenStandard,
+  });
+  await transactionBuilder()
+    .add(
+      delegateUtilityV1(umi, {
+        mint,
+        delegate: utilityDelegate.publicKey,
+        tokenStandard,
+      })
+    )
+    .add(lockV1(umi, { mint, authority: utilityDelegate, tokenStandard }))
+    .sendAndConfirm(umi);
+  t.like(await fetchDigitalAssetWithAssociatedToken(umi, mint, owner), <
+    DigitalAssetWithToken
+  >{ tokenRecord: { state: TokenState.Locked } });
+
+  // When the utility delegate unlocks the asset.
+  await unlockV1(umi, {
+    mint,
+    authority: utilityDelegate,
+    tokenStandard,
+  }).sendAndConfirm(umi);
+
+  // Then the token state was successfully updated.
+  t.like(await fetchDigitalAssetWithAssociatedToken(umi, mint, owner), <
+    DigitalAssetWithToken
+  >{ tokenRecord: { state: TokenState.Unlocked } });
+});
+
+test('it can unfreeze a NonFungible', async (t) => {
+  // Given a NonFungible with a standard delegate that has locked the asset.
+  const umi = await createUmi();
+  const owner = umi.identity.publicKey;
+  const tokenStandard = TokenStandard.NonFungible;
+  const standardDelegate = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi);
+  await transactionBuilder()
+    .add(
+      delegateStandardV1(umi, {
+        mint,
+        delegate: standardDelegate.publicKey,
+        tokenStandard,
+      })
+    )
+    .add(lockV1(umi, { mint, authority: standardDelegate, tokenStandard }))
+    .sendAndConfirm(umi);
+  t.like(await fetchDigitalAssetWithAssociatedToken(umi, mint, owner), <
+    DigitalAssetWithToken
+  >{ token: { state: SplTokenState.Frozen }, tokenRecord: undefined });
+
+  // When the standard delegate unlocks the asset.
+  await unlockV1(umi, {
+    mint,
+    authority: standardDelegate,
+    tokenStandard,
+  }).sendAndConfirm(umi);
+
+  // Then the token state of the token account was successfully updated.
+  t.like(await fetchDigitalAssetWithAssociatedToken(umi, mint, owner), <
+    DigitalAssetWithToken
+  >{ token: { state: SplTokenState.Initialized }, tokenRecord: undefined });
+});
+
+test('it can unfreeze a Fungible', async (t) => {
+  // Given a Fungible asset with the identity as the freeze authority of the mint
+  const umi = await createUmi();
+  const freezeAuthority = umi.identity;
+  const owner = umi.identity.publicKey;
+  const tokenStandard = TokenStandard.Fungible;
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenStandard,
+  });
+
+  // And given the freeze authority has locked the asset.
+  await lockV1(umi, {
+    mint,
+    authority: freezeAuthority,
+    tokenStandard,
+  }).sendAndConfirm(umi);
+  t.like(await fetchDigitalAssetWithAssociatedToken(umi, mint, owner), <
+    DigitalAssetWithToken
+  >{ token: { state: SplTokenState.Frozen }, tokenRecord: undefined });
+
+  // When the freeze authority unlocks the asset.
+  await unlockV1(umi, {
+    mint,
+    authority: freezeAuthority,
+    tokenStandard,
+  }).sendAndConfirm(umi);
+
+  // Then the token state of the token account was successfully updated.
+  t.like(await fetchDigitalAssetWithAssociatedToken(umi, mint, owner), <
+    DigitalAssetWithToken
+  >{ token: { state: SplTokenState.Initialized }, tokenRecord: undefined });
+});
+
+test('it can unfreeze a FungibleAsset', async (t) => {
+  // Given a FungibleAsset asset with the identity as the freeze authority of the mint
+  const umi = await createUmi();
+  const freezeAuthority = umi.identity;
+  const owner = umi.identity.publicKey;
+  const tokenStandard = TokenStandard.FungibleAsset;
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenStandard,
+  });
+
+  // And given the freeze authority has locked the asset.
+  await lockV1(umi, {
+    mint,
+    authority: freezeAuthority,
+    tokenStandard,
+  }).sendAndConfirm(umi);
+  t.like(await fetchDigitalAssetWithAssociatedToken(umi, mint, owner), <
+    DigitalAssetWithToken
+  >{ token: { state: SplTokenState.Frozen }, tokenRecord: undefined });
+
+  // When the freeze authority unlocks the asset.
+  await unlockV1(umi, {
+    mint,
+    authority: freezeAuthority,
+    tokenStandard,
+  }).sendAndConfirm(umi);
+
+  // Then the token state of the token account was successfully updated.
+  t.like(await fetchDigitalAssetWithAssociatedToken(umi, mint, owner), <
+    DigitalAssetWithToken
+  >{ token: { state: SplTokenState.Initialized }, tokenRecord: undefined });
+});

--- a/clients/js/test/unverifyCollectionV1.test.ts
+++ b/clients/js/test/unverifyCollectionV1.test.ts
@@ -1,0 +1,104 @@
+import { generateSigner, some } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  Metadata,
+  MetadataDelegateRole,
+  TokenStandard,
+  delegateCollectionV1,
+  fetchMetadata,
+  findMetadataDelegateRecordPda,
+  findMetadataPda,
+  unverifyCollectionV1,
+  verifyCollectionV1,
+} from '../src';
+import {
+  NON_EDITION_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
+
+NON_EDITION_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it can unverify the collection of a ${tokenStandard}`, async (t) => {
+    // Given a collection.
+    const umi = await createUmi();
+    const collectionAuthority = generateSigner(umi);
+    const { publicKey: collectionMint } = await createDigitalAssetWithToken(
+      umi,
+      { isCollection: true, authority: collectionAuthority }
+    );
+
+    // And an asset verified as part of that collection.
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      collection: some({ key: collectionMint, verified: false }),
+      tokenStandard: TokenStandard[tokenStandard],
+    });
+    const metadata = findMetadataPda(umi, { mint });
+    await verifyCollectionV1(umi, {
+      metadata,
+      collectionMint,
+      authority: collectionAuthority,
+    }).sendAndConfirm(umi);
+    t.like(await fetchMetadata(umi, metadata), <Metadata>{
+      collection: some({ key: collectionMint, verified: true }),
+    });
+
+    // When the collection authority unverifies the collection on the asset.
+    await unverifyCollectionV1(umi, {
+      metadata,
+      collectionMint,
+      authority: collectionAuthority,
+    }).sendAndConfirm(umi);
+
+    // Then the collection is now marked as unverified on the asset.
+    t.like(await fetchMetadata(umi, metadata), <Metadata>{
+      collection: some({ key: collectionMint, verified: false }),
+    });
+  });
+
+  test(`it can unverify the collection of a ${tokenStandard} as a delegate`, async (t) => {
+    // Given a collection with a delegate.
+    const umi = await createUmi();
+    const collectionDelegate = generateSigner(umi);
+    const { publicKey: collectionMint } = await createDigitalAssetWithToken(
+      umi,
+      { isCollection: true }
+    );
+    await delegateCollectionV1(umi, {
+      mint: collectionMint,
+      delegate: collectionDelegate.publicKey,
+      tokenStandard: TokenStandard.NonFungible,
+    }).sendAndConfirm(umi);
+
+    // And an asset verified as part of that collection.
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      collection: some({ key: collectionMint, verified: false }),
+      tokenStandard: TokenStandard[tokenStandard],
+    });
+    const metadata = findMetadataPda(umi, { mint });
+    await verifyCollectionV1(umi, {
+      metadata,
+      collectionMint,
+    }).sendAndConfirm(umi);
+    t.like(await fetchMetadata(umi, metadata), <Metadata>{
+      collection: some({ key: collectionMint, verified: true }),
+    });
+
+    // When the collection delegate unverifies the collection on the asset.
+    await unverifyCollectionV1(umi, {
+      metadata,
+      collectionMint,
+      authority: collectionDelegate,
+      delegateRecord: findMetadataDelegateRecordPda(umi, {
+        mint: collectionMint,
+        delegateRole: MetadataDelegateRole.Collection,
+        delegate: collectionDelegate.publicKey,
+        updateAuthority: umi.identity.publicKey,
+      }),
+    }).sendAndConfirm(umi);
+
+    // Then the collection is now marked as unverified on the asset.
+    t.like(await fetchMetadata(umi, metadata), <Metadata>{
+      collection: some({ key: collectionMint, verified: false }),
+    });
+  });
+});

--- a/clients/js/test/unverifyCreatorV1.test.ts
+++ b/clients/js/test/unverifyCreatorV1.test.ts
@@ -8,143 +8,45 @@ import {
   unverifyCreatorV1,
   verifyCreatorV1,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
+import {
+  NON_EDITION_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
-test('it can unverify the creator of a NonFungible', async (t) => {
-  // Given a NonFungible with an verified creator.
-  const umi = await createUmi();
-  const creator = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    creators: some([
-      { address: creator.publicKey, verified: false, share: 100 },
-    ]),
-  });
-  const metadata = findMetadataPda(umi, { mint });
-  await verifyCreatorV1(umi, {
-    metadata,
-    authority: creator,
-  }).sendAndConfirm(umi);
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    creators: some([
-      { address: creator.publicKey, verified: true, share: 100 },
-    ]),
-  });
+NON_EDITION_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it can unverify the creator of a ${tokenStandard}`, async (t) => {
+    // Given an asset with an verified creator.
+    const umi = await createUmi();
+    const creator = generateSigner(umi);
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      tokenStandard: TokenStandard[tokenStandard],
+      creators: some([
+        { address: creator.publicKey, verified: false, share: 100 },
+      ]),
+    });
+    const metadata = findMetadataPda(umi, { mint });
+    await verifyCreatorV1(umi, {
+      metadata,
+      authority: creator,
+    }).sendAndConfirm(umi);
+    t.like(await fetchMetadata(umi, metadata), <Metadata>{
+      creators: some([
+        { address: creator.publicKey, verified: true, share: 100 },
+      ]),
+    });
 
-  // When the creator unverifies themselves on the asset.
-  await unverifyCreatorV1(umi, {
-    metadata,
-    authority: creator,
-  }).sendAndConfirm(umi);
+    // When the creator unverifies themselves on the asset.
+    await unverifyCreatorV1(umi, {
+      metadata,
+      authority: creator,
+    }).sendAndConfirm(umi);
 
-  // Then the creator is now marked as unverified on the asset.
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    creators: some([
-      { address: creator.publicKey, verified: false, share: 100 },
-    ]),
-  });
-});
-
-test('it can unverify the creator of a ProgrammableNonFungible', async (t) => {
-  // Given a ProgrammableNonFungible with an verified creator.
-  const umi = await createUmi();
-  const creator = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-    creators: some([
-      { address: creator.publicKey, verified: false, share: 100 },
-    ]),
-  });
-  const metadata = findMetadataPda(umi, { mint });
-  await verifyCreatorV1(umi, {
-    metadata,
-    authority: creator,
-  }).sendAndConfirm(umi);
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    creators: some([
-      { address: creator.publicKey, verified: true, share: 100 },
-    ]),
-  });
-
-  // When the creator unverifies themselves on the asset.
-  await unverifyCreatorV1(umi, {
-    metadata,
-    authority: creator,
-  }).sendAndConfirm(umi);
-
-  // Then the creator is now marked as unverified on the asset.
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    creators: some([
-      { address: creator.publicKey, verified: false, share: 100 },
-    ]),
-  });
-});
-
-test('it can unverify the creator of a Fungible', async (t) => {
-  // Given a Fungible with an verified creator.
-  const umi = await createUmi();
-  const creator = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenStandard: TokenStandard.Fungible,
-    creators: some([
-      { address: creator.publicKey, verified: false, share: 100 },
-    ]),
-  });
-  const metadata = findMetadataPda(umi, { mint });
-  await verifyCreatorV1(umi, {
-    metadata,
-    authority: creator,
-  }).sendAndConfirm(umi);
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    creators: some([
-      { address: creator.publicKey, verified: true, share: 100 },
-    ]),
-  });
-
-  // When the creator unverifies themselves on the asset.
-  await unverifyCreatorV1(umi, {
-    metadata,
-    authority: creator,
-  }).sendAndConfirm(umi);
-
-  // Then the creator is now marked as unverified on the asset.
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    creators: some([
-      { address: creator.publicKey, verified: false, share: 100 },
-    ]),
-  });
-});
-
-test('it can unverify the creator of a FungibleAsset', async (t) => {
-  // Given a FungibleAsset with an verified creator.
-  const umi = await createUmi();
-  const creator = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenStandard: TokenStandard.FungibleAsset,
-    creators: some([
-      { address: creator.publicKey, verified: false, share: 100 },
-    ]),
-  });
-  const metadata = findMetadataPda(umi, { mint });
-  await verifyCreatorV1(umi, {
-    metadata,
-    authority: creator,
-  }).sendAndConfirm(umi);
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    creators: some([
-      { address: creator.publicKey, verified: true, share: 100 },
-    ]),
-  });
-
-  // When the creator unverifies themselves on the asset.
-  await unverifyCreatorV1(umi, {
-    metadata,
-    authority: creator,
-  }).sendAndConfirm(umi);
-
-  // Then the creator is now marked as unverified on the asset.
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    creators: some([
-      { address: creator.publicKey, verified: false, share: 100 },
-    ]),
+    // Then the creator is now marked as unverified on the asset.
+    t.like(await fetchMetadata(umi, metadata), <Metadata>{
+      creators: some([
+        { address: creator.publicKey, verified: false, share: 100 },
+      ]),
+    });
   });
 });

--- a/clients/js/test/unverifyCreatorV1.test.ts
+++ b/clients/js/test/unverifyCreatorV1.test.ts
@@ -1,0 +1,150 @@
+import { generateSigner, some } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  Metadata,
+  TokenStandard,
+  fetchMetadata,
+  findMetadataPda,
+  unverifyCreatorV1,
+  verifyCreatorV1,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can unverify the creator of a NonFungible', async (t) => {
+  // Given a NonFungible with an verified creator.
+  const umi = await createUmi();
+  const creator = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    creators: some([
+      { address: creator.publicKey, verified: false, share: 100 },
+    ]),
+  });
+  const metadata = findMetadataPda(umi, { mint });
+  await verifyCreatorV1(umi, {
+    metadata,
+    authority: creator,
+  }).sendAndConfirm(umi);
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    creators: some([
+      { address: creator.publicKey, verified: true, share: 100 },
+    ]),
+  });
+
+  // When the creator unverifies themselves on the asset.
+  await unverifyCreatorV1(umi, {
+    metadata,
+    authority: creator,
+  }).sendAndConfirm(umi);
+
+  // Then the creator is now marked as unverified on the asset.
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    creators: some([
+      { address: creator.publicKey, verified: false, share: 100 },
+    ]),
+  });
+});
+
+test('it can unverify the creator of a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible with an verified creator.
+  const umi = await createUmi();
+  const creator = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+    creators: some([
+      { address: creator.publicKey, verified: false, share: 100 },
+    ]),
+  });
+  const metadata = findMetadataPda(umi, { mint });
+  await verifyCreatorV1(umi, {
+    metadata,
+    authority: creator,
+  }).sendAndConfirm(umi);
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    creators: some([
+      { address: creator.publicKey, verified: true, share: 100 },
+    ]),
+  });
+
+  // When the creator unverifies themselves on the asset.
+  await unverifyCreatorV1(umi, {
+    metadata,
+    authority: creator,
+  }).sendAndConfirm(umi);
+
+  // Then the creator is now marked as unverified on the asset.
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    creators: some([
+      { address: creator.publicKey, verified: false, share: 100 },
+    ]),
+  });
+});
+
+test('it can unverify the creator of a Fungible', async (t) => {
+  // Given a Fungible with an verified creator.
+  const umi = await createUmi();
+  const creator = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenStandard: TokenStandard.Fungible,
+    creators: some([
+      { address: creator.publicKey, verified: false, share: 100 },
+    ]),
+  });
+  const metadata = findMetadataPda(umi, { mint });
+  await verifyCreatorV1(umi, {
+    metadata,
+    authority: creator,
+  }).sendAndConfirm(umi);
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    creators: some([
+      { address: creator.publicKey, verified: true, share: 100 },
+    ]),
+  });
+
+  // When the creator unverifies themselves on the asset.
+  await unverifyCreatorV1(umi, {
+    metadata,
+    authority: creator,
+  }).sendAndConfirm(umi);
+
+  // Then the creator is now marked as unverified on the asset.
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    creators: some([
+      { address: creator.publicKey, verified: false, share: 100 },
+    ]),
+  });
+});
+
+test('it can unverify the creator of a FungibleAsset', async (t) => {
+  // Given a FungibleAsset with an verified creator.
+  const umi = await createUmi();
+  const creator = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenStandard: TokenStandard.FungibleAsset,
+    creators: some([
+      { address: creator.publicKey, verified: false, share: 100 },
+    ]),
+  });
+  const metadata = findMetadataPda(umi, { mint });
+  await verifyCreatorV1(umi, {
+    metadata,
+    authority: creator,
+  }).sendAndConfirm(umi);
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    creators: some([
+      { address: creator.publicKey, verified: true, share: 100 },
+    ]),
+  });
+
+  // When the creator unverifies themselves on the asset.
+  await unverifyCreatorV1(umi, {
+    metadata,
+    authority: creator,
+  }).sendAndConfirm(umi);
+
+  // Then the creator is now marked as unverified on the asset.
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    creators: some([
+      { address: creator.publicKey, verified: false, share: 100 },
+    ]),
+  });
+});

--- a/clients/js/test/updateV1.test.ts
+++ b/clients/js/test/updateV1.test.ts
@@ -10,28 +10,28 @@ import {
 import { createDigitalAsset, createUmi } from './_setup';
 
 test('it can update a NonFungible', async (t) => {
-  // Given an existing NFT.
+  // Given an existing NonFungible.
   const umi = await createUmi();
-  const mint = await createDigitalAsset(umi, { name: 'NFT #1' });
+  const mint = await createDigitalAsset(umi, { name: 'NonFungible #1' });
   const initialMetadata = findMetadataPda(umi, { mint: mint.publicKey });
   const initialMetadataAccount = await fetchMetadata(umi, initialMetadata);
 
-  // When we update the name of the NFT.
+  // When we update the name of the NonFungible.
   await updateV1(umi, {
     mint: mint.publicKey,
-    data: some({ ...initialMetadataAccount, name: 'NFT #2' }),
+    data: some({ ...initialMetadataAccount, name: 'NonFungible #2' }),
   }).sendAndConfirm(umi);
 
   // Then the account data was updated.
   const updatedMetadataAccount = await fetchMetadata(umi, initialMetadata);
-  t.like(updatedMetadataAccount, <Metadata>{ name: 'NFT #2' });
+  t.like(updatedMetadataAccount, <Metadata>{ name: 'NonFungible #2' });
 });
 
 test('it can update a ProgrammableNonFungible', async (t) => {
-  // Given an existing PNFT.
+  // Given an existing ProgrammableNonFungible.
   const umi = await createUmi();
   const mint = await createDigitalAsset(umi, {
-    name: 'NFT #1',
+    name: 'ProgrammableNonFungible #1',
     tokenStandard: TokenStandard.ProgrammableNonFungible,
   });
   const initialMetadata = findMetadataPda(umi, { mint: mint.publicKey });
@@ -40,10 +40,57 @@ test('it can update a ProgrammableNonFungible', async (t) => {
   // When we update the name of the PNFT.
   await updateV1(umi, {
     mint: mint.publicKey,
-    data: some({ ...initialMetadataAccount, name: 'NFT #2' }),
+    data: some({
+      ...initialMetadataAccount,
+      name: 'ProgrammableNonFungible #2',
+    }),
   }).sendAndConfirm(umi);
 
   // Then the account data was updated.
   const updatedMetadataAccount = await fetchMetadata(umi, initialMetadata);
-  t.like(updatedMetadataAccount, <Metadata>{ name: 'NFT #2' });
+  t.like(updatedMetadataAccount, <Metadata>{
+    name: 'ProgrammableNonFungible #2',
+  });
+});
+
+test('it can update a Fungible', async (t) => {
+  // Given an existing Fungible.
+  const umi = await createUmi();
+  const mint = await createDigitalAsset(umi, {
+    name: 'Fungible #1',
+    tokenStandard: TokenStandard.Fungible,
+  });
+  const initialMetadata = findMetadataPda(umi, { mint: mint.publicKey });
+  const initialMetadataAccount = await fetchMetadata(umi, initialMetadata);
+
+  // When we update the name of the Fungible.
+  await updateV1(umi, {
+    mint: mint.publicKey,
+    data: some({ ...initialMetadataAccount, name: 'Fungible #2' }),
+  }).sendAndConfirm(umi);
+
+  // Then the account data was updated.
+  const updatedMetadataAccount = await fetchMetadata(umi, initialMetadata);
+  t.like(updatedMetadataAccount, <Metadata>{ name: 'Fungible #2' });
+});
+
+test('it can update a FungibleAsset', async (t) => {
+  // Given an existing FungibleAsset.
+  const umi = await createUmi();
+  const mint = await createDigitalAsset(umi, {
+    name: 'FungibleAsset #1',
+    tokenStandard: TokenStandard.FungibleAsset,
+  });
+  const initialMetadata = findMetadataPda(umi, { mint: mint.publicKey });
+  const initialMetadataAccount = await fetchMetadata(umi, initialMetadata);
+
+  // When we update the name of the FungibleAsset.
+  await updateV1(umi, {
+    mint: mint.publicKey,
+    data: some({ ...initialMetadataAccount, name: 'FungibleAsset #2' }),
+  }).sendAndConfirm(umi);
+
+  // Then the account data was updated.
+  const updatedMetadataAccount = await fetchMetadata(umi, initialMetadata);
+  t.like(updatedMetadataAccount, <Metadata>{ name: 'FungibleAsset #2' });
 });

--- a/clients/js/test/updateV1.test.ts
+++ b/clients/js/test/updateV1.test.ts
@@ -1,6 +1,12 @@
 import { some } from '@metaplex-foundation/umi';
 import test from 'ava';
-import { fetchMetadata, findMetadataPda, Metadata, updateV1 } from '../src';
+import {
+  fetchMetadata,
+  findMetadataPda,
+  Metadata,
+  TokenStandard,
+  updateV1,
+} from '../src';
 import { createDigitalAsset, createUmi } from './_setup';
 
 test('it can update a NonFungible', async (t) => {
@@ -11,6 +17,27 @@ test('it can update a NonFungible', async (t) => {
   const initialMetadataAccount = await fetchMetadata(umi, initialMetadata);
 
   // When we update the name of the NFT.
+  await updateV1(umi, {
+    mint: mint.publicKey,
+    data: some({ ...initialMetadataAccount, name: 'NFT #2' }),
+  }).sendAndConfirm(umi);
+
+  // Then the account data was updated.
+  const updatedMetadataAccount = await fetchMetadata(umi, initialMetadata);
+  t.like(updatedMetadataAccount, <Metadata>{ name: 'NFT #2' });
+});
+
+test('it can update a ProgrammableNonFungible', async (t) => {
+  // Given an existing PNFT.
+  const umi = await createUmi();
+  const mint = await createDigitalAsset(umi, {
+    name: 'NFT #1',
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  });
+  const initialMetadata = findMetadataPda(umi, { mint: mint.publicKey });
+  const initialMetadataAccount = await fetchMetadata(umi, initialMetadata);
+
+  // When we update the name of the PNFT.
   await updateV1(umi, {
     mint: mint.publicKey,
     data: some({ ...initialMetadataAccount, name: 'NFT #2' }),

--- a/clients/js/test/updateV1.test.ts
+++ b/clients/js/test/updateV1.test.ts
@@ -7,90 +7,33 @@ import {
   TokenStandard,
   updateV1,
 } from '../src';
-import { createDigitalAsset, createUmi } from './_setup';
+import {
+  createDigitalAsset,
+  createUmi,
+  NON_EDITION_TOKEN_STANDARDS,
+} from './_setup';
 
-test('it can update a NonFungible', async (t) => {
-  // Given an existing NonFungible.
-  const umi = await createUmi();
-  const mint = await createDigitalAsset(umi, { name: 'NonFungible #1' });
-  const initialMetadata = findMetadataPda(umi, { mint: mint.publicKey });
-  const initialMetadataAccount = await fetchMetadata(umi, initialMetadata);
+NON_EDITION_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it can update a ${tokenStandard}`, async (t) => {
+    // Given an existing asset.
+    const umi = await createUmi();
+    const mint = await createDigitalAsset(umi, {
+      name: 'Asset #1',
+      tokenStandard: TokenStandard[tokenStandard],
+    });
+    const initialMetadata = findMetadataPda(umi, { mint: mint.publicKey });
+    const initialMetadataAccount = await fetchMetadata(umi, initialMetadata);
 
-  // When we update the name of the NonFungible.
-  await updateV1(umi, {
-    mint: mint.publicKey,
-    data: some({ ...initialMetadataAccount, name: 'NonFungible #2' }),
-  }).sendAndConfirm(umi);
+    // When we update the name of the asset.
+    await updateV1(umi, {
+      mint: mint.publicKey,
+      data: some({ ...initialMetadataAccount, name: 'Asset #2' }),
+    }).sendAndConfirm(umi);
 
-  // Then the account data was updated.
-  const updatedMetadataAccount = await fetchMetadata(umi, initialMetadata);
-  t.like(updatedMetadataAccount, <Metadata>{ name: 'NonFungible #2' });
-});
-
-test('it can update a ProgrammableNonFungible', async (t) => {
-  // Given an existing ProgrammableNonFungible.
-  const umi = await createUmi();
-  const mint = await createDigitalAsset(umi, {
-    name: 'ProgrammableNonFungible #1',
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
+    // Then the account data was updated.
+    const updatedMetadataAccount = await fetchMetadata(umi, initialMetadata);
+    t.like(updatedMetadataAccount, <Metadata>{
+      name: 'Asset #2',
+    });
   });
-  const initialMetadata = findMetadataPda(umi, { mint: mint.publicKey });
-  const initialMetadataAccount = await fetchMetadata(umi, initialMetadata);
-
-  // When we update the name of the PNFT.
-  await updateV1(umi, {
-    mint: mint.publicKey,
-    data: some({
-      ...initialMetadataAccount,
-      name: 'ProgrammableNonFungible #2',
-    }),
-  }).sendAndConfirm(umi);
-
-  // Then the account data was updated.
-  const updatedMetadataAccount = await fetchMetadata(umi, initialMetadata);
-  t.like(updatedMetadataAccount, <Metadata>{
-    name: 'ProgrammableNonFungible #2',
-  });
-});
-
-test('it can update a Fungible', async (t) => {
-  // Given an existing Fungible.
-  const umi = await createUmi();
-  const mint = await createDigitalAsset(umi, {
-    name: 'Fungible #1',
-    tokenStandard: TokenStandard.Fungible,
-  });
-  const initialMetadata = findMetadataPda(umi, { mint: mint.publicKey });
-  const initialMetadataAccount = await fetchMetadata(umi, initialMetadata);
-
-  // When we update the name of the Fungible.
-  await updateV1(umi, {
-    mint: mint.publicKey,
-    data: some({ ...initialMetadataAccount, name: 'Fungible #2' }),
-  }).sendAndConfirm(umi);
-
-  // Then the account data was updated.
-  const updatedMetadataAccount = await fetchMetadata(umi, initialMetadata);
-  t.like(updatedMetadataAccount, <Metadata>{ name: 'Fungible #2' });
-});
-
-test('it can update a FungibleAsset', async (t) => {
-  // Given an existing FungibleAsset.
-  const umi = await createUmi();
-  const mint = await createDigitalAsset(umi, {
-    name: 'FungibleAsset #1',
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-  const initialMetadata = findMetadataPda(umi, { mint: mint.publicKey });
-  const initialMetadataAccount = await fetchMetadata(umi, initialMetadata);
-
-  // When we update the name of the FungibleAsset.
-  await updateV1(umi, {
-    mint: mint.publicKey,
-    data: some({ ...initialMetadataAccount, name: 'FungibleAsset #2' }),
-  }).sendAndConfirm(umi);
-
-  // Then the account data was updated.
-  const updatedMetadataAccount = await fetchMetadata(umi, initialMetadata);
-  t.like(updatedMetadataAccount, <Metadata>{ name: 'FungibleAsset #2' });
 });

--- a/clients/js/test/verifyCollectionV1.test.ts
+++ b/clients/js/test/verifyCollectionV1.test.ts
@@ -10,16 +10,13 @@ import {
   findMetadataPda,
   verifyCollectionV1,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
+import {
+  NON_EDITION_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
-const tokenStandards: Array<keyof typeof TokenStandard> = [
-  'NonFungible',
-  'ProgrammableNonFungible',
-  'Fungible',
-  'FungibleAsset',
-];
-
-tokenStandards.forEach((tokenStandard) => {
+NON_EDITION_TOKEN_STANDARDS.forEach((tokenStandard) => {
   test(`it can verify the collection of a ${tokenStandard}`, async (t) => {
     // Given an asset with an unverified collection.
     const umi = await createUmi();

--- a/clients/js/test/verifyCollectionV1.test.ts
+++ b/clients/js/test/verifyCollectionV1.test.ts
@@ -1,0 +1,36 @@
+import { generateSigner, publicKey, some } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  Metadata,
+  fetchMetadata,
+  findMetadataPda,
+  verifyCollectionV1,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can verify the collection of a NonFungible', async (t) => {
+  // Given a NonFungible with an unverified collection.
+  const umi = await createUmi();
+  const collectionAuthority = generateSigner(umi);
+  const { publicKey: collectionMint } = await createDigitalAssetWithToken(umi, {
+    isCollection: true,
+    authority: collectionAuthority,
+  });
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    collection: some({ key: collectionMint, verified: false }),
+  });
+
+  // When the collection authority verifies the collection on the asset.
+  const metadata = findMetadataPda(umi, { mint });
+  await verifyCollectionV1(umi, {
+    metadata,
+    collectionMint,
+    authority: collectionAuthority,
+  }).sendAndConfirm(umi);
+
+  // Then the collection is now marked as verified on the asset.
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    publicKey: publicKey(metadata),
+    collection: some({ key: collectionMint, verified: true }),
+  });
+});

--- a/clients/js/test/verifyCollectionV1.test.ts
+++ b/clients/js/test/verifyCollectionV1.test.ts
@@ -12,264 +12,78 @@ import {
 } from '../src';
 import { createDigitalAssetWithToken, createUmi } from './_setup';
 
-test('it can verify the collection of a NonFungible', async (t) => {
-  // Given a NonFungible with an unverified collection.
-  const umi = await createUmi();
-  const collectionAuthority = generateSigner(umi);
-  const { publicKey: collectionMint } = await createDigitalAssetWithToken(umi, {
-    isCollection: true,
-    authority: collectionAuthority,
-  });
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    collection: some({ key: collectionMint, verified: false }),
+const tokenStandards: Array<keyof typeof TokenStandard> = [
+  'NonFungible',
+  'ProgrammableNonFungible',
+  'Fungible',
+  'FungibleAsset',
+];
+
+tokenStandards.forEach((tokenStandard) => {
+  test(`it can verify the collection of a ${tokenStandard}`, async (t) => {
+    // Given an asset with an unverified collection.
+    const umi = await createUmi();
+    const collectionAuthority = generateSigner(umi);
+    const { publicKey: collectionMint } = await createDigitalAssetWithToken(
+      umi,
+      { isCollection: true, authority: collectionAuthority }
+    );
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      collection: some({ key: collectionMint, verified: false }),
+      tokenStandard: TokenStandard[tokenStandard],
+    });
+
+    // When the collection authority verifies the collection on the asset.
+    const metadata = findMetadataPda(umi, { mint });
+    await verifyCollectionV1(umi, {
+      metadata,
+      collectionMint,
+      authority: collectionAuthority,
+    }).sendAndConfirm(umi);
+
+    // Then the collection is now marked as verified on the asset.
+    t.like(await fetchMetadata(umi, metadata), <Metadata>{
+      publicKey: publicKey(metadata),
+      collection: some({ key: collectionMint, verified: true }),
+    });
   });
 
-  // When the collection authority verifies the collection on the asset.
-  const metadata = findMetadataPda(umi, { mint });
-  await verifyCollectionV1(umi, {
-    metadata,
-    collectionMint,
-    authority: collectionAuthority,
-  }).sendAndConfirm(umi);
-
-  // Then the collection is now marked as verified on the asset.
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    publicKey: publicKey(metadata),
-    collection: some({ key: collectionMint, verified: true }),
-  });
-});
-
-test('it can verify the collection of a ProgrammableNonFungible', async (t) => {
-  // Given a ProgrammableNonFungible with an unverified collection.
-  const umi = await createUmi();
-  const collectionAuthority = generateSigner(umi);
-  const { publicKey: collectionMint } = await createDigitalAssetWithToken(umi, {
-    isCollection: true,
-    authority: collectionAuthority,
-  });
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    collection: some({ key: collectionMint, verified: false }),
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-  });
-
-  // When the collection authority verifies the collection on the asset.
-  const metadata = findMetadataPda(umi, { mint });
-  await verifyCollectionV1(umi, {
-    metadata,
-    collectionMint,
-    authority: collectionAuthority,
-  }).sendAndConfirm(umi);
-
-  // Then the collection is now marked as verified on the asset.
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    publicKey: publicKey(metadata),
-    collection: some({ key: collectionMint, verified: true }),
-  });
-});
-
-test('it can verify the collection of a Fungible', async (t) => {
-  // Given a Fungible with an unverified collection.
-  const umi = await createUmi();
-  const collectionAuthority = generateSigner(umi);
-  const { publicKey: collectionMint } = await createDigitalAssetWithToken(umi, {
-    isCollection: true,
-    authority: collectionAuthority,
-  });
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    collection: some({ key: collectionMint, verified: false }),
-    tokenStandard: TokenStandard.Fungible,
-  });
-
-  // When the collection authority verifies the collection on the asset.
-  const metadata = findMetadataPda(umi, { mint });
-  await verifyCollectionV1(umi, {
-    metadata,
-    collectionMint,
-    authority: collectionAuthority,
-  }).sendAndConfirm(umi);
-
-  // Then the collection is now marked as verified on the asset.
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    publicKey: publicKey(metadata),
-    collection: some({ key: collectionMint, verified: true }),
-  });
-});
-
-test('it can verify the collection of a FungibleAsset', async (t) => {
-  // Given a FungibleAsset with an unverified collection.
-  const umi = await createUmi();
-  const collectionAuthority = generateSigner(umi);
-  const { publicKey: collectionMint } = await createDigitalAssetWithToken(umi, {
-    isCollection: true,
-    authority: collectionAuthority,
-  });
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    collection: some({ key: collectionMint, verified: false }),
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-
-  // When the collection authority verifies the collection on the asset.
-  const metadata = findMetadataPda(umi, { mint });
-  await verifyCollectionV1(umi, {
-    metadata,
-    collectionMint,
-    authority: collectionAuthority,
-  }).sendAndConfirm(umi);
-
-  // Then the collection is now marked as verified on the asset.
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    publicKey: publicKey(metadata),
-    collection: some({ key: collectionMint, verified: true }),
-  });
-});
-
-test('it can verify the collection of a NonFungible as a delegate', async (t) => {
-  // Given a NonFungible with an unverified collection that as a delegate.
-  const umi = await createUmi();
-  const collectionDelegate = generateSigner(umi);
-  const { publicKey: collectionMint } = await createDigitalAssetWithToken(umi, {
-    isCollection: true,
-  });
-  await delegateCollectionV1(umi, {
-    mint: collectionMint,
-    delegate: collectionDelegate.publicKey,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    collection: some({ key: collectionMint, verified: false }),
-  });
-
-  // When the collection delegate verifies the collection on the asset.
-  const metadata = findMetadataPda(umi, { mint });
-  await verifyCollectionV1(umi, {
-    metadata,
-    collectionMint,
-    authority: collectionDelegate,
-    delegateRecord: findMetadataDelegateRecordPda(umi, {
+  test(`it can verify the collection of a ${tokenStandard} as a delegate`, async (t) => {
+    // Given an asset with an unverified collection that as a delegate.
+    const umi = await createUmi();
+    const collectionDelegate = generateSigner(umi);
+    const { publicKey: collectionMint } = await createDigitalAssetWithToken(
+      umi,
+      { isCollection: true }
+    );
+    await delegateCollectionV1(umi, {
       mint: collectionMint,
-      delegateRole: MetadataDelegateRole.Collection,
       delegate: collectionDelegate.publicKey,
-      updateAuthority: umi.identity.publicKey,
-    }),
-  }).sendAndConfirm(umi);
+      tokenStandard: TokenStandard.NonFungible,
+    }).sendAndConfirm(umi);
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      collection: some({ key: collectionMint, verified: false }),
+      tokenStandard: TokenStandard[tokenStandard],
+    });
 
-  // Then the collection is now marked as verified on the asset.
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    publicKey: publicKey(metadata),
-    collection: some({ key: collectionMint, verified: true }),
-  });
-});
+    // When the collection delegate verifies the collection on the asset.
+    const metadata = findMetadataPda(umi, { mint });
+    await verifyCollectionV1(umi, {
+      metadata,
+      collectionMint,
+      authority: collectionDelegate,
+      delegateRecord: findMetadataDelegateRecordPda(umi, {
+        mint: collectionMint,
+        delegateRole: MetadataDelegateRole.Collection,
+        delegate: collectionDelegate.publicKey,
+        updateAuthority: umi.identity.publicKey,
+      }),
+    }).sendAndConfirm(umi);
 
-test('it can verify the collection of a ProgrammableNonFungible as a delegate', async (t) => {
-  // Given a ProgrammableNonFungible with an unverified collection that as a delegate.
-  const umi = await createUmi();
-  const collectionDelegate = generateSigner(umi);
-  const { publicKey: collectionMint } = await createDigitalAssetWithToken(umi, {
-    isCollection: true,
-  });
-  await delegateCollectionV1(umi, {
-    mint: collectionMint,
-    delegate: collectionDelegate.publicKey,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    collection: some({ key: collectionMint, verified: false }),
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-  });
-
-  // When the collection delegate verifies the collection on the asset.
-  const metadata = findMetadataPda(umi, { mint });
-  await verifyCollectionV1(umi, {
-    metadata,
-    collectionMint,
-    authority: collectionDelegate,
-    delegateRecord: findMetadataDelegateRecordPda(umi, {
-      mint: collectionMint,
-      delegateRole: MetadataDelegateRole.Collection,
-      delegate: collectionDelegate.publicKey,
-      updateAuthority: umi.identity.publicKey,
-    }),
-  }).sendAndConfirm(umi);
-
-  // Then the collection is now marked as verified on the asset.
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    publicKey: publicKey(metadata),
-    collection: some({ key: collectionMint, verified: true }),
-  });
-});
-
-test('it can verify the collection of a Fungible as a delegate', async (t) => {
-  // Given a Fungible with an unverified collection that as a delegate.
-  const umi = await createUmi();
-  const collectionDelegate = generateSigner(umi);
-  const { publicKey: collectionMint } = await createDigitalAssetWithToken(umi, {
-    isCollection: true,
-  });
-  await delegateCollectionV1(umi, {
-    mint: collectionMint,
-    delegate: collectionDelegate.publicKey,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    collection: some({ key: collectionMint, verified: false }),
-    tokenStandard: TokenStandard.Fungible,
-  });
-
-  // When the collection delegate verifies the collection on the asset.
-  const metadata = findMetadataPda(umi, { mint });
-  await verifyCollectionV1(umi, {
-    metadata,
-    collectionMint,
-    authority: collectionDelegate,
-    delegateRecord: findMetadataDelegateRecordPda(umi, {
-      mint: collectionMint,
-      delegateRole: MetadataDelegateRole.Collection,
-      delegate: collectionDelegate.publicKey,
-      updateAuthority: umi.identity.publicKey,
-    }),
-  }).sendAndConfirm(umi);
-
-  // Then the collection is now marked as verified on the asset.
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    publicKey: publicKey(metadata),
-    collection: some({ key: collectionMint, verified: true }),
-  });
-});
-
-test('it can verify the collection of a FungibleAsset as a delegate', async (t) => {
-  // Given a FungibleAsset with an unverified collection that as a delegate.
-  const umi = await createUmi();
-  const collectionDelegate = generateSigner(umi);
-  const { publicKey: collectionMint } = await createDigitalAssetWithToken(umi, {
-    isCollection: true,
-  });
-  await delegateCollectionV1(umi, {
-    mint: collectionMint,
-    delegate: collectionDelegate.publicKey,
-    tokenStandard: TokenStandard.NonFungible,
-  }).sendAndConfirm(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    collection: some({ key: collectionMint, verified: false }),
-    tokenStandard: TokenStandard.FungibleAsset,
-  });
-
-  // When the collection delegate verifies the collection on the asset.
-  const metadata = findMetadataPda(umi, { mint });
-  await verifyCollectionV1(umi, {
-    metadata,
-    collectionMint,
-    authority: collectionDelegate,
-    delegateRecord: findMetadataDelegateRecordPda(umi, {
-      mint: collectionMint,
-      delegateRole: MetadataDelegateRole.Collection,
-      delegate: collectionDelegate.publicKey,
-      updateAuthority: umi.identity.publicKey,
-    }),
-  }).sendAndConfirm(umi);
-
-  // Then the collection is now marked as verified on the asset.
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    publicKey: publicKey(metadata),
-    collection: some({ key: collectionMint, verified: true }),
+    // Then the collection is now marked as verified on the asset.
+    t.like(await fetchMetadata(umi, metadata), <Metadata>{
+      publicKey: publicKey(metadata),
+      collection: some({ key: collectionMint, verified: true }),
+    });
   });
 });

--- a/clients/js/test/verifyCollectionV1.test.ts
+++ b/clients/js/test/verifyCollectionV1.test.ts
@@ -39,6 +39,90 @@ test('it can verify the collection of a NonFungible', async (t) => {
   });
 });
 
+test('it can verify the collection of a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible with an unverified collection.
+  const umi = await createUmi();
+  const collectionAuthority = generateSigner(umi);
+  const { publicKey: collectionMint } = await createDigitalAssetWithToken(umi, {
+    isCollection: true,
+    authority: collectionAuthority,
+  });
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    collection: some({ key: collectionMint, verified: false }),
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  });
+
+  // When the collection authority verifies the collection on the asset.
+  const metadata = findMetadataPda(umi, { mint });
+  await verifyCollectionV1(umi, {
+    metadata,
+    collectionMint,
+    authority: collectionAuthority,
+  }).sendAndConfirm(umi);
+
+  // Then the collection is now marked as verified on the asset.
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    publicKey: publicKey(metadata),
+    collection: some({ key: collectionMint, verified: true }),
+  });
+});
+
+test('it can verify the collection of a Fungible', async (t) => {
+  // Given a Fungible with an unverified collection.
+  const umi = await createUmi();
+  const collectionAuthority = generateSigner(umi);
+  const { publicKey: collectionMint } = await createDigitalAssetWithToken(umi, {
+    isCollection: true,
+    authority: collectionAuthority,
+  });
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    collection: some({ key: collectionMint, verified: false }),
+    tokenStandard: TokenStandard.Fungible,
+  });
+
+  // When the collection authority verifies the collection on the asset.
+  const metadata = findMetadataPda(umi, { mint });
+  await verifyCollectionV1(umi, {
+    metadata,
+    collectionMint,
+    authority: collectionAuthority,
+  }).sendAndConfirm(umi);
+
+  // Then the collection is now marked as verified on the asset.
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    publicKey: publicKey(metadata),
+    collection: some({ key: collectionMint, verified: true }),
+  });
+});
+
+test('it can verify the collection of a FungibleAsset', async (t) => {
+  // Given a FungibleAsset with an unverified collection.
+  const umi = await createUmi();
+  const collectionAuthority = generateSigner(umi);
+  const { publicKey: collectionMint } = await createDigitalAssetWithToken(umi, {
+    isCollection: true,
+    authority: collectionAuthority,
+  });
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    collection: some({ key: collectionMint, verified: false }),
+    tokenStandard: TokenStandard.FungibleAsset,
+  });
+
+  // When the collection authority verifies the collection on the asset.
+  const metadata = findMetadataPda(umi, { mint });
+  await verifyCollectionV1(umi, {
+    metadata,
+    collectionMint,
+    authority: collectionAuthority,
+  }).sendAndConfirm(umi);
+
+  // Then the collection is now marked as verified on the asset.
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    publicKey: publicKey(metadata),
+    collection: some({ key: collectionMint, verified: true }),
+  });
+});
+
 test('it can verify the collection of a NonFungible as a delegate', async (t) => {
   // Given a NonFungible with an unverified collection that as a delegate.
   const umi = await createUmi();
@@ -53,6 +137,120 @@ test('it can verify the collection of a NonFungible as a delegate', async (t) =>
   }).sendAndConfirm(umi);
   const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
     collection: some({ key: collectionMint, verified: false }),
+  });
+
+  // When the collection delegate verifies the collection on the asset.
+  const metadata = findMetadataPda(umi, { mint });
+  await verifyCollectionV1(umi, {
+    metadata,
+    collectionMint,
+    authority: collectionDelegate,
+    delegateRecord: findMetadataDelegateRecordPda(umi, {
+      mint: collectionMint,
+      delegateRole: MetadataDelegateRole.Collection,
+      delegate: collectionDelegate.publicKey,
+      updateAuthority: umi.identity.publicKey,
+    }),
+  }).sendAndConfirm(umi);
+
+  // Then the collection is now marked as verified on the asset.
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    publicKey: publicKey(metadata),
+    collection: some({ key: collectionMint, verified: true }),
+  });
+});
+
+test('it can verify the collection of a ProgrammableNonFungible as a delegate', async (t) => {
+  // Given a ProgrammableNonFungible with an unverified collection that as a delegate.
+  const umi = await createUmi();
+  const collectionDelegate = generateSigner(umi);
+  const { publicKey: collectionMint } = await createDigitalAssetWithToken(umi, {
+    isCollection: true,
+  });
+  await delegateCollectionV1(umi, {
+    mint: collectionMint,
+    delegate: collectionDelegate.publicKey,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    collection: some({ key: collectionMint, verified: false }),
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+  });
+
+  // When the collection delegate verifies the collection on the asset.
+  const metadata = findMetadataPda(umi, { mint });
+  await verifyCollectionV1(umi, {
+    metadata,
+    collectionMint,
+    authority: collectionDelegate,
+    delegateRecord: findMetadataDelegateRecordPda(umi, {
+      mint: collectionMint,
+      delegateRole: MetadataDelegateRole.Collection,
+      delegate: collectionDelegate.publicKey,
+      updateAuthority: umi.identity.publicKey,
+    }),
+  }).sendAndConfirm(umi);
+
+  // Then the collection is now marked as verified on the asset.
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    publicKey: publicKey(metadata),
+    collection: some({ key: collectionMint, verified: true }),
+  });
+});
+
+test('it can verify the collection of a Fungible as a delegate', async (t) => {
+  // Given a Fungible with an unverified collection that as a delegate.
+  const umi = await createUmi();
+  const collectionDelegate = generateSigner(umi);
+  const { publicKey: collectionMint } = await createDigitalAssetWithToken(umi, {
+    isCollection: true,
+  });
+  await delegateCollectionV1(umi, {
+    mint: collectionMint,
+    delegate: collectionDelegate.publicKey,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    collection: some({ key: collectionMint, verified: false }),
+    tokenStandard: TokenStandard.Fungible,
+  });
+
+  // When the collection delegate verifies the collection on the asset.
+  const metadata = findMetadataPda(umi, { mint });
+  await verifyCollectionV1(umi, {
+    metadata,
+    collectionMint,
+    authority: collectionDelegate,
+    delegateRecord: findMetadataDelegateRecordPda(umi, {
+      mint: collectionMint,
+      delegateRole: MetadataDelegateRole.Collection,
+      delegate: collectionDelegate.publicKey,
+      updateAuthority: umi.identity.publicKey,
+    }),
+  }).sendAndConfirm(umi);
+
+  // Then the collection is now marked as verified on the asset.
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    publicKey: publicKey(metadata),
+    collection: some({ key: collectionMint, verified: true }),
+  });
+});
+
+test('it can verify the collection of a FungibleAsset as a delegate', async (t) => {
+  // Given a FungibleAsset with an unverified collection that as a delegate.
+  const umi = await createUmi();
+  const collectionDelegate = generateSigner(umi);
+  const { publicKey: collectionMint } = await createDigitalAssetWithToken(umi, {
+    isCollection: true,
+  });
+  await delegateCollectionV1(umi, {
+    mint: collectionMint,
+    delegate: collectionDelegate.publicKey,
+    tokenStandard: TokenStandard.NonFungible,
+  }).sendAndConfirm(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    collection: some({ key: collectionMint, verified: false }),
+    tokenStandard: TokenStandard.FungibleAsset,
   });
 
   // When the collection delegate verifies the collection on the asset.

--- a/clients/js/test/verifyCreatorV1.test.ts
+++ b/clients/js/test/verifyCreatorV1.test.ts
@@ -7,111 +7,37 @@ import {
   findMetadataPda,
   verifyCreatorV1,
 } from '../src';
-import { createDigitalAssetWithToken, createUmi } from './_setup';
+import {
+  NON_EDITION_TOKEN_STANDARDS,
+  createDigitalAssetWithToken,
+  createUmi,
+} from './_setup';
 
-test('it can verify the creator of a NonFungible', async (t) => {
-  // Given a NonFungible with an unverified creator.
-  const umi = await createUmi();
-  const creator = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    creators: some([
-      { address: creator.publicKey, verified: false, share: 100 },
-    ]),
-  });
+NON_EDITION_TOKEN_STANDARDS.forEach((tokenStandard) => {
+  test(`it can verify the creator of a ${tokenStandard}`, async (t) => {
+    // Given an asset with an unverified creator.
+    const umi = await createUmi();
+    const creator = generateSigner(umi);
+    const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+      tokenStandard: TokenStandard[tokenStandard],
+      creators: some([
+        { address: creator.publicKey, verified: false, share: 100 },
+      ]),
+    });
 
-  // When the creator verifies themselves on the asset.
-  const metadata = findMetadataPda(umi, { mint });
-  await verifyCreatorV1(umi, {
-    metadata,
-    authority: creator,
-  }).sendAndConfirm(umi);
+    // When the creator verifies themselves on the asset.
+    const metadata = findMetadataPda(umi, { mint });
+    await verifyCreatorV1(umi, {
+      metadata,
+      authority: creator,
+    }).sendAndConfirm(umi);
 
-  // Then the creator is now marked as verified on the asset.
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    publicKey: publicKey(metadata),
-    creators: some([
-      { address: creator.publicKey, verified: true, share: 100 },
-    ]),
-  });
-});
-
-test('it can verify the creator of a ProgrammableNonFungible', async (t) => {
-  // Given a ProgrammableNonFungible with an unverified creator.
-  const umi = await createUmi();
-  const creator = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenStandard: TokenStandard.ProgrammableNonFungible,
-    creators: some([
-      { address: creator.publicKey, verified: false, share: 100 },
-    ]),
-  });
-
-  // When the creator verifies themselves on the asset.
-  const metadata = findMetadataPda(umi, { mint });
-  await verifyCreatorV1(umi, {
-    metadata,
-    authority: creator,
-  }).sendAndConfirm(umi);
-
-  // Then the creator is now marked as verified on the asset.
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    publicKey: publicKey(metadata),
-    creators: some([
-      { address: creator.publicKey, verified: true, share: 100 },
-    ]),
-  });
-});
-
-test('it can verify the creator of a Fungible', async (t) => {
-  // Given a Fungible with an unverified creator.
-  const umi = await createUmi();
-  const creator = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenStandard: TokenStandard.Fungible,
-    creators: some([
-      { address: creator.publicKey, verified: false, share: 100 },
-    ]),
-  });
-
-  // When the creator verifies themselves on the asset.
-  const metadata = findMetadataPda(umi, { mint });
-  await verifyCreatorV1(umi, {
-    metadata,
-    authority: creator,
-  }).sendAndConfirm(umi);
-
-  // Then the creator is now marked as verified on the asset.
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    publicKey: publicKey(metadata),
-    creators: some([
-      { address: creator.publicKey, verified: true, share: 100 },
-    ]),
-  });
-});
-
-test('it can verify the creator of a FungibleAsset', async (t) => {
-  // Given a FungibleAsset with an unverified creator.
-  const umi = await createUmi();
-  const creator = generateSigner(umi);
-  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
-    tokenStandard: TokenStandard.FungibleAsset,
-    creators: some([
-      { address: creator.publicKey, verified: false, share: 100 },
-    ]),
-  });
-
-  // When the creator verifies themselves on the asset.
-  const metadata = findMetadataPda(umi, { mint });
-  await verifyCreatorV1(umi, {
-    metadata,
-    authority: creator,
-  }).sendAndConfirm(umi);
-
-  // Then the creator is now marked as verified on the asset.
-  t.like(await fetchMetadata(umi, metadata), <Metadata>{
-    publicKey: publicKey(metadata),
-    creators: some([
-      { address: creator.publicKey, verified: true, share: 100 },
-    ]),
+    // Then the creator is now marked as verified on the asset.
+    t.like(await fetchMetadata(umi, metadata), <Metadata>{
+      publicKey: publicKey(metadata),
+      creators: some([
+        { address: creator.publicKey, verified: true, share: 100 },
+      ]),
+    });
   });
 });

--- a/clients/js/test/verifyCreatorV1.test.ts
+++ b/clients/js/test/verifyCreatorV1.test.ts
@@ -1,0 +1,117 @@
+import { generateSigner, publicKey, some } from '@metaplex-foundation/umi';
+import test from 'ava';
+import {
+  Metadata,
+  TokenStandard,
+  fetchMetadata,
+  findMetadataPda,
+  verifyCreatorV1,
+} from '../src';
+import { createDigitalAssetWithToken, createUmi } from './_setup';
+
+test('it can verify the creator of a NonFungible', async (t) => {
+  // Given a NonFungible with an unverified creator.
+  const umi = await createUmi();
+  const creator = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    creators: some([
+      { address: creator.publicKey, verified: false, share: 100 },
+    ]),
+  });
+
+  // When the creator verifies themselves on the asset.
+  const metadata = findMetadataPda(umi, { mint });
+  await verifyCreatorV1(umi, {
+    metadata,
+    authority: creator,
+  }).sendAndConfirm(umi);
+
+  // Then the creator is now marked as verified on the asset.
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    publicKey: publicKey(metadata),
+    creators: some([
+      { address: creator.publicKey, verified: true, share: 100 },
+    ]),
+  });
+});
+
+test('it can verify the creator of a ProgrammableNonFungible', async (t) => {
+  // Given a ProgrammableNonFungible with an unverified creator.
+  const umi = await createUmi();
+  const creator = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenStandard: TokenStandard.ProgrammableNonFungible,
+    creators: some([
+      { address: creator.publicKey, verified: false, share: 100 },
+    ]),
+  });
+
+  // When the creator verifies themselves on the asset.
+  const metadata = findMetadataPda(umi, { mint });
+  await verifyCreatorV1(umi, {
+    metadata,
+    authority: creator,
+  }).sendAndConfirm(umi);
+
+  // Then the creator is now marked as verified on the asset.
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    publicKey: publicKey(metadata),
+    creators: some([
+      { address: creator.publicKey, verified: true, share: 100 },
+    ]),
+  });
+});
+
+test('it can verify the creator of a Fungible', async (t) => {
+  // Given a Fungible with an unverified creator.
+  const umi = await createUmi();
+  const creator = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenStandard: TokenStandard.Fungible,
+    creators: some([
+      { address: creator.publicKey, verified: false, share: 100 },
+    ]),
+  });
+
+  // When the creator verifies themselves on the asset.
+  const metadata = findMetadataPda(umi, { mint });
+  await verifyCreatorV1(umi, {
+    metadata,
+    authority: creator,
+  }).sendAndConfirm(umi);
+
+  // Then the creator is now marked as verified on the asset.
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    publicKey: publicKey(metadata),
+    creators: some([
+      { address: creator.publicKey, verified: true, share: 100 },
+    ]),
+  });
+});
+
+test('it can verify the creator of a FungibleAsset', async (t) => {
+  // Given a FungibleAsset with an unverified creator.
+  const umi = await createUmi();
+  const creator = generateSigner(umi);
+  const { publicKey: mint } = await createDigitalAssetWithToken(umi, {
+    tokenStandard: TokenStandard.FungibleAsset,
+    creators: some([
+      { address: creator.publicKey, verified: false, share: 100 },
+    ]),
+  });
+
+  // When the creator verifies themselves on the asset.
+  const metadata = findMetadataPda(umi, { mint });
+  await verifyCreatorV1(umi, {
+    metadata,
+    authority: creator,
+  }).sendAndConfirm(umi);
+
+  // Then the creator is now marked as verified on the asset.
+  t.like(await fetchMetadata(umi, metadata), <Metadata>{
+    publicKey: publicKey(metadata),
+    creators: some([
+      { address: creator.publicKey, verified: true, share: 100 },
+    ]),
+  });
+});

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -224,6 +224,28 @@ kinobi.update(
         },
       },
     },
+    revoke: {
+      accounts: {
+        masterEdition: {
+          defaultsTo: k.resolverDefault("resolveMasterEdition", [
+            k.dependsOnAccount("mint"),
+            k.dependsOnArg("tokenStandard"),
+          ]),
+        },
+        tokenRecord: {
+          defaultsTo: k.resolverDefault("resolveTokenRecord", [
+            k.dependsOnAccount("mint"),
+            k.dependsOnAccount("token"),
+            k.dependsOnArg("tokenStandard"),
+          ]),
+        },
+      },
+      args: {
+        tokenStandard: {
+          type: k.linkTypeNode("tokenStandard"),
+        },
+      },
+    },
     updateMetadataAccount: {
       args: { updateAuthority: { name: "newUpdateAuthority" } },
     },
@@ -470,6 +492,22 @@ kinobi.update(
     delegateTransferV1: approveTokenDelegateDefaults,
     delegateUpdateV1: approveMetadataDelegateDefaults("Update"),
     delegateUtilityV1: approveTokenDelegateDefaults,
+    revokeCollectionV1: approveMetadataDelegateDefaults("Collection"),
+    revokeLockedTransferV1: approveTokenDelegateDefaults,
+    revokeProgrammableConfigV1:
+      approveMetadataDelegateDefaults("ProgrammableConfig"),
+    revokeSaleV1: approveTokenDelegateDefaults,
+    revokeStakingV1: approveTokenDelegateDefaults,
+    revokeStandardV1: {
+      ...approveTokenDelegateDefaults,
+      accounts: {
+        ...approveTokenDelegateDefaults.accounts,
+        tokenRecord: { defaultsTo: k.programIdDefault() },
+      },
+    },
+    revokeTransferV1: approveTokenDelegateDefaults,
+    revokeUpdateV1: approveMetadataDelegateDefaults("Update"),
+    revokeUtilityV1: approveTokenDelegateDefaults,
     verifyCollectionV1: { accounts: { ...collectionMintDefaults } },
     unverifyCollectionV1: { accounts: { ...collectionMintDefaults } },
   })

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -458,6 +458,11 @@ kinobi.update(
     delegateLockedTransferV1: approveTokenDelegateDefaults,
     delegateProgrammableConfigV1:
       approveMetadataDelegateDefaults("ProgrammableConfig"),
+    delegateSaleV1: approveTokenDelegateDefaults,
+    delegateStakingV1: approveTokenDelegateDefaults,
+    delegateStandardV1: approveTokenDelegateDefaults,
+    delegateTransferV1: approveTokenDelegateDefaults,
+    delegateUpdateV1: approveMetadataDelegateDefaults("Update"),
     delegateUtilityV1: approveTokenDelegateDefaults,
     verifyCollectionV1: { accounts: { ...collectionMintDefaults } },
     unverifyCollectionV1: { accounts: { ...collectionMintDefaults } },

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -111,7 +111,7 @@ kinobi.update(
 // Update Instructions.
 kinobi.update(
   new k.UpdateInstructionsVisitor({
-    Create: {
+    create: {
       bytesCreatedOnChain: k.bytesFromNumber(
         82 + // Mint account.
           679 + // Metadata account.
@@ -127,13 +127,35 @@ kinobi.update(
         },
       },
     },
-    Mint: {
+    mint: {
       bytesCreatedOnChain: k.bytesFromNumber(
         165 + // Token account.
           47 + // Token Record account.
           128 * 2, // 2 account headers.
         false
       ),
+    },
+    delegate: {
+      accounts: {
+        masterEdition: {
+          defaultsTo: k.resolverDefault("resolveMasterEdition", [
+            k.dependsOnAccount("mint"),
+            k.dependsOnArg("tokenStandard"),
+          ]),
+        },
+        tokenRecord: {
+          defaultsTo: k.resolverDefault("resolveTokenRecord", [
+            k.dependsOnAccount("mint"),
+            k.dependsOnAccount("token"),
+            k.dependsOnArg("tokenStandard"),
+          ]),
+        },
+      },
+      args: {
+        tokenStandard: {
+          type: k.linkTypeNode("tokenStandard"),
+        },
+      },
     },
     updateMetadataAccount: {
       args: { updateAuthority: { name: "newUpdateAuthority" } },

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -310,6 +310,40 @@ kinobi.update(
         tokenStandard: { type: k.linkTypeNode("tokenStandard") },
       },
     },
+    burn: {
+      accounts: {
+        token: {
+          isOptional: false,
+          defaultsTo: k.pdaDefault("associatedToken", {
+            importFrom: "mplEssentials",
+            seeds: {
+              mint: k.accountDefault("mint"),
+              owner: k.argDefault("tokenOwner"),
+            },
+          }),
+        },
+        edition: {
+          defaultsTo: k.resolverDefault("resolveMasterEdition", [
+            k.dependsOnAccount("mint"),
+            k.dependsOnArg("tokenStandard"),
+          ]),
+        },
+        tokenRecord: {
+          defaultsTo: k.resolverDefault("resolveTokenRecord", [
+            k.dependsOnAccount("mint"),
+            k.dependsOnAccount("token"),
+            k.dependsOnArg("tokenStandard"),
+          ]),
+        },
+      },
+      args: {
+        tokenOwner: {
+          type: k.publicKeyTypeNode(),
+          defaultsTo: k.identityDefault(),
+        },
+        tokenStandard: { type: k.linkTypeNode("tokenStandard") },
+      },
+    },
     updateMetadataAccount: {
       args: { updateAuthority: { name: "newUpdateAuthority" } },
     },

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -455,6 +455,7 @@ kinobi.update(
       },
     },
     delegateCollectionV1: approveMetadataDelegateDefaults("Collection"),
+    delegateLockedTransferV1: approveTokenDelegateDefaults,
     delegateUtilityV1: approveTokenDelegateDefaults,
     verifyCollectionV1: { accounts: { ...collectionMintDefaults } },
     unverifyCollectionV1: { accounts: { ...collectionMintDefaults } },

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -402,6 +402,21 @@ kinobi.update(
         tokenStandard: { type: k.linkTypeNode("tokenStandard") },
       },
     },
+    delegateUtilityV1: {
+      accounts: {
+        token: { isOptional: false, defaultsTo: null },
+        delegateRecord: { defaultsTo: k.pdaDefault("tokenRecord") },
+        splTokenProgram: {
+          defaultsTo: k.programDefault(
+            "splToken",
+            "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+          ),
+        },
+      },
+    },
+    delegateUpdateV1: {
+      accounts: {},
+    },
     verifyCollectionV1: { accounts: { ...collectionMintDefaults } },
     unverifyCollectionV1: { accounts: { ...collectionMintDefaults } },
   })

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -201,6 +201,10 @@ kinobi.update(
     "mintArgs.V1": {
       authorizationData: k.vNone(),
     },
+    "transferArgs.V1": {
+      authorizationData: k.vNone(),
+      amount: k.vScalar(1),
+    },
   })
 );
 
@@ -235,6 +239,11 @@ kinobi.update(
 );
 
 // Update versioned instructions.
+const ataPdaDefault = (mint = "mint", owner = "owner") =>
+  k.pdaDefault("associatedToken", {
+    importFrom: "mplEssentials",
+    seeds: { mint: k.accountDefault(mint), owner: k.accountDefault(owner) },
+  });
 const collectionMintDefaults = {
   collectionMint: { isOptional: false, defaultsTo: null },
   collectionMetadata: {
@@ -299,18 +308,10 @@ kinobi.update(
           ]),
         },
         tokenOwner: {
-          defaultsTo: k.resolverDefault("resolveMintTokenOwner", [], {
-            resolvedIsOptional: false,
-          }),
+          defaultsTo: k.resolverDefault("resolveMintTokenOwner", []),
         },
         token: {
-          defaultsTo: k.pdaDefault("associatedToken", {
-            importFrom: "mplEssentials",
-            seeds: {
-              mint: k.accountDefault("mint"),
-              owner: k.accountDefault("tokenOwner"),
-            },
-          }),
+          defaultsTo: ataPdaDefault("mint", "tokenOwner"),
         },
         tokenRecord: {
           defaultsTo: k.resolverDefault("resolveTokenRecord", [
@@ -318,6 +319,30 @@ kinobi.update(
             k.dependsOnAccount("token"),
             k.dependsOnArg("tokenStandard"),
           ]),
+        },
+      },
+      args: {
+        tokenStandard: { type: k.linkTypeNode("tokenStandard") },
+      },
+    },
+    transferV1: {
+      accounts: {
+        token: {
+          defaultsTo: ataPdaDefault("mint", "tokenOwner"),
+        },
+        tokenOwner: {
+          defaultsTo: k.identityDefault(),
+        },
+        ownerTokenRecord: {
+          name: "tokenRecord",
+          defaultsTo: k.resolverDefault("resolveTokenRecord", [
+            k.dependsOnAccount("mint"),
+            k.dependsOnAccount("token"),
+            k.dependsOnArg("tokenStandard"),
+          ]),
+        },
+        destination: {
+          name: "destinationToken",
         },
       },
       args: {

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -328,6 +328,11 @@ kinobi.update(
             k.dependsOnArg("tokenStandard"),
           ]),
         },
+        masterEdition: {
+          defaultsTo: k.resolverDefault("resolveBurnMasterEdition", [
+            k.dependsOnAccount("masterEditionMint"),
+          ]),
+        },
         tokenRecord: {
           defaultsTo: k.resolverDefault("resolveTokenRecord", [
             k.dependsOnAccount("mint"),

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -202,13 +202,8 @@ kinobi.update(
       collectionDetails: k.vEnum("CollectionDetailsToggle", "None", "empty"),
       uses: k.vEnum("UsesToggle", "None", "empty"),
       ruleSet: k.vEnum("RuleSetToggle", "None", "empty"),
-      authorizationData: k.vNone(),
-    },
-    "mintArgs.V1": {
-      authorizationData: k.vNone(),
     },
     "transferArgs.V1": {
-      authorizationData: k.vNone(),
       amount: k.vScalar(1),
     },
   })

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -379,6 +379,26 @@ const approveTokenDelegateDefaults = {
     },
   },
 };
+const approveMetadataDelegateDefaults = (role) => ({
+  accounts: {
+    delegateRecord: {
+      defaultsTo: k.pdaDefault("metadataDelegateRecord", {
+        seeds: {
+          mint: k.accountDefault("mint"),
+          delegateRole: k.valueDefault(k.vEnum("MetadataDelegateRole", role)),
+          updateAuthority: k.argDefault("updateAuthority"),
+          delegate: k.accountDefault("delegate"),
+        },
+      }),
+    },
+  },
+  args: {
+    updateAuthority: {
+      type: k.publicKeyTypeNode(),
+      defaultsTo: k.identityDefault(),
+    },
+  },
+});
 const collectionMintDefaults = {
   collectionMint: { isOptional: false, defaultsTo: null },
   collectionMetadata: {
@@ -434,28 +454,7 @@ kinobi.update(
         },
       },
     },
-    delegateCollectionV1: {
-      accounts: {
-        delegateRecord: {
-          defaultsTo: k.pdaDefault("metadataDelegateRecord", {
-            seeds: {
-              mint: k.accountDefault("mint"),
-              delegateRole: k.valueDefault(
-                k.vEnum("MetadataDelegateRole", "Collection")
-              ),
-              updateAuthority: k.argDefault("updateAuthority"),
-              delegate: k.accountDefault("delegate"),
-            },
-          }),
-        },
-      },
-      args: {
-        updateAuthority: {
-          type: k.publicKeyTypeNode(),
-          defaultsTo: k.identityDefault(),
-        },
-      },
-    },
+    delegateCollectionV1: approveMetadataDelegateDefaults("Collection"),
     delegateUtilityV1: approveTokenDelegateDefaults,
     verifyCollectionV1: { accounts: { ...collectionMintDefaults } },
     unverifyCollectionV1: { accounts: { ...collectionMintDefaults } },

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -404,13 +404,28 @@ kinobi.update(
     },
     delegateUtilityV1: {
       accounts: {
-        token: { isOptional: false, defaultsTo: null },
+        token: {
+          isOptional: false,
+          defaultsTo: k.pdaDefault("associatedToken", {
+            importFrom: "mplEssentials",
+            seeds: {
+              mint: k.accountDefault("mint"),
+              owner: k.argDefault("tokenOwner"),
+            },
+          }),
+        },
         delegateRecord: { defaultsTo: k.pdaDefault("tokenRecord") },
         splTokenProgram: {
           defaultsTo: k.programDefault(
             "splToken",
             "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
           ),
+        },
+      },
+      args: {
+        tokenOwner: {
+          type: k.publicKeyTypeNode(),
+          defaultsTo: k.identityDefault(),
         },
       },
     },

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -374,7 +374,7 @@ kinobi.update(
 );
 
 // Update versioned instructions.
-const approveTokenDelegateDefaults = {
+const tokenDelegateDefaults = {
   accounts: {
     token: {
       isOptional: false,
@@ -401,7 +401,7 @@ const approveTokenDelegateDefaults = {
     },
   },
 };
-const approveMetadataDelegateDefaults = (role) => ({
+const metadataDelegateDefaults = (role) => ({
   accounts: {
     delegateRecord: {
       defaultsTo: k.pdaDefault("metadataDelegateRecord", {
@@ -476,38 +476,37 @@ kinobi.update(
         },
       },
     },
-    delegateCollectionV1: approveMetadataDelegateDefaults("Collection"),
-    delegateLockedTransferV1: approveTokenDelegateDefaults,
+    delegateCollectionV1: metadataDelegateDefaults("Collection"),
+    delegateLockedTransferV1: tokenDelegateDefaults,
     delegateProgrammableConfigV1:
-      approveMetadataDelegateDefaults("ProgrammableConfig"),
-    delegateSaleV1: approveTokenDelegateDefaults,
-    delegateStakingV1: approveTokenDelegateDefaults,
+      metadataDelegateDefaults("ProgrammableConfig"),
+    delegateSaleV1: tokenDelegateDefaults,
+    delegateStakingV1: tokenDelegateDefaults,
     delegateStandardV1: {
-      ...approveTokenDelegateDefaults,
+      ...tokenDelegateDefaults,
       accounts: {
-        ...approveTokenDelegateDefaults.accounts,
+        ...tokenDelegateDefaults.accounts,
         tokenRecord: { defaultsTo: k.programIdDefault() },
       },
     },
-    delegateTransferV1: approveTokenDelegateDefaults,
-    delegateUpdateV1: approveMetadataDelegateDefaults("Update"),
-    delegateUtilityV1: approveTokenDelegateDefaults,
-    revokeCollectionV1: approveMetadataDelegateDefaults("Collection"),
-    revokeLockedTransferV1: approveTokenDelegateDefaults,
-    revokeProgrammableConfigV1:
-      approveMetadataDelegateDefaults("ProgrammableConfig"),
-    revokeSaleV1: approveTokenDelegateDefaults,
-    revokeStakingV1: approveTokenDelegateDefaults,
+    delegateTransferV1: tokenDelegateDefaults,
+    delegateUpdateV1: metadataDelegateDefaults("Update"),
+    delegateUtilityV1: tokenDelegateDefaults,
+    revokeCollectionV1: metadataDelegateDefaults("Collection"),
+    revokeLockedTransferV1: tokenDelegateDefaults,
+    revokeProgrammableConfigV1: metadataDelegateDefaults("ProgrammableConfig"),
+    revokeSaleV1: tokenDelegateDefaults,
+    revokeStakingV1: tokenDelegateDefaults,
     revokeStandardV1: {
-      ...approveTokenDelegateDefaults,
+      ...tokenDelegateDefaults,
       accounts: {
-        ...approveTokenDelegateDefaults.accounts,
+        ...tokenDelegateDefaults.accounts,
         tokenRecord: { defaultsTo: k.programIdDefault() },
       },
     },
-    revokeTransferV1: approveTokenDelegateDefaults,
-    revokeUpdateV1: approveMetadataDelegateDefaults("Update"),
-    revokeUtilityV1: approveTokenDelegateDefaults,
+    revokeTransferV1: tokenDelegateDefaults,
+    revokeUpdateV1: metadataDelegateDefaults("Update"),
+    revokeUtilityV1: tokenDelegateDefaults,
     verifyCollectionV1: { accounts: { ...collectionMintDefaults } },
     unverifyCollectionV1: { accounts: { ...collectionMintDefaults } },
   })

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -434,10 +434,29 @@ kinobi.update(
         },
       },
     },
-    delegateUtilityV1: approveTokenDelegateDefaults,
-    delegateUpdateV1: {
-      accounts: {},
+    delegateCollectionV1: {
+      accounts: {
+        delegateRecord: {
+          defaultsTo: k.pdaDefault("metadataDelegateRecord", {
+            seeds: {
+              mint: k.accountDefault("mint"),
+              delegateRole: k.valueDefault(
+                k.vEnum("MetadataDelegateRole", "Collection")
+              ),
+              updateAuthority: k.argDefault("updateAuthority"),
+              delegate: k.accountDefault("delegate"),
+            },
+          }),
+        },
+      },
+      args: {
+        updateAuthority: {
+          type: k.publicKeyTypeNode(),
+          defaultsTo: k.identityDefault(),
+        },
+      },
     },
+    delegateUtilityV1: approveTokenDelegateDefaults,
     verifyCollectionV1: { accounts: { ...collectionMintDefaults } },
     unverifyCollectionV1: { accounts: { ...collectionMintDefaults } },
   })

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -460,7 +460,13 @@ kinobi.update(
       approveMetadataDelegateDefaults("ProgrammableConfig"),
     delegateSaleV1: approveTokenDelegateDefaults,
     delegateStakingV1: approveTokenDelegateDefaults,
-    delegateStandardV1: approveTokenDelegateDefaults,
+    delegateStandardV1: {
+      ...approveTokenDelegateDefaults,
+      accounts: {
+        ...approveTokenDelegateDefaults.accounts,
+        tokenRecord: { defaultsTo: k.programIdDefault() },
+      },
+    },
     delegateTransferV1: approveTokenDelegateDefaults,
     delegateUpdateV1: approveMetadataDelegateDefaults("Update"),
     delegateUtilityV1: approveTokenDelegateDefaults,

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -246,6 +246,38 @@ kinobi.update(
         },
       },
     },
+    lock: {
+      accounts: {
+        token: {
+          defaultsTo: ataPdaDefault("mint", "tokenOwner"),
+        },
+        tokenOwner: {
+          defaultsTo: k.identityDefault(),
+        },
+        edition: {
+          defaultsTo: k.resolverDefault(
+            "resolveMasterEditionForProgrammables",
+            [k.dependsOnAccount("mint"), k.dependsOnArg("tokenStandard")]
+          ),
+        },
+        tokenRecord: {
+          defaultsTo: k.resolverDefault("resolveTokenRecord", [
+            k.dependsOnAccount("mint"),
+            k.dependsOnAccount("token"),
+            k.dependsOnArg("tokenStandard"),
+          ]),
+        },
+        splTokenProgram: {
+          defaultsTo: k.resolverDefault(
+            "resolveTokenProgramForNonProgrammables",
+            [k.dependsOnArg("tokenStandard")]
+          ),
+        },
+      },
+      args: {
+        tokenStandard: { type: k.linkTypeNode("tokenStandard") },
+      },
+    },
     updateMetadataAccount: {
       args: { updateAuthority: { name: "newUpdateAuthority" } },
     },

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -99,6 +99,12 @@ kinobi.update(
       ignoreIfOptional: true,
       ...k.pdaDefault("masterEdition"),
     },
+    {
+      account: "authorizationRulesProgram",
+      ...k.resolverDefault("resolveAuthorizationRulesProgram", [
+        k.dependsOnAccount("authorizationRules"),
+      ]),
+    },
   ])
 );
 

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -333,6 +333,12 @@ kinobi.update(
         tokenOwner: {
           defaultsTo: k.identityDefault(),
         },
+        edition: {
+          defaultsTo: k.resolverDefault(
+            "resolveMasterEditionForProgrammables",
+            [k.dependsOnAccount("mint"), k.dependsOnArg("tokenStandard")]
+          ),
+        },
         ownerTokenRecord: {
           name: "tokenRecord",
           defaultsTo: k.resolverDefault("resolveTokenRecord", [
@@ -344,6 +350,13 @@ kinobi.update(
         destination: {
           name: "destinationToken",
           defaultsTo: ataPdaDefault("mint", "destinationOwner"),
+        },
+        destinationTokenRecord: {
+          defaultsTo: k.resolverDefault("resolveDestinationTokenRecord", [
+            k.dependsOnAccount("mint"),
+            k.dependsOnAccount("destinationToken"),
+            k.dependsOnArg("tokenStandard"),
+          ]),
         },
       },
       args: {

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -147,7 +147,7 @@ kinobi.update(
           ]),
         },
         tokenOwner: {
-          defaultsTo: k.resolverDefault("resolveMintTokenOwner", []),
+          defaultsTo: k.resolverDefault("resolveOptionalTokenOwner", []),
         },
         token: {
           defaultsTo: ataPdaDefault("mint", "tokenOwner"),
@@ -248,17 +248,17 @@ kinobi.update(
     },
     lock: {
       accounts: {
+        tokenOwner: {
+          defaultsTo: k.resolverDefault("resolveOptionalTokenOwner", []),
+        },
         token: {
           defaultsTo: ataPdaDefault("mint", "tokenOwner"),
         },
-        tokenOwner: {
-          defaultsTo: k.identityDefault(),
-        },
         edition: {
-          defaultsTo: k.resolverDefault(
-            "resolveMasterEditionForProgrammables",
-            [k.dependsOnAccount("mint"), k.dependsOnArg("tokenStandard")]
-          ),
+          defaultsTo: k.resolverDefault("resolveMasterEdition", [
+            k.dependsOnAccount("mint"),
+            k.dependsOnArg("tokenStandard"),
+          ]),
         },
         tokenRecord: {
           defaultsTo: k.resolverDefault("resolveTokenRecord", [

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -109,6 +109,11 @@ kinobi.update(
 );
 
 // Update Instructions.
+const ataPdaDefault = (mint = "mint", owner = "owner") =>
+  k.pdaDefault("associatedToken", {
+    importFrom: "mplEssentials",
+    seeds: { mint: k.accountDefault(mint), owner: k.accountDefault(owner) },
+  });
 kinobi.update(
   new k.UpdateInstructionsVisitor({
     create: {
@@ -134,6 +139,68 @@ kinobi.update(
           128 * 2, // 2 account headers.
         false
       ),
+      accounts: {
+        masterEdition: {
+          defaultsTo: k.resolverDefault("resolveMasterEdition", [
+            k.dependsOnAccount("mint"),
+            k.dependsOnArg("tokenStandard"),
+          ]),
+        },
+        tokenOwner: {
+          defaultsTo: k.resolverDefault("resolveMintTokenOwner", []),
+        },
+        token: {
+          defaultsTo: ataPdaDefault("mint", "tokenOwner"),
+        },
+        tokenRecord: {
+          defaultsTo: k.resolverDefault("resolveTokenRecord", [
+            k.dependsOnAccount("mint"),
+            k.dependsOnAccount("token"),
+            k.dependsOnArg("tokenStandard"),
+          ]),
+        },
+      },
+      args: {
+        tokenStandard: { type: k.linkTypeNode("tokenStandard") },
+      },
+    },
+    transfer: {
+      accounts: {
+        token: {
+          defaultsTo: ataPdaDefault("mint", "tokenOwner"),
+        },
+        tokenOwner: {
+          defaultsTo: k.identityDefault(),
+        },
+        edition: {
+          defaultsTo: k.resolverDefault(
+            "resolveMasterEditionForProgrammables",
+            [k.dependsOnAccount("mint"), k.dependsOnArg("tokenStandard")]
+          ),
+        },
+        ownerTokenRecord: {
+          name: "tokenRecord",
+          defaultsTo: k.resolverDefault("resolveTokenRecord", [
+            k.dependsOnAccount("mint"),
+            k.dependsOnAccount("token"),
+            k.dependsOnArg("tokenStandard"),
+          ]),
+        },
+        destination: {
+          name: "destinationToken",
+          defaultsTo: ataPdaDefault("mint", "destinationOwner"),
+        },
+        destinationTokenRecord: {
+          defaultsTo: k.resolverDefault("resolveDestinationTokenRecord", [
+            k.dependsOnAccount("mint"),
+            k.dependsOnAccount("destinationToken"),
+            k.dependsOnArg("tokenStandard"),
+          ]),
+        },
+      },
+      args: {
+        tokenStandard: { type: k.linkTypeNode("tokenStandard") },
+      },
     },
     delegate: {
       accounts: {
@@ -285,11 +352,6 @@ kinobi.update(
 );
 
 // Update versioned instructions.
-const ataPdaDefault = (mint = "mint", owner = "owner") =>
-  k.pdaDefault("associatedToken", {
-    importFrom: "mplEssentials",
-    seeds: { mint: k.accountDefault(mint), owner: k.accountDefault(owner) },
-  });
 const approveTokenDelegateDefaults = {
   accounts: {
     token: {
@@ -370,70 +432,6 @@ kinobi.update(
             k.dependsOnAccount("authority"),
           ]),
         },
-      },
-    },
-    mintV1: {
-      accounts: {
-        masterEdition: {
-          defaultsTo: k.resolverDefault("resolveMasterEdition", [
-            k.dependsOnAccount("mint"),
-            k.dependsOnArg("tokenStandard"),
-          ]),
-        },
-        tokenOwner: {
-          defaultsTo: k.resolverDefault("resolveMintTokenOwner", []),
-        },
-        token: {
-          defaultsTo: ataPdaDefault("mint", "tokenOwner"),
-        },
-        tokenRecord: {
-          defaultsTo: k.resolverDefault("resolveTokenRecord", [
-            k.dependsOnAccount("mint"),
-            k.dependsOnAccount("token"),
-            k.dependsOnArg("tokenStandard"),
-          ]),
-        },
-      },
-      args: {
-        tokenStandard: { type: k.linkTypeNode("tokenStandard") },
-      },
-    },
-    transferV1: {
-      accounts: {
-        token: {
-          defaultsTo: ataPdaDefault("mint", "tokenOwner"),
-        },
-        tokenOwner: {
-          defaultsTo: k.identityDefault(),
-        },
-        edition: {
-          defaultsTo: k.resolverDefault(
-            "resolveMasterEditionForProgrammables",
-            [k.dependsOnAccount("mint"), k.dependsOnArg("tokenStandard")]
-          ),
-        },
-        ownerTokenRecord: {
-          name: "tokenRecord",
-          defaultsTo: k.resolverDefault("resolveTokenRecord", [
-            k.dependsOnAccount("mint"),
-            k.dependsOnAccount("token"),
-            k.dependsOnArg("tokenStandard"),
-          ]),
-        },
-        destination: {
-          name: "destinationToken",
-          defaultsTo: ataPdaDefault("mint", "destinationOwner"),
-        },
-        destinationTokenRecord: {
-          defaultsTo: k.resolverDefault("resolveDestinationTokenRecord", [
-            k.dependsOnAccount("mint"),
-            k.dependsOnAccount("destinationToken"),
-            k.dependsOnArg("tokenStandard"),
-          ]),
-        },
-      },
-      args: {
-        tokenStandard: { type: k.linkTypeNode("tokenStandard") },
       },
     },
     delegateUtilityV1: approveTokenDelegateDefaults,

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -214,6 +214,22 @@ kinobi.update(
   })
 );
 
+// Set more struct default values dynamically.
+kinobi.update(
+  new k.TransformNodesVisitor([
+    {
+      selector: { kind: "structFieldTypeNode", name: "authorizationData" },
+      transformer: (node) => {
+        k.assertStructFieldTypeNode(node);
+        return k.structFieldTypeNode({
+          ...node,
+          defaultsTo: { strategy: "optional", value: k.vNone() },
+        });
+      },
+    },
+  ])
+);
+
 // Unwrap types and structs.
 kinobi.update(new k.UnwrapDefinedTypesVisitor(["Data", "AssetData"]));
 kinobi.update(

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -343,6 +343,7 @@ kinobi.update(
         },
         destination: {
           name: "destinationToken",
+          defaultsTo: ataPdaDefault("mint", "destinationOwner"),
         },
       },
       args: {

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -290,6 +290,33 @@ const ataPdaDefault = (mint = "mint", owner = "owner") =>
     importFrom: "mplEssentials",
     seeds: { mint: k.accountDefault(mint), owner: k.accountDefault(owner) },
   });
+const approveTokenDelegateDefaults = {
+  accounts: {
+    token: {
+      isOptional: false,
+      defaultsTo: k.pdaDefault("associatedToken", {
+        importFrom: "mplEssentials",
+        seeds: {
+          mint: k.accountDefault("mint"),
+          owner: k.argDefault("tokenOwner"),
+        },
+      }),
+    },
+    delegateRecord: { defaultsTo: k.pdaDefault("tokenRecord") },
+    splTokenProgram: {
+      defaultsTo: k.programDefault(
+        "splToken",
+        "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+      ),
+    },
+  },
+  args: {
+    tokenOwner: {
+      type: k.publicKeyTypeNode(),
+      defaultsTo: k.identityDefault(),
+    },
+  },
+};
 const collectionMintDefaults = {
   collectionMint: { isOptional: false, defaultsTo: null },
   collectionMetadata: {
@@ -409,33 +436,7 @@ kinobi.update(
         tokenStandard: { type: k.linkTypeNode("tokenStandard") },
       },
     },
-    delegateUtilityV1: {
-      accounts: {
-        token: {
-          isOptional: false,
-          defaultsTo: k.pdaDefault("associatedToken", {
-            importFrom: "mplEssentials",
-            seeds: {
-              mint: k.accountDefault("mint"),
-              owner: k.argDefault("tokenOwner"),
-            },
-          }),
-        },
-        delegateRecord: { defaultsTo: k.pdaDefault("tokenRecord") },
-        splTokenProgram: {
-          defaultsTo: k.programDefault(
-            "splToken",
-            "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
-          ),
-        },
-      },
-      args: {
-        tokenOwner: {
-          type: k.publicKeyTypeNode(),
-          defaultsTo: k.identityDefault(),
-        },
-      },
-    },
+    delegateUtilityV1: approveTokenDelegateDefaults,
     delegateUpdateV1: {
       accounts: {},
     },

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -278,6 +278,38 @@ kinobi.update(
         tokenStandard: { type: k.linkTypeNode("tokenStandard") },
       },
     },
+    unlock: {
+      accounts: {
+        tokenOwner: {
+          defaultsTo: k.resolverDefault("resolveOptionalTokenOwner", []),
+        },
+        token: {
+          defaultsTo: ataPdaDefault("mint", "tokenOwner"),
+        },
+        edition: {
+          defaultsTo: k.resolverDefault("resolveMasterEdition", [
+            k.dependsOnAccount("mint"),
+            k.dependsOnArg("tokenStandard"),
+          ]),
+        },
+        tokenRecord: {
+          defaultsTo: k.resolverDefault("resolveTokenRecord", [
+            k.dependsOnAccount("mint"),
+            k.dependsOnAccount("token"),
+            k.dependsOnArg("tokenStandard"),
+          ]),
+        },
+        splTokenProgram: {
+          defaultsTo: k.resolverDefault(
+            "resolveTokenProgramForNonProgrammables",
+            [k.dependsOnArg("tokenStandard")]
+          ),
+        },
+      },
+      args: {
+        tokenStandard: { type: k.linkTypeNode("tokenStandard") },
+      },
+    },
     updateMetadataAccount: {
       args: { updateAuthority: { name: "newUpdateAuthority" } },
     },

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -485,17 +485,19 @@ const metadataDelegateDefaults = (role) => ({
     },
   },
 });
-const collectionMintDefaults = {
-  collectionMint: { isOptional: false, defaultsTo: null },
-  collectionMetadata: {
-    defaultsTo: k.pdaDefault("metadata", {
-      seeds: { mint: k.accountDefault("collectionMint") },
-    }),
-  },
-  collectionMasterEdition: {
-    defaultsTo: k.pdaDefault("masterEdition", {
-      seeds: { mint: k.accountDefault("collectionMint") },
-    }),
+const verifyCollectionDefaults = {
+  accounts: {
+    collectionMint: { isOptional: false, defaultsTo: null },
+    collectionMetadata: {
+      defaultsTo: k.pdaDefault("metadata", {
+        seeds: { mint: k.accountDefault("collectionMint") },
+      }),
+    },
+    collectionMasterEdition: {
+      defaultsTo: k.pdaDefault("masterEdition", {
+        seeds: { mint: k.accountDefault("collectionMint") },
+      }),
+    },
   },
 };
 kinobi.update(
@@ -571,8 +573,8 @@ kinobi.update(
     revokeTransferV1: tokenDelegateDefaults,
     revokeUpdateV1: metadataDelegateDefaults("Update"),
     revokeUtilityV1: tokenDelegateDefaults,
-    verifyCollectionV1: { accounts: { ...collectionMintDefaults } },
-    unverifyCollectionV1: { accounts: { ...collectionMintDefaults } },
+    verifyCollectionV1: verifyCollectionDefaults,
+    unverifyCollectionV1: verifyCollectionDefaults,
   })
 );
 

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -456,6 +456,8 @@ kinobi.update(
     },
     delegateCollectionV1: approveMetadataDelegateDefaults("Collection"),
     delegateLockedTransferV1: approveTokenDelegateDefaults,
+    delegateProgrammableConfigV1:
+      approveMetadataDelegateDefaults("ProgrammableConfig"),
     delegateUtilityV1: approveTokenDelegateDefaults,
     verifyCollectionV1: { accounts: { ...collectionMintDefaults } },
     unverifyCollectionV1: { accounts: { ...collectionMintDefaults } },

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -225,9 +225,6 @@ kinobi.update(
       uses: k.vEnum("UsesToggle", "None", "empty"),
       ruleSet: k.vEnum("RuleSetToggle", "None", "empty"),
     },
-    "transferArgs.V1": {
-      amount: k.vScalar(1),
-    },
   })
 );
 
@@ -241,6 +238,16 @@ kinobi.update(
         return k.structFieldTypeNode({
           ...node,
           defaultsTo: { strategy: "optional", value: k.vNone() },
+        });
+      },
+    },
+    {
+      selector: { kind: "structFieldTypeNode", name: "amount" },
+      transformer: (node) => {
+        k.assertStructFieldTypeNode(node);
+        return k.structFieldTypeNode({
+          ...node,
+          defaultsTo: { strategy: "optional", value: k.vScalar(1) },
         });
       },
     },

--- a/idls/mpl_token_metadata.json
+++ b/idls/mpl_token_metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.9.1",
+  "version": "1.10.0",
   "name": "mpl_token_metadata",
   "instructions": [
     {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "validator:stop": "amman stop"
   },
   "devDependencies": {
-    "@metaplex-foundation/kinobi": "file:../kinobi",
+    "@metaplex-foundation/kinobi": "^0.7.4",
     "@metaplex-foundation/shank-js": "^0.1.0",
     "@metaplex-foundation/amman": "^0.12.1",
     "typescript": "^4.9.4"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "validator:stop": "amman stop"
   },
   "devDependencies": {
-    "@metaplex-foundation/kinobi": "^0.7.0",
+    "@metaplex-foundation/kinobi": "^0.7.2",
     "@metaplex-foundation/shank-js": "^0.1.0",
     "@metaplex-foundation/amman": "^0.12.1",
     "typescript": "^4.9.4"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "validator:stop": "amman stop"
   },
   "devDependencies": {
-    "@metaplex-foundation/kinobi": "^0.7.2",
+    "@metaplex-foundation/kinobi": "file:../kinobi",
     "@metaplex-foundation/shank-js": "^0.1.0",
     "@metaplex-foundation/amman": "^0.12.1",
     "typescript": "^4.9.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ devDependencies:
     specifier: ^0.12.1
     version: 0.12.1(typescript@4.9.5)
   '@metaplex-foundation/kinobi':
-    specifier: ^0.7.0
-    version: 0.7.0
+    specifier: ^0.7.2
+    version: 0.7.2
   '@metaplex-foundation/shank-js':
     specifier: ^0.1.0
     version: 0.1.0
@@ -85,8 +85,8 @@ packages:
     resolution: {integrity: sha512-S9RulC2fFCFOQraz61bij+5YCHhSO9llJegK8c8Y6731fSi6snUSQJdCUqYS8AIgR0TKbQvdvgSyIIdbDFZbBA==}
     dev: true
 
-  /@metaplex-foundation/kinobi@0.7.0:
-    resolution: {integrity: sha512-OKtsM9z63KLanH+MLdy/LRNxt8qKFC32fsiI9YaGPW6zjAlZ5kApf8jtI4cISK4CoSL6OIAIdcMtotadjHZrCw==}
+  /@metaplex-foundation/kinobi@0.7.2:
+    resolution: {integrity: sha512-Dbct7HvKklMAHdNJtLfmSFxFBQsu1kNpF5NCm10Ahz9vlRjcS1GSqUPCExVz081F0fx8w2WHHK48qeLBpOXiQA==}
     dependencies:
       '@noble/hashes': 1.2.0
       chalk: 4.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ devDependencies:
     specifier: ^0.12.1
     version: 0.12.1(typescript@4.9.5)
   '@metaplex-foundation/kinobi':
-    specifier: file:../kinobi
-    version: file:../kinobi
+    specifier: ^0.7.4
+    version: 0.7.4
   '@metaplex-foundation/shank-js':
     specifier: ^0.1.0
     version: 0.1.0
@@ -83,6 +83,17 @@ packages:
 
   /@metaplex-foundation/cusper@0.0.2:
     resolution: {integrity: sha512-S9RulC2fFCFOQraz61bij+5YCHhSO9llJegK8c8Y6731fSi6snUSQJdCUqYS8AIgR0TKbQvdvgSyIIdbDFZbBA==}
+    dev: true
+
+  /@metaplex-foundation/kinobi@0.7.4:
+    resolution: {integrity: sha512-ywoaoKpui4ffFoF0jZjMfPY5UJA3G3+Wu08nLuvQl+gDqEal05Bj15/tAd8+upY6eyWG4G0qopPXegbk+SP1aw==}
+    dependencies:
+      '@noble/hashes': 1.2.0
+      chalk: 4.1.2
+      nunjucks: 3.2.3
+      prettier: 2.8.4
+    transitivePeerDependencies:
+      - chokidar
     dev: true
 
   /@metaplex-foundation/rustbin@0.3.1:
@@ -1265,17 +1276,4 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-    dev: true
-
-  file:../kinobi:
-    resolution: {directory: ../kinobi, type: directory}
-    name: '@metaplex-foundation/kinobi'
-    version: 0.7.4
-    dependencies:
-      '@noble/hashes': 1.2.0
-      chalk: 4.1.2
-      nunjucks: 3.2.3
-      prettier: 2.8.4
-    transitivePeerDependencies:
-      - chokidar
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ devDependencies:
     specifier: ^0.12.1
     version: 0.12.1(typescript@4.9.5)
   '@metaplex-foundation/kinobi':
-    specifier: ^0.7.2
-    version: 0.7.2
+    specifier: file:../kinobi
+    version: file:../kinobi
   '@metaplex-foundation/shank-js':
     specifier: ^0.1.0
     version: 0.1.0
@@ -83,17 +83,6 @@ packages:
 
   /@metaplex-foundation/cusper@0.0.2:
     resolution: {integrity: sha512-S9RulC2fFCFOQraz61bij+5YCHhSO9llJegK8c8Y6731fSi6snUSQJdCUqYS8AIgR0TKbQvdvgSyIIdbDFZbBA==}
-    dev: true
-
-  /@metaplex-foundation/kinobi@0.7.2:
-    resolution: {integrity: sha512-Dbct7HvKklMAHdNJtLfmSFxFBQsu1kNpF5NCm10Ahz9vlRjcS1GSqUPCExVz081F0fx8w2WHHK48qeLBpOXiQA==}
-    dependencies:
-      '@noble/hashes': 1.2.0
-      chalk: 4.1.2
-      nunjucks: 3.2.3
-      prettier: 2.8.4
-    transitivePeerDependencies:
-      - chokidar
     dev: true
 
   /@metaplex-foundation/rustbin@0.3.1:
@@ -1276,4 +1265,17 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+    dev: true
+
+  file:../kinobi:
+    resolution: {directory: ../kinobi, type: directory}
+    name: '@metaplex-foundation/kinobi'
+    version: 0.7.4
+    dependencies:
+      '@noble/hashes': 1.2.0
+      chalk: 4.1.2
+      nunjucks: 3.2.3
+      prettier: 2.8.4
+    transitivePeerDependencies:
+      - chokidar
     dev: true


### PR DESCRIPTION
This PR configures Kinobi for all new handlers (aside from a couple that are not quite ready on the program). It also tests the happy path of these handlers for the following token standards: `NonFungible`, `ProgrammableNonFungible`, `Fungible` and `FungibleAsset`.