### PR TITLE
Deprecate locked transfer address

### DIFF
--- a/programs/token-metadata/program/src/instruction/burn.rs
+++ b/programs/token-metadata/program/src/instruction/burn.rs
@@ -25,6 +25,7 @@ use crate::instruction::MetadataInstruction;
 ///   7. `[writable]` Print Edition PDA Account
 ///   8. `[writable]` Edition Marker PDA Account
 ///   9. [] SPL Token program.
+#[allow(clippy::too_many_arguments)]
 pub fn burn_edition_nft(
     program_id: Pubkey,
     metadata: Pubkey,
@@ -69,6 +70,7 @@ pub fn burn_edition_nft(
 /// 4. `[writable]` NFT edition account
 /// 5. `[]` SPL Token program.
 /// 6. Optional `[writable]` Collection metadata account
+#[allow(clippy::too_many_arguments)]
 pub fn burn_nft(
     program_id: Pubkey,
     metadata: Pubkey,

--- a/programs/token-metadata/program/src/instruction/delegate.rs
+++ b/programs/token-metadata/program/src/instruction/delegate.rs
@@ -49,6 +49,10 @@ pub enum DelegateArgs {
     },
     LockedTransferV1 {
         amount: u64,
+        #[deprecated(
+            since = "1.13.2",
+            note = "The locked address is deprecated and will soon be removed."
+        )]
         /// locked destination pubkey
         locked_address: Pubkey,
         /// Required authorization data to validate the request.

--- a/programs/token-metadata/program/src/instruction/escrow.rs
+++ b/programs/token-metadata/program/src/instruction/escrow.rs
@@ -39,6 +39,7 @@ pub fn close_escrow_account(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn create_escrow_account(
     program_id: Pubkey,
     escrow_account: Pubkey,
@@ -82,6 +83,7 @@ pub struct TransferOutOfEscrowArgs {
     pub amount: u64,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn transfer_out_of_escrow(
     program_id: Pubkey,
     escrow: Pubkey,

--- a/programs/token-metadata/program/src/processor/delegate/delegate.rs
+++ b/programs/token-metadata/program/src/processor/delegate/delegate.rs
@@ -309,6 +309,11 @@ fn create_persistent_delegate_v1(
                 }
             };
 
+            // we cannot replace an existing delegate, it must be revoked first
+            if token_record.delegate.is_some() {
+                return Err(MetadataError::DelegateAlreadyExists.into());
+            }
+
             // if we have a rule set, we need to store its revision; at this point,
             // we will validate that we have the correct auth rules PDA
             if let Some(ProgrammableConfig::V1 {

--- a/programs/token-metadata/program/src/processor/delegate/delegate.rs
+++ b/programs/token-metadata/program/src/processor/delegate/delegate.rs
@@ -221,6 +221,7 @@ fn create_delegate_v1(
 /// spl-token 'approve' delegate.
 ///
 /// Note that `DelegateRole::Sale` is only available for programmable assets.
+#[allow(deprecated)]
 fn create_persistent_delegate_v1(
     program_id: &Pubkey,
     ctx: Context<Delegate>,
@@ -308,11 +309,6 @@ fn create_persistent_delegate_v1(
                 }
             };
 
-            // we cannot replace an existing delegate, it must be revoked first
-            if token_record.delegate.is_some() {
-                return Err(MetadataError::DelegateAlreadyExists.into());
-            }
-
             // if we have a rule set, we need to store its revision; at this point,
             // we will validate that we have the correct auth rules PDA
             if let Some(ProgrammableConfig::V1 {
@@ -371,6 +367,8 @@ fn create_persistent_delegate_v1(
                 TokenState::Unlocked
             };
 
+            // stores the locked transfer address for backwards compatibility, but this is
+            // not enforced by the transfer instruction
             token_record.locked_transfer = if matches!(role, TokenDelegateRole::LockedTransfer) {
                 if let DelegateArgs::LockedTransferV1 { locked_address, .. } = args {
                     Some(*locked_address)
@@ -482,6 +480,7 @@ fn create_persistent_delegate_v1(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn create_pda_account<'a>(
     program_id: &Pubkey,
     delegate_record_info: &'a AccountInfo<'a>,

--- a/programs/token-metadata/program/src/state/programmable.rs
+++ b/programs/token-metadata/program/src/state/programmable.rs
@@ -76,6 +76,11 @@ pub struct TokenRecord {
     pub delegate: Option<Pubkey>,
     /// The role of the current token delegate.
     pub delegate_role: Option<TokenDelegateRole>,
+
+    #[deprecated(
+        since = "1.13.2",
+        note = "The locked address is deprecated and will soon be removed."
+    )]
     /// Stores the destination pubkey when a transfer is lock to an allowed address. This
     /// pubkey gets set when a 'LockTransfer' delegate is approved.
     pub locked_transfer: Option<Pubkey>,

--- a/programs/token-metadata/program/src/utils/master_edition.rs
+++ b/programs/token-metadata/program/src/utils/master_edition.rs
@@ -548,6 +548,7 @@ pub fn mint_limited_edition<'a>(
 /// error.
 ///
 /// After a master edition is created, it becomes the mint authority of the mint account.
+#[allow(clippy::too_many_arguments)]
 pub fn create_master_edition<'a>(
     program_id: &Pubkey,
     edition_account_info: &'a AccountInfo<'a>,

--- a/programs/token-metadata/program/src/utils/metadata.rs
+++ b/programs/token-metadata/program/src/utils/metadata.rs
@@ -43,6 +43,7 @@ pub struct CreateMetadataAccountsLogicArgs<'a> {
 }
 
 /// Create a new account instruction
+#[allow(clippy::too_many_arguments)]
 pub fn process_create_metadata_accounts_logic(
     program_id: &Pubkey,
     accounts: CreateMetadataAccountsLogicArgs,

--- a/programs/token-metadata/program/tests/transfer.rs
+++ b/programs/token-metadata/program/tests/transfer.rs
@@ -1325,8 +1325,7 @@ mod auth_rules_transfer {
 
     #[tokio::test]
     async fn locked_transfer_delegate() {
-        // tests a LockedTransfer delegate transferring from a system wallet to an invalid address and
-        // from a system wallet to the the locked PDA address
+        // tests a LockedTransfer delegate, which works similarly to a Transfer delegate
         let mut program_test = ProgramTest::new("mpl_token_metadata", mpl_token_metadata::ID, None);
         program_test.add_program("mpl_token_auth_rules", mpl_token_auth_rules::ID, None);
         program_test.add_program("rooster", rooster::ID, None);
@@ -1388,30 +1387,6 @@ mod auth_rules_transfer {
 
         // tries to make an invalid transfer: the destination address does not match
         // the address at the delegate creation
-
-        let authority = context.payer.dirty_clone();
-
-        let args = TransferArgs::V1 {
-            authorization_data: None,
-            amount: transfer_amount,
-        };
-
-        let params = TransferParams {
-            context: &mut context,
-            authority: &delegate,
-            source_owner: &authority.pubkey(),
-            destination_owner: nft.metadata,
-            destination_token: None,
-            authorization_rules: Some(rule_set),
-            payer: &authority,
-            args: args.clone(),
-        };
-
-        let error = nft.transfer(params).await.unwrap_err();
-
-        assert_custom_error_ix!(2, error, MetadataError::InvalidLockedTransferAddress);
-
-        // makes the correct transfer
 
         let authority = context.payer.dirty_clone();
 


### PR DESCRIPTION
PR to deprecate the address in the `LockedTransfer` delegate. This allows the delegate to transfer to any address. The `address` field is still present on the delegate args to maintain compatibility, but it will be removed in a future release.