### PR TITLE
add tokenRecord test

### DIFF
--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -33,6 +33,11 @@ export const OG_TOKEN_STANDARDS: TokenStandardKeys[] = [
   'Fungible',
 ];
 
+export const NON_EDITION_NON_FUNGIBLE_STANDARDS: TokenStandardKeys[] = [
+  'NonFungible',
+  'ProgrammableNonFungible',
+];
+
 export const FUNGIBLE_TOKEN_STANDARDS: TokenStandardKeys[] = [
   'FungibleAsset',
   'Fungible',

--- a/clients/js/test/transferV1.test.ts
+++ b/clients/js/test/transferV1.test.ts
@@ -101,18 +101,19 @@ NON_EDITION_NON_FUNGIBLE_STANDARDS.forEach((tokenStandard) => {
       tokenStandard: TokenStandard[tokenStandard],
     });
 
-    // Then it can not be transferred with an amount of 0.
+    // When we try to transfer an amount of 0.
     const ownerB = generateSigner(umi).publicKey;
-    await t.throwsAsync(
-      transferV1(umi, {
-        mint,
-        authority: ownerA,
-        tokenOwner: ownerA.publicKey,
-        destinationOwner: ownerB,
-        tokenStandard: TokenStandard[tokenStandard],
-        amount: 0,
-      }).sendAndConfirm(umi)
-    );
+    const promise = transferV1(umi, {
+      mint,
+      authority: ownerA,
+      tokenOwner: ownerA.publicKey,
+      destinationOwner: ownerB,
+      tokenStandard: TokenStandard[tokenStandard],
+      amount: 0,
+    }).sendAndConfirm(umi);
+
+    // Then we expect a program error.
+    await t.throwsAsync(promise, { name: 'InvalidAmount' });
   });
 });
 

--- a/clients/js/test/transferV1.test.ts
+++ b/clients/js/test/transferV1.test.ts
@@ -6,7 +6,6 @@ import {
   TokenStandard,
   TokenState,
   fetchDigitalAssetWithAssociatedToken,
-  safeFetchTokenRecordFromSeeds,
   transferV1,
 } from '../src';
 import {
@@ -99,7 +98,7 @@ test('transferring a ProgrammableNonFungible with an amount of 0 does not cause 
     tokenOwner: ownerA.publicKey,
     tokenStandard: TokenStandard.ProgrammableNonFungible,
   });
-  
+
   // When we run transfer with amount 0
   const ownerB = generateSigner(umi).publicKey;
   await transferV1(umi, {
@@ -112,7 +111,11 @@ test('transferring a ProgrammableNonFungible with an amount of 0 does not cause 
   }).sendAndConfirm(umi);
 
   // Then the token stays with the old owner and they keep the tokenRecord.
-  const originalAsset = await fetchDigitalAssetWithAssociatedToken(umi, mint, ownerA.publicKey);
+  const originalAsset = await fetchDigitalAssetWithAssociatedToken(
+    umi,
+    mint,
+    ownerA.publicKey
+  );
   t.like(originalAsset, <DigitalAssetWithToken>{
     mint: {
       publicKey: publicKey(mint),
@@ -132,16 +135,12 @@ test('transferring a ProgrammableNonFungible with an amount of 0 does not cause 
   });
 
   // And no additional tokenRecord is created.
-  const newEmptyAsset = await fetchDigitalAssetWithAssociatedToken(umi, mint, ownerB);
+  const newEmptyAsset = await fetchDigitalAssetWithAssociatedToken(
+    umi,
+    mint,
+    ownerB
+  );
   t.like(newEmptyAsset, <DigitalAssetWithToken>{
-    token: {
-      publicKey: findAssociatedTokenPda(umi, {
-        mint,
-        owner: ownerB,
-      })[0],
-      owner: ownerB,
-      amount: 0n,
-    },
     tokenRecord: undefined,
   });
 });


### PR DESCRIPTION
Currently it's possible to run transferV1 to transfer a pNFT with amount 0. It results in the tokenRecord being closed for ownerA and is created for ownerB, but the pNFT itself stays with ownerA. The pNFT then is stuck.

This test is to proove the issue.

Case where something like this happened in mainnet-beta:
3JRzySrxayxC4kvyTy8Pt15moWYbdzkyhPwt9w9w9NGEy6ssj21FkrA4jt35FGpKqzM1cfEhwH5XwGJrsUVPSwJC