### PR TITLE
Prevent delegate to change the update authority

### DIFF
--- a/clients/js/src/generated/errors/mplTokenMetadata.ts
+++ b/clients/js/src/generated/errors/mplTokenMetadata.ts
@@ -2837,6 +2837,22 @@ export class InvalidMetadataFlagsError extends ProgramError {
 codeToErrorMap.set(0xc0, InvalidMetadataFlagsError);
 nameToErrorMap.set('InvalidMetadataFlags', InvalidMetadataFlagsError);
 
+/** CannotChangeUpdateAuthorityWithDelegate: Cannot change the update authority with a delegate */
+export class CannotChangeUpdateAuthorityWithDelegateError extends ProgramError {
+  readonly name: string = 'CannotChangeUpdateAuthorityWithDelegate';
+
+  readonly code: number = 0xc1; // 193
+
+  constructor(program: Program, cause?: Error) {
+    super('Cannot change the update authority with a delegate', program, cause);
+  }
+}
+codeToErrorMap.set(0xc1, CannotChangeUpdateAuthorityWithDelegateError);
+nameToErrorMap.set(
+  'CannotChangeUpdateAuthorityWithDelegate',
+  CannotChangeUpdateAuthorityWithDelegateError
+);
+
 /**
  * Attempts to resolve a custom program error from the provided error code.
  * @category Errors

--- a/clients/js/test/updateAsAuthorityItemDelegateV2.test.ts
+++ b/clients/js/test/updateAsAuthorityItemDelegateV2.test.ts
@@ -63,8 +63,10 @@ NON_EDITION_TOKEN_STANDARDS.forEach((tokenStandard) => {
       authority: authorityItemDelegate,
       newUpdateAuthority: some(newUpdateAuthority),
     }).sendAndConfirm(umi);
-    
+
     // Then we expect a program error.
-    await t.throwsAsync(promise, { name: 'CannotChangeUpdateAuthorityWithDelegate' });
+    await t.throwsAsync(promise, {
+      name: 'CannotChangeUpdateAuthorityWithDelegate',
+    });
   });
 });

--- a/clients/js/test/updateAsAuthorityItemDelegateV2.test.ts
+++ b/clients/js/test/updateAsAuthorityItemDelegateV2.test.ts
@@ -29,16 +29,42 @@ NON_EDITION_TOKEN_STANDARDS.forEach((tokenStandard) => {
       tokenStandard: TokenStandard[tokenStandard],
     }).sendAndConfirm(umi);
 
-    // When the delegate updates the update authority of the asset.
-    const newUpdateAuthority = generateSigner(umi).publicKey;
+    // When the delegate updates the asset to be immutable.
     await updateAsAuthorityItemDelegateV2(umi, {
       mint,
       authority: authorityItemDelegate,
-      newUpdateAuthority: some(newUpdateAuthority),
+      isMutable: false,
     }).sendAndConfirm(umi);
 
     // Then the account data was updated.
     const updatedMetadata = await fetchMetadataFromSeeds(umi, { mint });
-    t.like(updatedMetadata, <Metadata>{ updateAuthority: newUpdateAuthority });
+    t.like(updatedMetadata, <Metadata>{ isMutable: false });
+  });
+
+  test(`it cannot change the update authority of a ${tokenStandard} asset`, async (t) => {
+    // Given an existing asset.
+    const umi = await createUmi();
+    const { publicKey: mint } = await createDigitalAsset(umi, {
+      tokenStandard: TokenStandard[tokenStandard],
+    });
+
+    // And an authority item delegate approved on the asset.
+    const authorityItemDelegate = generateSigner(umi);
+    await delegateAuthorityItemV1(umi, {
+      mint,
+      delegate: authorityItemDelegate.publicKey,
+      tokenStandard: TokenStandard[tokenStandard],
+    }).sendAndConfirm(umi);
+
+    // When the delegate updates the update authority of the asset.
+    const newUpdateAuthority = generateSigner(umi).publicKey;
+    const promise = updateAsAuthorityItemDelegateV2(umi, {
+      mint,
+      authority: authorityItemDelegate,
+      newUpdateAuthority: some(newUpdateAuthority),
+    }).sendAndConfirm(umi);
+    
+    // Then we expect a program error.
+    await t.throwsAsync(promise, { name: 'CannotChangeUpdateAuthorityWithDelegate' });
   });
 });

--- a/clients/rust/src/generated/errors/mpl_token_metadata.rs
+++ b/clients/rust/src/generated/errors/mpl_token_metadata.rs
@@ -588,4 +588,7 @@ pub enum MplTokenMetadataError {
     /// 0xC0 -
     #[error("")]
     InvalidMetadataFlags,
+    /// 0xC1 - Cannot change the update authority with a delegate
+    #[error("Cannot change the update authority with a delegate")]
+    CannotChangeUpdateAuthorityWithDelegate,
 }

--- a/idls/token_metadata.json
+++ b/idls/token_metadata.json
@@ -7721,6 +7721,11 @@
       "code": 192,
       "name": "InvalidMetadataFlags",
       "msg": ""
+    },
+    {
+      "code": 193,
+      "name": "CannotChangeUpdateAuthorityWithDelegate",
+      "msg": "Cannot change the update authority with a delegate"
     }
   ],
   "metadata": {

--- a/programs/token-metadata/program/src/error.rs
+++ b/programs/token-metadata/program/src/error.rs
@@ -759,6 +759,10 @@ pub enum MetadataError {
     /// 192
     #[error("")]
     InvalidMetadataFlags,
+
+    /// 193
+    #[error("Cannot change the update authority with a delegate")]
+    CannotChangeUpdateAuthorityWithDelegate,
 }
 
 impl PrintProgramError for MetadataError {

--- a/programs/token-metadata/program/src/instruction/metadata.rs
+++ b/programs/token-metadata/program/src/instruction/metadata.rs
@@ -127,6 +127,10 @@ pub enum UpdateArgs {
     },
     AsAuthorityItemDelegateV2 {
         /// The new update authority.
+        #[deprecated(
+            since = "1.13.3",
+            note = "A delegate cannot change the update authority. This field will be removed in a future release."
+        )]
         new_update_authority: Option<Pubkey>,
         /// Indicates whether the primary sale has happened or not (once set to `true`, it cannot be
         /// changed back).

--- a/programs/token-metadata/program/src/state/metadata.rs
+++ b/programs/token-metadata/program/src/state/metadata.rs
@@ -111,15 +111,21 @@ impl Metadata {
         // Only the Update Authority can update this section.
         match &args {
             UpdateArgs::V1 {
+                new_update_authority,
                 uses,
                 collection_details,
                 ..
             }
             | UpdateArgs::AsUpdateAuthorityV2 {
+                new_update_authority,
                 uses,
                 collection_details,
                 ..
             } => {
+                if let Some(authority) = new_update_authority {
+                    self.update_authority = *authority;
+                }
+
                 if uses.is_some() {
                     let uses_option = uses.clone().to_option();
                     // If already None leave it as None.
@@ -198,23 +204,6 @@ impl Metadata {
                     } else {
                         return Err(MetadataError::IsMutableCanOnlyBeFlippedToFalse.into());
                     }
-                }
-            }
-            _ => (),
-        }
-
-        // Update Authority can update this section.
-        match &args {
-            UpdateArgs::V1 {
-                new_update_authority,
-                ..
-            }
-            | UpdateArgs::AsUpdateAuthorityV2 {
-                new_update_authority,
-                ..
-            } => {
-                if let Some(authority) = new_update_authority {
-                    self.update_authority = *authority;
                 }
             }
             _ => (),

--- a/programs/token-metadata/program/src/state/metadata.rs
+++ b/programs/token-metadata/program/src/state/metadata.rs
@@ -168,27 +168,20 @@ impl Metadata {
         // Update Authority or Authority Item Delegate can update this section.
         match &args {
             UpdateArgs::V1 {
-                new_update_authority,
                 primary_sale_happened,
                 is_mutable,
                 ..
             }
             | UpdateArgs::AsUpdateAuthorityV2 {
-                new_update_authority,
                 primary_sale_happened,
                 is_mutable,
                 ..
             }
             | UpdateArgs::AsAuthorityItemDelegateV2 {
-                new_update_authority,
                 primary_sale_happened,
                 is_mutable,
                 ..
             } => {
-                if let Some(authority) = new_update_authority {
-                    self.update_authority = *authority;
-                }
-
                 if let Some(primary_sale) = primary_sale_happened {
                     // If received primary_sale is true, flip to true.
                     if *primary_sale || !self.primary_sale_happened {
@@ -209,6 +202,32 @@ impl Metadata {
             }
             _ => (),
         }
+
+        // Update Authority can update this section.
+        match &args {
+            UpdateArgs::V1 {
+                new_update_authority,
+                ..
+            }
+            | UpdateArgs::AsUpdateAuthorityV2 {
+                new_update_authority,
+                ..
+            } => {
+                if let Some(authority) = new_update_authority {
+                    self.update_authority = *authority;
+                }
+            }
+            _ => (),
+        }
+
+        // Update authority by Authority Item Delegate is deprecated.
+        if let UpdateArgs::AsAuthorityItemDelegateV2 {
+            new_update_authority: Some(_authority),
+            ..
+        } = &args
+        {
+            return Err(MetadataError::CannotChangeUpdateAuthorityWithDelegate.into());
+        };
 
         // Update Authority or Collection Delegates can update this section.
         match &args {


### PR DESCRIPTION
Currently, an `AsAuthorityItemDelegateV2` delegate can change the update authority. This is an undesirable behaviour since a rogue delegate can take over the authority of the metadata. This PR deprecates the `new_update_authority` field and prevents the delegate from changing the update authority.