### PR TITLE
Add amount check on transfer

### DIFF
--- a/programs/token-metadata/program/src/processor/metadata/transfer.rs
+++ b/programs/token-metadata/program/src/processor/metadata/transfer.rs
@@ -92,6 +92,10 @@ fn transfer_v1(program_id: &Pubkey, ctx: Context<Transfer>, args: TransferArgs) 
         amount,
     } = args;
 
+    if amount == 0 {
+        return Err(MetadataError::InvalidAmount.into());
+    }
+
     // Check signers
 
     // This authority must always be a signer, regardless of if it's the


### PR DESCRIPTION
This PR prevents going through the transfer when the amount is equal to `0`. This prevents closing the token record of the source account  since the token is not transferred.