### PR TITLE
Allow replacing a delegate

### DIFF
--- a/programs/token-metadata/program/src/processor/delegate/delegate.rs
+++ b/programs/token-metadata/program/src/processor/delegate/delegate.rs
@@ -308,11 +308,6 @@ fn create_persistent_delegate_v1(
                 }
             };
 
-            // we cannot replace an existing delegate, it must be revoked first
-            if token_record.delegate.is_some() {
-                return Err(MetadataError::DelegateAlreadyExists.into());
-            }
-
             // if we have a rule set, we need to store its revision; at this point,
             // we will validate that we have the correct auth rules PDA
             if let Some(ProgrammableConfig::V1 {


### PR DESCRIPTION
This PR changes the behaviour of the `Delegate` instruction to have the same behaviour as SPL Token `approve` instruction: to set a new delegate, there is no need to revoke the previous one.