### PR TITLE
Bump kinobi version

### DIFF
--- a/clients/rust/src/generated/accounts/collection_authority_record.rs
+++ b/clients/rust/src/generated/accounts/collection_authority_record.rs
@@ -60,11 +60,11 @@ impl CollectionAuthorityRecord {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for CollectionAuthorityRecord {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for CollectionAuthorityRecord {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/clients/rust/src/generated/accounts/edition.rs
+++ b/clients/rust/src/generated/accounts/edition.rs
@@ -32,11 +32,11 @@ impl Edition {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for Edition {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for Edition {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/clients/rust/src/generated/accounts/edition_marker.rs
+++ b/clients/rust/src/generated/accounts/edition_marker.rs
@@ -58,11 +58,11 @@ impl EditionMarker {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for EditionMarker {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for EditionMarker {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/clients/rust/src/generated/accounts/edition_marker_v2.rs
+++ b/clients/rust/src/generated/accounts/edition_marker_v2.rs
@@ -55,11 +55,11 @@ impl EditionMarkerV2 {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for EditionMarkerV2 {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for EditionMarkerV2 {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/clients/rust/src/generated/accounts/master_edition.rs
+++ b/clients/rust/src/generated/accounts/master_edition.rs
@@ -54,11 +54,11 @@ impl MasterEdition {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for MasterEdition {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for MasterEdition {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/clients/rust/src/generated/accounts/metadata.rs
+++ b/clients/rust/src/generated/accounts/metadata.rs
@@ -79,11 +79,11 @@ impl Metadata {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for Metadata {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for Metadata {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/clients/rust/src/generated/accounts/metadata_delegate_record.rs
+++ b/clients/rust/src/generated/accounts/metadata_delegate_record.rs
@@ -83,11 +83,11 @@ impl MetadataDelegateRecord {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for MetadataDelegateRecord {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for MetadataDelegateRecord {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/clients/rust/src/generated/accounts/token_owned_escrow.rs
+++ b/clients/rust/src/generated/accounts/token_owned_escrow.rs
@@ -32,11 +32,11 @@ impl TokenOwnedEscrow {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for TokenOwnedEscrow {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for TokenOwnedEscrow {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/clients/rust/src/generated/accounts/token_record.rs
+++ b/clients/rust/src/generated/accounts/token_record.rs
@@ -65,11 +65,11 @@ impl TokenRecord {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for TokenRecord {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for TokenRecord {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/clients/rust/src/generated/accounts/use_authority_record.rs
+++ b/clients/rust/src/generated/accounts/use_authority_record.rs
@@ -59,11 +59,11 @@ impl UseAuthorityRecord {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for UseAuthorityRecord {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for UseAuthorityRecord {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/clients/rust/src/generated/errors/mpl_token_metadata.rs
+++ b/clients/rust/src/generated/errors/mpl_token_metadata.rs
@@ -10,586 +10,586 @@ use thiserror::Error;
 
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
 pub enum MplTokenMetadataError {
-    /// 0x0 -
+    /// 0 (0x0) -
     #[error("")]
     InstructionUnpackError,
-    /// 0x1 -
+    /// 1 (0x1) -
     #[error("")]
     InstructionPackError,
-    /// 0x2 - Lamport balance below rent-exempt threshold
+    /// 2 (0x2) - Lamport balance below rent-exempt threshold
     #[error("Lamport balance below rent-exempt threshold")]
     NotRentExempt,
-    /// 0x3 - Already initialized
+    /// 3 (0x3) - Already initialized
     #[error("Already initialized")]
     AlreadyInitialized,
-    /// 0x4 - Uninitialized
+    /// 4 (0x4) - Uninitialized
     #[error("Uninitialized")]
     Uninitialized,
-    /// 0x5 -  Metadata's key must match seed of ['metadata', program id, mint] provided
+    /// 5 (0x5) -  Metadata's key must match seed of ['metadata', program id, mint] provided
     #[error(" Metadata's key must match seed of ['metadata', program id, mint] provided")]
     InvalidMetadataKey,
-    /// 0x6 - Edition's key must match seed of ['metadata', program id, name, 'edition'] provided
+    /// 6 (0x6) - Edition's key must match seed of ['metadata', program id, name, 'edition'] provided
     #[error("Edition's key must match seed of ['metadata', program id, name, 'edition'] provided")]
     InvalidEditionKey,
-    /// 0x7 - Update Authority given does not match
+    /// 7 (0x7) - Update Authority given does not match
     #[error("Update Authority given does not match")]
     UpdateAuthorityIncorrect,
-    /// 0x8 - Update Authority needs to be signer to update metadata
+    /// 8 (0x8) - Update Authority needs to be signer to update metadata
     #[error("Update Authority needs to be signer to update metadata")]
     UpdateAuthorityIsNotSigner,
-    /// 0x9 - You must be the mint authority and signer on this transaction
+    /// 9 (0x9) - You must be the mint authority and signer on this transaction
     #[error("You must be the mint authority and signer on this transaction")]
     NotMintAuthority,
-    /// 0xA - Mint authority provided does not match the authority on the mint
+    /// 10 (0xA) - Mint authority provided does not match the authority on the mint
     #[error("Mint authority provided does not match the authority on the mint")]
     InvalidMintAuthority,
-    /// 0xB - Name too long
+    /// 11 (0xB) - Name too long
     #[error("Name too long")]
     NameTooLong,
-    /// 0xC - Symbol too long
+    /// 12 (0xC) - Symbol too long
     #[error("Symbol too long")]
     SymbolTooLong,
-    /// 0xD - URI too long
+    /// 13 (0xD) - URI too long
     #[error("URI too long")]
     UriTooLong,
-    /// 0xE -
+    /// 14 (0xE) -
     #[error("")]
     UpdateAuthorityMustBeEqualToMetadataAuthorityAndSigner,
-    /// 0xF - Mint given does not match mint on Metadata
+    /// 15 (0xF) - Mint given does not match mint on Metadata
     #[error("Mint given does not match mint on Metadata")]
     MintMismatch,
-    /// 0x10 - Editions must have exactly one token
+    /// 16 (0x10) - Editions must have exactly one token
     #[error("Editions must have exactly one token")]
     EditionsMustHaveExactlyOneToken,
-    /// 0x11 -
+    /// 17 (0x11) -
     #[error("")]
     MaxEditionsMintedAlready,
-    /// 0x12 -
+    /// 18 (0x12) -
     #[error("")]
     TokenMintToFailed,
-    /// 0x13 -
+    /// 19 (0x13) -
     #[error("")]
     MasterRecordMismatch,
-    /// 0x14 -
+    /// 20 (0x14) -
     #[error("")]
     DestinationMintMismatch,
-    /// 0x15 -
+    /// 21 (0x15) -
     #[error("")]
     EditionAlreadyMinted,
-    /// 0x16 -
+    /// 22 (0x16) -
     #[error("")]
     PrintingMintDecimalsShouldBeZero,
-    /// 0x17 -
+    /// 23 (0x17) -
     #[error("")]
     OneTimePrintingAuthorizationMintDecimalsShouldBeZero,
-    /// 0x18 - EditionMintDecimalsShouldBeZero
+    /// 24 (0x18) - EditionMintDecimalsShouldBeZero
     #[error("EditionMintDecimalsShouldBeZero")]
     EditionMintDecimalsShouldBeZero,
-    /// 0x19 -
+    /// 25 (0x19) -
     #[error("")]
     TokenBurnFailed,
-    /// 0x1A -
+    /// 26 (0x1A) -
     #[error("")]
     TokenAccountOneTimeAuthMintMismatch,
-    /// 0x1B - Derived key invalid
+    /// 27 (0x1B) - Derived key invalid
     #[error("Derived key invalid")]
     DerivedKeyInvalid,
-    /// 0x1C - The Printing mint does not match that on the master edition!
+    /// 28 (0x1C) - The Printing mint does not match that on the master edition!
     #[error("The Printing mint does not match that on the master edition!")]
     PrintingMintMismatch,
-    /// 0x1D - The One Time Printing Auth mint does not match that on the master edition!
+    /// 29 (0x1D) - The One Time Printing Auth mint does not match that on the master edition!
     #[error("The One Time Printing Auth mint does not match that on the master edition!")]
     OneTimePrintingAuthMintMismatch,
-    /// 0x1E - The mint of the token account does not match the Printing mint!
+    /// 30 (0x1E) - The mint of the token account does not match the Printing mint!
     #[error("The mint of the token account does not match the Printing mint!")]
     TokenAccountMintMismatch,
-    /// 0x1F - The mint of the token account does not match the master metadata mint!
+    /// 31 (0x1F) - The mint of the token account does not match the master metadata mint!
     #[error("The mint of the token account does not match the master metadata mint!")]
     TokenAccountMintMismatchV2,
-    /// 0x20 - Not enough tokens to mint a limited edition
+    /// 32 (0x20) - Not enough tokens to mint a limited edition
     #[error("Not enough tokens to mint a limited edition")]
     NotEnoughTokens,
-    /// 0x21 -
+    /// 33 (0x21) -
     #[error("")]
     PrintingMintAuthorizationAccountMismatch,
-    /// 0x22 -
+    /// 34 (0x22) -
     #[error("")]
     AuthorizationTokenAccountOwnerMismatch,
-    /// 0x23 -
+    /// 35 (0x23) -
     #[error("")]
     Disabled,
-    /// 0x24 - Creators list too long
+    /// 36 (0x24) - Creators list too long
     #[error("Creators list too long")]
     CreatorsTooLong,
-    /// 0x25 - Creators must be at least one if set
+    /// 37 (0x25) - Creators must be at least one if set
     #[error("Creators must be at least one if set")]
     CreatorsMustBeAtleastOne,
-    /// 0x26 -
+    /// 38 (0x26) -
     #[error("")]
     MustBeOneOfCreators,
-    /// 0x27 - This metadata does not have creators
+    /// 39 (0x27) - This metadata does not have creators
     #[error("This metadata does not have creators")]
     NoCreatorsPresentOnMetadata,
-    /// 0x28 - This creator address was not found
+    /// 40 (0x28) - This creator address was not found
     #[error("This creator address was not found")]
     CreatorNotFound,
-    /// 0x29 - Basis points cannot be more than 10000
+    /// 41 (0x29) - Basis points cannot be more than 10000
     #[error("Basis points cannot be more than 10000")]
     InvalidBasisPoints,
-    /// 0x2A - Primary sale can only be flipped to true and is immutable
+    /// 42 (0x2A) - Primary sale can only be flipped to true and is immutable
     #[error("Primary sale can only be flipped to true and is immutable")]
     PrimarySaleCanOnlyBeFlippedToTrue,
-    /// 0x2B - Owner does not match that on the account given
+    /// 43 (0x2B) - Owner does not match that on the account given
     #[error("Owner does not match that on the account given")]
     OwnerMismatch,
-    /// 0x2C - This account has no tokens to be used for authorization
+    /// 44 (0x2C) - This account has no tokens to be used for authorization
     #[error("This account has no tokens to be used for authorization")]
     NoBalanceInAccountForAuthorization,
-    /// 0x2D - Share total must equal 100 for creator array
+    /// 45 (0x2D) - Share total must equal 100 for creator array
     #[error("Share total must equal 100 for creator array")]
     ShareTotalMustBe100,
-    /// 0x2E -
+    /// 46 (0x2E) -
     #[error("")]
     ReservationExists,
-    /// 0x2F -
+    /// 47 (0x2F) -
     #[error("")]
     ReservationDoesNotExist,
-    /// 0x30 -
+    /// 48 (0x30) -
     #[error("")]
     ReservationNotSet,
-    /// 0x31 -
+    /// 49 (0x31) -
     #[error("")]
     ReservationAlreadyMade,
-    /// 0x32 -
+    /// 50 (0x32) -
     #[error("")]
     BeyondMaxAddressSize,
-    /// 0x33 - NumericalOverflowError
+    /// 51 (0x33) - NumericalOverflowError
     #[error("NumericalOverflowError")]
     NumericalOverflowError,
-    /// 0x34 -
+    /// 52 (0x34) -
     #[error("")]
     ReservationBreachesMaximumSupply,
-    /// 0x35 -
+    /// 53 (0x35) -
     #[error("")]
     AddressNotInReservation,
-    /// 0x36 - You cannot unilaterally verify another creator, they must sign
+    /// 54 (0x36) - You cannot unilaterally verify another creator, they must sign
     #[error("You cannot unilaterally verify another creator, they must sign")]
     CannotVerifyAnotherCreator,
-    /// 0x37 - You cannot unilaterally unverify another creator
+    /// 55 (0x37) - You cannot unilaterally unverify another creator
     #[error("You cannot unilaterally unverify another creator")]
     CannotUnverifyAnotherCreator,
-    /// 0x38 -
+    /// 56 (0x38) -
     #[error("")]
     SpotMismatch,
-    /// 0x39 - Incorrect account owner
+    /// 57 (0x39) - Incorrect account owner
     #[error("Incorrect account owner")]
     IncorrectOwner,
-    /// 0x3A -
+    /// 58 (0x3A) -
     #[error("")]
     PrintingWouldBreachMaximumSupply,
-    /// 0x3B - Data is immutable
+    /// 59 (0x3B) - Data is immutable
     #[error("Data is immutable")]
     DataIsImmutable,
-    /// 0x3C - No duplicate creator addresses
+    /// 60 (0x3C) - No duplicate creator addresses
     #[error("No duplicate creator addresses")]
     DuplicateCreatorAddress,
-    /// 0x3D -
+    /// 61 (0x3D) -
     #[error("")]
     ReservationSpotsRemainingShouldMatchTotalSpotsAtStart,
-    /// 0x3E - Invalid token program
+    /// 62 (0x3E) - Invalid token program
     #[error("Invalid token program")]
     InvalidTokenProgram,
-    /// 0x3F - Data type mismatch
+    /// 63 (0x3F) - Data type mismatch
     #[error("Data type mismatch")]
     DataTypeMismatch,
-    /// 0x40 -
+    /// 64 (0x40) -
     #[error("")]
     BeyondAlottedAddressSize,
-    /// 0x41 -
+    /// 65 (0x41) -
     #[error("")]
     ReservationNotComplete,
-    /// 0x42 -
+    /// 66 (0x42) -
     #[error("")]
     TriedToReplaceAnExistingReservation,
-    /// 0x43 - Invalid operation
+    /// 67 (0x43) - Invalid operation
     #[error("Invalid operation")]
     InvalidOperation,
-    /// 0x44 - Invalid Owner
+    /// 68 (0x44) - Invalid Owner
     #[error("Invalid Owner")]
     InvalidOwner,
-    /// 0x45 - Printing mint supply must be zero for conversion
+    /// 69 (0x45) - Printing mint supply must be zero for conversion
     #[error("Printing mint supply must be zero for conversion")]
     PrintingMintSupplyMustBeZeroForConversion,
-    /// 0x46 - One Time Auth mint supply must be zero for conversion
+    /// 70 (0x46) - One Time Auth mint supply must be zero for conversion
     #[error("One Time Auth mint supply must be zero for conversion")]
     OneTimeAuthMintSupplyMustBeZeroForConversion,
-    /// 0x47 - You tried to insert one edition too many into an edition mark pda
+    /// 71 (0x47) - You tried to insert one edition too many into an edition mark pda
     #[error("You tried to insert one edition too many into an edition mark pda")]
     InvalidEditionIndex,
-    /// 0x48 -
+    /// 72 (0x48) -
     #[error("")]
     ReservationArrayShouldBeSizeOne,
-    /// 0x49 - Is Mutable can only be flipped to false
+    /// 73 (0x49) - Is Mutable can only be flipped to false
     #[error("Is Mutable can only be flipped to false")]
     IsMutableCanOnlyBeFlippedToFalse,
-    /// 0x4A - Collection cannot be verified in this instruction
+    /// 74 (0x4A) - Collection cannot be verified in this instruction
     #[error("Collection cannot be verified in this instruction")]
     CollectionCannotBeVerifiedInThisInstruction,
-    /// 0x4B - This instruction was deprecated in a previous release and is now removed
+    /// 75 (0x4B) - This instruction was deprecated in a previous release and is now removed
     #[error("This instruction was deprecated in a previous release and is now removed")]
     Removed,
-    /// 0x4C -
+    /// 76 (0x4C) -
     #[error("")]
     MustBeBurned,
-    /// 0x4D - This use method is invalid
+    /// 77 (0x4D) - This use method is invalid
     #[error("This use method is invalid")]
     InvalidUseMethod,
-    /// 0x4E - Cannot Change Use Method after the first use
+    /// 78 (0x4E) - Cannot Change Use Method after the first use
     #[error("Cannot Change Use Method after the first use")]
     CannotChangeUseMethodAfterFirstUse,
-    /// 0x4F - Cannot Change Remaining or Available uses after the first use
+    /// 79 (0x4F) - Cannot Change Remaining or Available uses after the first use
     #[error("Cannot Change Remaining or Available uses after the first use")]
     CannotChangeUsesAfterFirstUse,
-    /// 0x50 - Collection Not Found on Metadata
+    /// 80 (0x50) - Collection Not Found on Metadata
     #[error("Collection Not Found on Metadata")]
     CollectionNotFound,
-    /// 0x51 - Collection Update Authority is invalid
+    /// 81 (0x51) - Collection Update Authority is invalid
     #[error("Collection Update Authority is invalid")]
     InvalidCollectionUpdateAuthority,
-    /// 0x52 - Collection Must Be a Unique Master Edition v2
+    /// 82 (0x52) - Collection Must Be a Unique Master Edition v2
     #[error("Collection Must Be a Unique Master Edition v2")]
     CollectionMustBeAUniqueMasterEdition,
-    /// 0x53 - The Use Authority Record Already Exists, to modify it Revoke, then Approve
+    /// 83 (0x53) - The Use Authority Record Already Exists, to modify it Revoke, then Approve
     #[error("The Use Authority Record Already Exists, to modify it Revoke, then Approve")]
     UseAuthorityRecordAlreadyExists,
-    /// 0x54 - The Use Authority Record is empty or already revoked
+    /// 84 (0x54) - The Use Authority Record is empty or already revoked
     #[error("The Use Authority Record is empty or already revoked")]
     UseAuthorityRecordAlreadyRevoked,
-    /// 0x55 - This token has no uses
+    /// 85 (0x55) - This token has no uses
     #[error("This token has no uses")]
     Unusable,
-    /// 0x56 - There are not enough Uses left on this token.
+    /// 86 (0x56) - There are not enough Uses left on this token.
     #[error("There are not enough Uses left on this token.")]
     NotEnoughUses,
-    /// 0x57 - This Collection Authority Record Already Exists.
+    /// 87 (0x57) - This Collection Authority Record Already Exists.
     #[error("This Collection Authority Record Already Exists.")]
     CollectionAuthorityRecordAlreadyExists,
-    /// 0x58 - This Collection Authority Record Does Not Exist.
+    /// 88 (0x58) - This Collection Authority Record Does Not Exist.
     #[error("This Collection Authority Record Does Not Exist.")]
     CollectionAuthorityDoesNotExist,
-    /// 0x59 - This Use Authority Record is invalid.
+    /// 89 (0x59) - This Use Authority Record is invalid.
     #[error("This Use Authority Record is invalid.")]
     InvalidUseAuthorityRecord,
-    /// 0x5A -
+    /// 90 (0x5A) -
     #[error("")]
     InvalidCollectionAuthorityRecord,
-    /// 0x5B - Metadata does not match the freeze authority on the mint
+    /// 91 (0x5B) - Metadata does not match the freeze authority on the mint
     #[error("Metadata does not match the freeze authority on the mint")]
     InvalidFreezeAuthority,
-    /// 0x5C - All tokens in this account have not been delegated to this user.
+    /// 92 (0x5C) - All tokens in this account have not been delegated to this user.
     #[error("All tokens in this account have not been delegated to this user.")]
     InvalidDelegate,
-    /// 0x5D -
+    /// 93 (0x5D) -
     #[error("")]
     CannotAdjustVerifiedCreator,
-    /// 0x5E - Verified creators cannot be removed.
+    /// 94 (0x5E) - Verified creators cannot be removed.
     #[error("Verified creators cannot be removed.")]
     CannotRemoveVerifiedCreator,
-    /// 0x5F -
+    /// 95 (0x5F) -
     #[error("")]
     CannotWipeVerifiedCreators,
-    /// 0x60 -
+    /// 96 (0x60) -
     #[error("")]
     NotAllowedToChangeSellerFeeBasisPoints,
-    /// 0x61 - Edition override cannot be zero
+    /// 97 (0x61) - Edition override cannot be zero
     #[error("Edition override cannot be zero")]
     EditionOverrideCannotBeZero,
-    /// 0x62 - Invalid User
+    /// 98 (0x62) - Invalid User
     #[error("Invalid User")]
     InvalidUser,
-    /// 0x63 - Revoke Collection Authority signer is incorrect
+    /// 99 (0x63) - Revoke Collection Authority signer is incorrect
     #[error("Revoke Collection Authority signer is incorrect")]
     RevokeCollectionAuthoritySignerIncorrect,
-    /// 0x64 -
+    /// 100 (0x64) -
     #[error("")]
     TokenCloseFailed,
-    /// 0x65 - Can't use this function on unsized collection
+    /// 101 (0x65) - Can't use this function on unsized collection
     #[error("Can't use this function on unsized collection")]
     UnsizedCollection,
-    /// 0x66 - Can't use this function on a sized collection
+    /// 102 (0x66) - Can't use this function on a sized collection
     #[error("Can't use this function on a sized collection")]
     SizedCollection,
-    /// 0x67 - Missing collection metadata account
+    /// 103 (0x67) - Missing collection metadata account
     #[error("Missing collection metadata account")]
     MissingCollectionMetadata,
-    /// 0x68 - This NFT is not a member of the specified collection.
+    /// 104 (0x68) - This NFT is not a member of the specified collection.
     #[error("This NFT is not a member of the specified collection.")]
     NotAMemberOfCollection,
-    /// 0x69 - This NFT is not a verified member of the specified collection.
+    /// 105 (0x69) - This NFT is not a verified member of the specified collection.
     #[error("This NFT is not a verified member of the specified collection.")]
     NotVerifiedMemberOfCollection,
-    /// 0x6A - This NFT is not a collection parent NFT.
+    /// 106 (0x6A) - This NFT is not a collection parent NFT.
     #[error("This NFT is not a collection parent NFT.")]
     NotACollectionParent,
-    /// 0x6B - Could not determine a TokenStandard type.
+    /// 107 (0x6B) - Could not determine a TokenStandard type.
     #[error("Could not determine a TokenStandard type.")]
     CouldNotDetermineTokenStandard,
-    /// 0x6C - This mint account has an edition but none was provided.
+    /// 108 (0x6C) - This mint account has an edition but none was provided.
     #[error("This mint account has an edition but none was provided.")]
     MissingEditionAccount,
-    /// 0x6D - This edition is not a Master Edition
+    /// 109 (0x6D) - This edition is not a Master Edition
     #[error("This edition is not a Master Edition")]
     NotAMasterEdition,
-    /// 0x6E - This Master Edition has existing prints
+    /// 110 (0x6E) - This Master Edition has existing prints
     #[error("This Master Edition has existing prints")]
     MasterEditionHasPrints,
-    /// 0x6F -
+    /// 111 (0x6F) -
     #[error("")]
     BorshDeserializationError,
-    /// 0x70 - Cannot update a verified collection in this command
+    /// 112 (0x70) - Cannot update a verified collection in this command
     #[error("Cannot update a verified collection in this command")]
     CannotUpdateVerifiedCollection,
-    /// 0x71 - Edition account doesnt match collection
+    /// 113 (0x71) - Edition account doesnt match collection
     #[error("Edition account doesnt match collection ")]
     CollectionMasterEditionAccountInvalid,
-    /// 0x72 - Item is already verified.
+    /// 114 (0x72) - Item is already verified.
     #[error("Item is already verified.")]
     AlreadyVerified,
-    /// 0x73 -
+    /// 115 (0x73) -
     #[error("")]
     AlreadyUnverified,
-    /// 0x74 - This edition is not a Print Edition
+    /// 116 (0x74) - This edition is not a Print Edition
     #[error("This edition is not a Print Edition")]
     NotAPrintEdition,
-    /// 0x75 - Invalid Master Edition
+    /// 117 (0x75) - Invalid Master Edition
     #[error("Invalid Master Edition")]
     InvalidMasterEdition,
-    /// 0x76 - Invalid Print Edition
+    /// 118 (0x76) - Invalid Print Edition
     #[error("Invalid Print Edition")]
     InvalidPrintEdition,
-    /// 0x77 - Invalid Edition Marker
+    /// 119 (0x77) - Invalid Edition Marker
     #[error("Invalid Edition Marker")]
     InvalidEditionMarker,
-    /// 0x78 - Reservation List is Deprecated
+    /// 120 (0x78) - Reservation List is Deprecated
     #[error("Reservation List is Deprecated")]
     ReservationListDeprecated,
-    /// 0x79 - Print Edition does not match Master Edition
+    /// 121 (0x79) - Print Edition does not match Master Edition
     #[error("Print Edition does not match Master Edition")]
     PrintEditionDoesNotMatchMasterEdition,
-    /// 0x7A - Edition Number greater than max supply
+    /// 122 (0x7A) - Edition Number greater than max supply
     #[error("Edition Number greater than max supply")]
     EditionNumberGreaterThanMaxSupply,
-    /// 0x7B - Must unverify before migrating collections.
+    /// 123 (0x7B) - Must unverify before migrating collections.
     #[error("Must unverify before migrating collections.")]
     MustUnverify,
-    /// 0x7C - Invalid Escrow Account Bump Seed
+    /// 124 (0x7C) - Invalid Escrow Account Bump Seed
     #[error("Invalid Escrow Account Bump Seed")]
     InvalidEscrowBumpSeed,
-    /// 0x7D - Must Escrow Authority
+    /// 125 (0x7D) - Must Escrow Authority
     #[error("Must Escrow Authority")]
     MustBeEscrowAuthority,
-    /// 0x7E - Invalid System Program
+    /// 126 (0x7E) - Invalid System Program
     #[error("Invalid System Program")]
     InvalidSystemProgram,
-    /// 0x7F - Must be a Non Fungible Token
+    /// 127 (0x7F) - Must be a Non Fungible Token
     #[error("Must be a Non Fungible Token")]
     MustBeNonFungible,
-    /// 0x80 - Insufficient tokens for transfer
+    /// 128 (0x80) - Insufficient tokens for transfer
     #[error("Insufficient tokens for transfer")]
     InsufficientTokens,
-    /// 0x81 - Borsh Serialization Error
+    /// 129 (0x81) - Borsh Serialization Error
     #[error("Borsh Serialization Error")]
     BorshSerializationError,
-    /// 0x82 - Cannot create NFT with no Freeze Authority.
+    /// 130 (0x82) - Cannot create NFT with no Freeze Authority.
     #[error("Cannot create NFT with no Freeze Authority.")]
     NoFreezeAuthoritySet,
-    /// 0x83 - Invalid collection size change
+    /// 131 (0x83) - Invalid collection size change
     #[error("Invalid collection size change")]
     InvalidCollectionSizeChange,
-    /// 0x84 - Invalid bubblegum signer
+    /// 132 (0x84) - Invalid bubblegum signer
     #[error("Invalid bubblegum signer")]
     InvalidBubblegumSigner,
-    /// 0x85 - Escrow parent cannot have a delegate
+    /// 133 (0x85) - Escrow parent cannot have a delegate
     #[error("Escrow parent cannot have a delegate")]
     EscrowParentHasDelegate,
-    /// 0x86 - Mint needs to be signer to initialize the account
+    /// 134 (0x86) - Mint needs to be signer to initialize the account
     #[error("Mint needs to be signer to initialize the account")]
     MintIsNotSigner,
-    /// 0x87 - Invalid token standard
+    /// 135 (0x87) - Invalid token standard
     #[error("Invalid token standard")]
     InvalidTokenStandard,
-    /// 0x88 - Invalid mint account for specified token standard
+    /// 136 (0x88) - Invalid mint account for specified token standard
     #[error("Invalid mint account for specified token standard")]
     InvalidMintForTokenStandard,
-    /// 0x89 - Invalid authorization rules account
+    /// 137 (0x89) - Invalid authorization rules account
     #[error("Invalid authorization rules account")]
     InvalidAuthorizationRules,
-    /// 0x8A - Missing authorization rules account
+    /// 138 (0x8A) - Missing authorization rules account
     #[error("Missing authorization rules account")]
     MissingAuthorizationRules,
-    /// 0x8B - Missing programmable configuration
+    /// 139 (0x8B) - Missing programmable configuration
     #[error("Missing programmable configuration")]
     MissingProgrammableConfig,
-    /// 0x8C - Invalid programmable configuration
+    /// 140 (0x8C) - Invalid programmable configuration
     #[error("Invalid programmable configuration")]
     InvalidProgrammableConfig,
-    /// 0x8D - Delegate already exists
+    /// 141 (0x8D) - Delegate already exists
     #[error("Delegate already exists")]
     DelegateAlreadyExists,
-    /// 0x8E - Delegate not found
+    /// 142 (0x8E) - Delegate not found
     #[error("Delegate not found")]
     DelegateNotFound,
-    /// 0x8F - Required account not set in instruction builder
+    /// 143 (0x8F) - Required account not set in instruction builder
     #[error("Required account not set in instruction builder")]
     MissingAccountInBuilder,
-    /// 0x90 - Required argument not set in instruction builder
+    /// 144 (0x90) - Required argument not set in instruction builder
     #[error("Required argument not set in instruction builder")]
     MissingArgumentInBuilder,
-    /// 0x91 - Feature not supported currently
+    /// 145 (0x91) - Feature not supported currently
     #[error("Feature not supported currently")]
     FeatureNotSupported,
-    /// 0x92 - Invalid system wallet
+    /// 146 (0x92) - Invalid system wallet
     #[error("Invalid system wallet")]
     InvalidSystemWallet,
-    /// 0x93 - Only the sale delegate can transfer while its set
+    /// 147 (0x93) - Only the sale delegate can transfer while its set
     #[error("Only the sale delegate can transfer while its set")]
     OnlySaleDelegateCanTransfer,
-    /// 0x94 - Missing token account
+    /// 148 (0x94) - Missing token account
     #[error("Missing token account")]
     MissingTokenAccount,
-    /// 0x95 - Missing SPL token program
+    /// 149 (0x95) - Missing SPL token program
     #[error("Missing SPL token program")]
     MissingSplTokenProgram,
-    /// 0x96 - Missing authorization rules program
+    /// 150 (0x96) - Missing authorization rules program
     #[error("Missing authorization rules program")]
     MissingAuthorizationRulesProgram,
-    /// 0x97 - Invalid delegate role for transfer
+    /// 151 (0x97) - Invalid delegate role for transfer
     #[error("Invalid delegate role for transfer")]
     InvalidDelegateRoleForTransfer,
-    /// 0x98 - Invalid transfer authority
+    /// 152 (0x98) - Invalid transfer authority
     #[error("Invalid transfer authority")]
     InvalidTransferAuthority,
-    /// 0x99 - Instruction not supported for ProgrammableNonFungible assets
+    /// 153 (0x99) - Instruction not supported for ProgrammableNonFungible assets
     #[error("Instruction not supported for ProgrammableNonFungible assets")]
     InstructionNotSupported,
-    /// 0x9A - Public key does not match expected value
+    /// 154 (0x9A) - Public key does not match expected value
     #[error("Public key does not match expected value")]
     KeyMismatch,
-    /// 0x9B - Token is locked
+    /// 155 (0x9B) - Token is locked
     #[error("Token is locked")]
     LockedToken,
-    /// 0x9C - Token is unlocked
+    /// 156 (0x9C) - Token is unlocked
     #[error("Token is unlocked")]
     UnlockedToken,
-    /// 0x9D - Missing delegate role
+    /// 157 (0x9D) - Missing delegate role
     #[error("Missing delegate role")]
     MissingDelegateRole,
-    /// 0x9E - Invalid authority type
+    /// 158 (0x9E) - Invalid authority type
     #[error("Invalid authority type")]
     InvalidAuthorityType,
-    /// 0x9F - Missing token record account
+    /// 159 (0x9F) - Missing token record account
     #[error("Missing token record account")]
     MissingTokenRecord,
-    /// 0xA0 - Mint supply must be zero for programmable assets
+    /// 160 (0xA0) - Mint supply must be zero for programmable assets
     #[error("Mint supply must be zero for programmable assets")]
     MintSupplyMustBeZero,
-    /// 0xA1 - Data is empty or zeroed
+    /// 161 (0xA1) - Data is empty or zeroed
     #[error("Data is empty or zeroed")]
     DataIsEmptyOrZeroed,
-    /// 0xA2 - Missing token owner
+    /// 162 (0xA2) - Missing token owner
     #[error("Missing token owner")]
     MissingTokenOwnerAccount,
-    /// 0xA3 - Master edition account has an invalid length
+    /// 163 (0xA3) - Master edition account has an invalid length
     #[error("Master edition account has an invalid length")]
     InvalidMasterEditionAccountLength,
-    /// 0xA4 - Incorrect token state
+    /// 164 (0xA4) - Incorrect token state
     #[error("Incorrect token state")]
     IncorrectTokenState,
-    /// 0xA5 - Invalid delegate role
+    /// 165 (0xA5) - Invalid delegate role
     #[error("Invalid delegate role")]
     InvalidDelegateRole,
-    /// 0xA6 - Print supply is required for non-fungibles
+    /// 166 (0xA6) - Print supply is required for non-fungibles
     #[error("Print supply is required for non-fungibles")]
     MissingPrintSupply,
-    /// 0xA7 - Missing master edition account
+    /// 167 (0xA7) - Missing master edition account
     #[error("Missing master edition account")]
     MissingMasterEditionAccount,
-    /// 0xA8 - Amount must be greater than zero
+    /// 168 (0xA8) - Amount must be greater than zero
     #[error("Amount must be greater than zero")]
     AmountMustBeGreaterThanZero,
-    /// 0xA9 - Invalid delegate args
+    /// 169 (0xA9) - Invalid delegate args
     #[error("Invalid delegate args")]
     InvalidDelegateArgs,
-    /// 0xAA - Missing address for locked transfer
+    /// 170 (0xAA) - Missing address for locked transfer
     #[error("Missing address for locked transfer")]
     MissingLockedTransferAddress,
-    /// 0xAB - Invalid destination address for locked transfer
+    /// 171 (0xAB) - Invalid destination address for locked transfer
     #[error("Invalid destination address for locked transfer")]
     InvalidLockedTransferAddress,
-    /// 0xAC - Exceeded account realloc increase limit
+    /// 172 (0xAC) - Exceeded account realloc increase limit
     #[error("Exceeded account realloc increase limit")]
     DataIncrementLimitExceeded,
-    /// 0xAD - Cannot update the rule set of a programmable asset that has a delegate
+    /// 173 (0xAD) - Cannot update the rule set of a programmable asset that has a delegate
     #[error("Cannot update the rule set of a programmable asset that has a delegate")]
     CannotUpdateAssetWithDelegate,
-    /// 0xAE - Invalid token amount for this operation or token standard
+    /// 174 (0xAE) - Invalid token amount for this operation or token standard
     #[error("Invalid token amount for this operation or token standard")]
     InvalidAmount,
-    /// 0xAF - Missing master edition mint account
+    /// 175 (0xAF) - Missing master edition mint account
     #[error("Missing master edition mint account")]
     MissingMasterEditionMintAccount,
-    /// 0xB0 - Missing master edition token account
+    /// 176 (0xB0) - Missing master edition token account
     #[error("Missing master edition token account")]
     MissingMasterEditionTokenAccount,
-    /// 0xB1 - Missing edition marker account
+    /// 177 (0xB1) - Missing edition marker account
     #[error("Missing edition marker account")]
     MissingEditionMarkerAccount,
-    /// 0xB2 - Cannot burn while persistent delegate is set
+    /// 178 (0xB2) - Cannot burn while persistent delegate is set
     #[error("Cannot burn while persistent delegate is set")]
     CannotBurnWithDelegate,
-    /// 0xB3 - Missing edition account
+    /// 179 (0xB3) - Missing edition account
     #[error("Missing edition account")]
     MissingEdition,
-    /// 0xB4 - Invalid Associated Token Account Program
+    /// 180 (0xB4) - Invalid Associated Token Account Program
     #[error("Invalid Associated Token Account Program")]
     InvalidAssociatedTokenAccountProgram,
-    /// 0xB5 - Invalid InstructionsSysvar
+    /// 181 (0xB5) - Invalid InstructionsSysvar
     #[error("Invalid InstructionsSysvar")]
     InvalidInstructionsSysvar,
-    /// 0xB6 - Invalid or Unneeded parent accounts
+    /// 182 (0xB6) - Invalid or Unneeded parent accounts
     #[error("Invalid or Unneeded parent accounts")]
     InvalidParentAccounts,
-    /// 0xB7 - Authority cannot apply all update args
+    /// 183 (0xB7) - Authority cannot apply all update args
     #[error("Authority cannot apply all update args")]
     InvalidUpdateArgs,
-    /// 0xB8 - Token account does not have enough tokens
+    /// 184 (0xB8) - Token account does not have enough tokens
     #[error("Token account does not have enough tokens")]
     InsufficientTokenBalance,
-    /// 0xB9 - Missing collection account
+    /// 185 (0xB9) - Missing collection account
     #[error("Missing collection account")]
     MissingCollectionMint,
-    /// 0xBA - Missing collection master edition account
+    /// 186 (0xBA) - Missing collection master edition account
     #[error("Missing collection master edition account")]
     MissingCollectionMasterEdition,
-    /// 0xBB - Invalid token record account
+    /// 187 (0xBB) - Invalid token record account
     #[error("Invalid token record account")]
     InvalidTokenRecord,
-    /// 0xBC - The close authority needs to be revoked by the Utility Delegate
+    /// 188 (0xBC) - The close authority needs to be revoked by the Utility Delegate
     #[error("The close authority needs to be revoked by the Utility Delegate")]
     InvalidCloseAuthority,
-    /// 0xBD - Invalid or removed instruction
+    /// 189 (0xBD) - Invalid or removed instruction
     #[error("Invalid or removed instruction")]
     InvalidInstruction,
-    /// 0xBE - Missing delegate record
+    /// 190 (0xBE) - Missing delegate record
     #[error("Missing delegate record")]
     MissingDelegateRecord,
-    /// 0xBF -
+    /// 191 (0xBF) -
     #[error("")]
     InvalidFeeAccount,
-    /// 0xC0 -
+    /// 192 (0xC0) -
     #[error("")]
     InvalidMetadataFlags,
-    /// 0xC1 - Cannot change the update authority with a delegate
+    /// 193 (0xC1) - Cannot change the update authority with a delegate
     #[error("Cannot change the update authority with a delegate")]
     CannotChangeUpdateAuthorityWithDelegate,
 }

--- a/clients/rust/src/generated/instructions/approve_collection_authority.rs
+++ b/clients/rust/src/generated/instructions/approve_collection_authority.rs
@@ -206,51 +206,51 @@ impl ApproveCollectionAuthorityBuilder {
 }
 
 /// `approve_collection_authority` CPI accounts.
-pub struct ApproveCollectionAuthorityCpiAccounts<'a> {
+pub struct ApproveCollectionAuthorityCpiAccounts<'a, 'b> {
     /// Collection Authority Record PDA
-    pub collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// A Collection Authority
-    pub new_collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update Authority of Collection NFT
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of Collection Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `approve_collection_authority` CPI instruction.
-pub struct ApproveCollectionAuthorityCpi<'a> {
+pub struct ApproveCollectionAuthorityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// A Collection Authority
-    pub new_collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update Authority of Collection NFT
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of Collection Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> ApproveCollectionAuthorityCpi<'a> {
+impl<'a, 'b> ApproveCollectionAuthorityCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: ApproveCollectionAuthorityCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: ApproveCollectionAuthorityCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -271,7 +271,7 @@ impl<'a> ApproveCollectionAuthorityCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -287,7 +287,7 @@ impl<'a> ApproveCollectionAuthorityCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -360,12 +360,12 @@ impl<'a> ApproveCollectionAuthorityCpi<'a> {
 }
 
 /// `approve_collection_authority` CPI instruction builder.
-pub struct ApproveCollectionAuthorityCpiBuilder<'a> {
-    instruction: Box<ApproveCollectionAuthorityCpiBuilderInstruction<'a>>,
+pub struct ApproveCollectionAuthorityCpiBuilder<'a, 'b> {
+    instruction: Box<ApproveCollectionAuthorityCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> ApproveCollectionAuthorityCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(ApproveCollectionAuthorityCpiBuilderInstruction {
             __program: program,
             collection_authority_record: None,
@@ -384,7 +384,7 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = Some(collection_authority_record);
         self
@@ -393,7 +393,7 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_collection_authority(
         &mut self,
-        new_collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        new_collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_collection_authority = Some(new_collection_authority);
         self
@@ -402,14 +402,14 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -417,14 +417,14 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Mint of Collection Metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -432,7 +432,7 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -442,7 +442,7 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn rent(
         &mut self,
-        rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.rent = rent;
         self
@@ -450,7 +450,7 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -458,7 +458,7 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -513,15 +513,15 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     }
 }
 
-struct ApproveCollectionAuthorityCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct ApproveCollectionAuthorityCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/approve_use_authority.rs
+++ b/clients/rust/src/generated/instructions/approve_use_authority.rs
@@ -270,65 +270,65 @@ impl ApproveUseAuthorityBuilder {
 }
 
 /// `approve_use_authority` CPI accounts.
-pub struct ApproveUseAuthorityCpiAccounts<'a> {
+pub struct ApproveUseAuthorityCpiAccounts<'a, 'b> {
     /// Use Authority Record PDA
-    pub use_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub use_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// A Use Authority
-    pub user: &'a solana_program::account_info::AccountInfo<'a>,
+    pub user: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owned Token Account Of Mint
-    pub owner_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Program As Signer (Burner)
-    pub burner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub burner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `approve_use_authority` CPI instruction.
-pub struct ApproveUseAuthorityCpi<'a> {
+pub struct ApproveUseAuthorityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Use Authority Record PDA
-    pub use_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub use_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// A Use Authority
-    pub user: &'a solana_program::account_info::AccountInfo<'a>,
+    pub user: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owned Token Account Of Mint
-    pub owner_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Program As Signer (Burner)
-    pub burner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub burner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: ApproveUseAuthorityInstructionArgs,
 }
 
-impl<'a> ApproveUseAuthorityCpi<'a> {
+impl<'a, 'b> ApproveUseAuthorityCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: ApproveUseAuthorityCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: ApproveUseAuthorityCpiAccounts<'a, 'b>,
         args: ApproveUseAuthorityInstructionArgs,
     ) -> Self {
         Self {
@@ -354,7 +354,7 @@ impl<'a> ApproveUseAuthorityCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -370,7 +370,7 @@ impl<'a> ApproveUseAuthorityCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -460,12 +460,12 @@ impl<'a> ApproveUseAuthorityCpi<'a> {
 }
 
 /// `approve_use_authority` CPI instruction builder.
-pub struct ApproveUseAuthorityCpiBuilder<'a> {
-    instruction: Box<ApproveUseAuthorityCpiBuilderInstruction<'a>>,
+pub struct ApproveUseAuthorityCpiBuilder<'a, 'b> {
+    instruction: Box<ApproveUseAuthorityCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> ApproveUseAuthorityCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(ApproveUseAuthorityCpiBuilderInstruction {
             __program: program,
             use_authority_record: None,
@@ -488,26 +488,26 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn use_authority_record(
         &mut self,
-        use_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+        use_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.use_authority_record = Some(use_authority_record);
         self
     }
     /// Owner
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
     /// A Use Authority
     #[inline(always)]
-    pub fn user(&mut self, user: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn user(&mut self, user: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.user = Some(user);
         self
     }
@@ -515,7 +515,7 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn owner_token_account(
         &mut self,
-        owner_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        owner_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.owner_token_account = Some(owner_token_account);
         self
@@ -524,14 +524,14 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Mint of Metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -539,7 +539,7 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn burner(
         &mut self,
-        burner: &'a solana_program::account_info::AccountInfo<'a>,
+        burner: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.burner = Some(burner);
         self
@@ -548,7 +548,7 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -557,7 +557,7 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -567,7 +567,7 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn rent(
         &mut self,
-        rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.rent = rent;
         self
@@ -580,7 +580,7 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -588,7 +588,7 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -657,19 +657,19 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     }
 }
 
-struct ApproveUseAuthorityCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    use_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    user: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner_token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    burner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct ApproveUseAuthorityCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    user: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    burner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     number_of_uses: Option<u64>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/bubblegum_set_collection_size.rs
+++ b/clients/rust/src/generated/instructions/bubblegum_set_collection_size.rs
@@ -198,41 +198,41 @@ impl BubblegumSetCollectionSizeBuilder {
 }
 
 /// `bubblegum_set_collection_size` CPI accounts.
-pub struct BubblegumSetCollectionSizeCpiAccounts<'a> {
+pub struct BubblegumSetCollectionSizeCpiAccounts<'a, 'b> {
     /// Collection Metadata account
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Signing PDA of Bubblegum program
-    pub bubblegum_signer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub bubblegum_signer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `bubblegum_set_collection_size` CPI instruction.
-pub struct BubblegumSetCollectionSizeCpi<'a> {
+pub struct BubblegumSetCollectionSizeCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Metadata account
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Signing PDA of Bubblegum program
-    pub bubblegum_signer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub bubblegum_signer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: BubblegumSetCollectionSizeInstructionArgs,
 }
 
-impl<'a> BubblegumSetCollectionSizeCpi<'a> {
+impl<'a, 'b> BubblegumSetCollectionSizeCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: BubblegumSetCollectionSizeCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: BubblegumSetCollectionSizeCpiAccounts<'a, 'b>,
         args: BubblegumSetCollectionSizeInstructionArgs,
     ) -> Self {
         Self {
@@ -252,7 +252,7 @@ impl<'a> BubblegumSetCollectionSizeCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -268,7 +268,7 @@ impl<'a> BubblegumSetCollectionSizeCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -329,12 +329,12 @@ impl<'a> BubblegumSetCollectionSizeCpi<'a> {
 }
 
 /// `bubblegum_set_collection_size` CPI instruction builder.
-pub struct BubblegumSetCollectionSizeCpiBuilder<'a> {
-    instruction: Box<BubblegumSetCollectionSizeCpiBuilderInstruction<'a>>,
+pub struct BubblegumSetCollectionSizeCpiBuilder<'a, 'b> {
+    instruction: Box<BubblegumSetCollectionSizeCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> BubblegumSetCollectionSizeCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(BubblegumSetCollectionSizeCpiBuilderInstruction {
             __program: program,
             collection_metadata: None,
@@ -351,7 +351,7 @@ impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_metadata(
         &mut self,
-        collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_metadata = Some(collection_metadata);
         self
@@ -360,7 +360,7 @@ impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority(
         &mut self,
-        collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority = Some(collection_authority);
         self
@@ -369,7 +369,7 @@ impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -378,7 +378,7 @@ impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn bubblegum_signer(
         &mut self,
-        bubblegum_signer: &'a solana_program::account_info::AccountInfo<'a>,
+        bubblegum_signer: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.bubblegum_signer = Some(bubblegum_signer);
         self
@@ -388,7 +388,7 @@ impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = collection_authority_record;
         self
@@ -404,7 +404,7 @@ impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -412,7 +412,7 @@ impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -469,13 +469,13 @@ impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
     }
 }
 
-struct BubblegumSetCollectionSizeCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    bubblegum_signer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct BubblegumSetCollectionSizeCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    bubblegum_signer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     set_collection_size_args: Option<SetCollectionSizeArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/burn_edition_nft.rs
+++ b/clients/rust/src/generated/instructions/burn_edition_nft.rs
@@ -256,59 +256,59 @@ impl BurnEditionNftBuilder {
 }
 
 /// `burn_edition_nft` CPI accounts.
-pub struct BurnEditionNftCpiAccounts<'a> {
+pub struct BurnEditionNftCpiAccounts<'a, 'b> {
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// NFT owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the print edition NFT
-    pub print_edition_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub print_edition_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the original/master NFT
-    pub master_edition_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account the print edition NFT is in
-    pub print_edition_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub print_edition_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account the Master Edition NFT is in
-    pub master_edition_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 of the original NFT
-    pub master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Print Edition account of the NFT
-    pub print_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub print_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition Marker PDA of the NFT
-    pub edition_marker_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_marker_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `burn_edition_nft` CPI instruction.
-pub struct BurnEditionNftCpi<'a> {
+pub struct BurnEditionNftCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// NFT owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the print edition NFT
-    pub print_edition_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub print_edition_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the original/master NFT
-    pub master_edition_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account the print edition NFT is in
-    pub print_edition_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub print_edition_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account the Master Edition NFT is in
-    pub master_edition_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 of the original NFT
-    pub master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Print Edition account of the NFT
-    pub print_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub print_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition Marker PDA of the NFT
-    pub edition_marker_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_marker_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> BurnEditionNftCpi<'a> {
+impl<'a, 'b> BurnEditionNftCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: BurnEditionNftCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: BurnEditionNftCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -331,7 +331,7 @@ impl<'a> BurnEditionNftCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -347,7 +347,7 @@ impl<'a> BurnEditionNftCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -425,12 +425,12 @@ impl<'a> BurnEditionNftCpi<'a> {
 }
 
 /// `burn_edition_nft` CPI instruction builder.
-pub struct BurnEditionNftCpiBuilder<'a> {
-    instruction: Box<BurnEditionNftCpiBuilderInstruction<'a>>,
+pub struct BurnEditionNftCpiBuilder<'a, 'b> {
+    instruction: Box<BurnEditionNftCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> BurnEditionNftCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> BurnEditionNftCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(BurnEditionNftCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -451,14 +451,14 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// NFT owner
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
@@ -466,7 +466,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn print_edition_mint(
         &mut self,
-        print_edition_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        print_edition_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.print_edition_mint = Some(print_edition_mint);
         self
@@ -475,7 +475,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition_mint(
         &mut self,
-        master_edition_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition_mint = Some(master_edition_mint);
         self
@@ -484,7 +484,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn print_edition_token_account(
         &mut self,
-        print_edition_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        print_edition_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.print_edition_token_account = Some(print_edition_token_account);
         self
@@ -493,7 +493,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition_token_account(
         &mut self,
-        master_edition_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition_token_account = Some(master_edition_token_account);
         self
@@ -502,7 +502,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition_account(
         &mut self,
-        master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition_account = Some(master_edition_account);
         self
@@ -511,7 +511,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn print_edition_account(
         &mut self,
-        print_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        print_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.print_edition_account = Some(print_edition_account);
         self
@@ -520,7 +520,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition_marker_account(
         &mut self,
-        edition_marker_account: &'a solana_program::account_info::AccountInfo<'a>,
+        edition_marker_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition_marker_account = Some(edition_marker_account);
         self
@@ -529,7 +529,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_token_program = Some(spl_token_program);
         self
@@ -537,7 +537,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -545,7 +545,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -616,17 +616,17 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     }
 }
 
-struct BurnEditionNftCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    print_edition_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    print_edition_token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition_token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    print_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition_marker_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct BurnEditionNftCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    print_edition_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    print_edition_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    print_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition_marker_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/burn_nft.rs
+++ b/clients/rust/src/generated/instructions/burn_nft.rs
@@ -189,47 +189,47 @@ impl BurnNftBuilder {
 }
 
 /// `burn_nft` CPI accounts.
-pub struct BurnNftCpiAccounts<'a> {
+pub struct BurnNftCpiAccounts<'a, 'b> {
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// NFT owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the NFT
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account to close
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 of the NFT
-    pub master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata of the Collection
-    pub collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `burn_nft` CPI instruction.
-pub struct BurnNftCpi<'a> {
+pub struct BurnNftCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// NFT owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the NFT
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account to close
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 of the NFT
-    pub master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata of the Collection
-    pub collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> BurnNftCpi<'a> {
+impl<'a, 'b> BurnNftCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: BurnNftCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: BurnNftCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -249,7 +249,7 @@ impl<'a> BurnNftCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -265,7 +265,7 @@ impl<'a> BurnNftCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -332,12 +332,12 @@ impl<'a> BurnNftCpi<'a> {
 }
 
 /// `burn_nft` CPI instruction builder.
-pub struct BurnNftCpiBuilder<'a> {
-    instruction: Box<BurnNftCpiBuilderInstruction<'a>>,
+pub struct BurnNftCpiBuilder<'a, 'b> {
+    instruction: Box<BurnNftCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> BurnNftCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> BurnNftCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(BurnNftCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -355,20 +355,20 @@ impl<'a> BurnNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// NFT owner
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
     /// Mint of the NFT
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -376,7 +376,7 @@ impl<'a> BurnNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account(
         &mut self,
-        token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account = Some(token_account);
         self
@@ -385,7 +385,7 @@ impl<'a> BurnNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition_account(
         &mut self,
-        master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition_account = Some(master_edition_account);
         self
@@ -394,7 +394,7 @@ impl<'a> BurnNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_token_program = Some(spl_token_program);
         self
@@ -404,7 +404,7 @@ impl<'a> BurnNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_metadata(
         &mut self,
-        collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_metadata = collection_metadata;
         self
@@ -412,7 +412,7 @@ impl<'a> BurnNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -420,7 +420,7 @@ impl<'a> BurnNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -470,14 +470,14 @@ impl<'a> BurnNftCpiBuilder<'a> {
     }
 }
 
-struct BurnNftCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct BurnNftCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/burn_v1.rs
+++ b/clients/rust/src/generated/instructions/burn_v1.rs
@@ -384,77 +384,77 @@ impl BurnV1Builder {
 }
 
 /// `burn_v1` CPI accounts.
-pub struct BurnV1CpiAccounts<'a> {
+pub struct BurnV1CpiAccounts<'a, 'b> {
     /// Asset owner or Utility delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata of the Collection
-    pub collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition of the asset
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account to close
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Master edition mint of the asset
-    pub master_edition_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Master edition token account
-    pub master_edition_token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition_token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Edition marker account
-    pub edition_marker: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition_marker: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `burn_v1` CPI instruction.
-pub struct BurnV1Cpi<'a> {
+pub struct BurnV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Asset owner or Utility delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata of the Collection
-    pub collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition of the asset
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account to close
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Master edition mint of the asset
-    pub master_edition_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Master edition token account
-    pub master_edition_token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition_token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Edition marker account
-    pub edition_marker: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition_marker: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: BurnV1InstructionArgs,
 }
 
-impl<'a> BurnV1Cpi<'a> {
+impl<'a, 'b> BurnV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: BurnV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: BurnV1CpiAccounts<'a, 'b>,
         args: BurnV1InstructionArgs,
     ) -> Self {
         Self {
@@ -483,7 +483,7 @@ impl<'a> BurnV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -499,7 +499,7 @@ impl<'a> BurnV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -662,12 +662,12 @@ impl<'a> BurnV1Cpi<'a> {
 }
 
 /// `burn_v1` CPI instruction builder.
-pub struct BurnV1CpiBuilder<'a> {
-    instruction: Box<BurnV1CpiBuilderInstruction<'a>>,
+pub struct BurnV1CpiBuilder<'a, 'b> {
+    instruction: Box<BurnV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> BurnV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> BurnV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(BurnV1CpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -693,7 +693,7 @@ impl<'a> BurnV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -703,7 +703,7 @@ impl<'a> BurnV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_metadata(
         &mut self,
-        collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_metadata = collection_metadata;
         self
@@ -712,7 +712,7 @@ impl<'a> BurnV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -722,20 +722,20 @@ impl<'a> BurnV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition = edition;
         self
     }
     /// Mint of token asset
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     /// Token account to close
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -744,7 +744,7 @@ impl<'a> BurnV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -754,7 +754,7 @@ impl<'a> BurnV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition_mint(
         &mut self,
-        master_edition_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition_mint = master_edition_mint;
         self
@@ -764,7 +764,7 @@ impl<'a> BurnV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition_token(
         &mut self,
-        master_edition_token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition_token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition_token = master_edition_token;
         self
@@ -774,7 +774,7 @@ impl<'a> BurnV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition_marker(
         &mut self,
-        edition_marker: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition_marker: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition_marker = edition_marker;
         self
@@ -784,7 +784,7 @@ impl<'a> BurnV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
@@ -793,7 +793,7 @@ impl<'a> BurnV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -802,7 +802,7 @@ impl<'a> BurnV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -811,7 +811,7 @@ impl<'a> BurnV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_token_program = Some(spl_token_program);
         self
@@ -825,7 +825,7 @@ impl<'a> BurnV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -833,7 +833,7 @@ impl<'a> BurnV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -901,22 +901,22 @@ impl<'a> BurnV1CpiBuilder<'a> {
     }
 }
 
-struct BurnV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition_token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition_marker: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct BurnV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition_token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition_marker: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     amount: Option<u64>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/close_escrow_account.rs
+++ b/clients/rust/src/generated/instructions/close_escrow_account.rs
@@ -197,51 +197,51 @@ impl CloseEscrowAccountBuilder {
 }
 
 /// `close_escrow_account` CPI accounts.
-pub struct CloseEscrowAccountCpiAccounts<'a> {
+pub struct CloseEscrowAccountCpiAccounts<'a, 'b> {
     /// Escrow account
-    pub escrow: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Wallet paying for the transaction and new account
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `close_escrow_account` CPI instruction.
-pub struct CloseEscrowAccountCpi<'a> {
+pub struct CloseEscrowAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Escrow account
-    pub escrow: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Wallet paying for the transaction and new account
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> CloseEscrowAccountCpi<'a> {
+impl<'a, 'b> CloseEscrowAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CloseEscrowAccountCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CloseEscrowAccountCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -262,7 +262,7 @@ impl<'a> CloseEscrowAccountCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -278,7 +278,7 @@ impl<'a> CloseEscrowAccountCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -348,12 +348,12 @@ impl<'a> CloseEscrowAccountCpi<'a> {
 }
 
 /// `close_escrow_account` CPI instruction builder.
-pub struct CloseEscrowAccountCpiBuilder<'a> {
-    instruction: Box<CloseEscrowAccountCpiBuilderInstruction<'a>>,
+pub struct CloseEscrowAccountCpiBuilder<'a, 'b> {
+    instruction: Box<CloseEscrowAccountCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CloseEscrowAccountCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CloseEscrowAccountCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CloseEscrowAccountCpiBuilderInstruction {
             __program: program,
             escrow: None,
@@ -372,7 +372,7 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn escrow(
         &mut self,
-        escrow: &'a solana_program::account_info::AccountInfo<'a>,
+        escrow: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.escrow = Some(escrow);
         self
@@ -381,14 +381,14 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -396,7 +396,7 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account(
         &mut self,
-        token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account = Some(token_account);
         self
@@ -405,14 +405,14 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: &'a solana_program::account_info::AccountInfo<'a>,
+        edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition = Some(edition);
         self
     }
     /// Wallet paying for the transaction and new account
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -420,7 +420,7 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -429,7 +429,7 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -437,7 +437,7 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -445,7 +445,7 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -497,15 +497,15 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     }
 }
 
-struct CloseEscrowAccountCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    escrow: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct CloseEscrowAccountCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    escrow: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/collect.rs
+++ b/clients/rust/src/generated/instructions/collect.rs
@@ -104,27 +104,27 @@ impl CollectBuilder {
 }
 
 /// `collect` CPI accounts.
-pub struct CollectCpiAccounts<'a> {
+pub struct CollectCpiAccounts<'a, 'b> {
     /// Authority to collect fees
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// PDA to retrieve fees from
-    pub pda_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub pda_account: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `collect` CPI instruction.
-pub struct CollectCpi<'a> {
+pub struct CollectCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Authority to collect fees
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// PDA to retrieve fees from
-    pub pda_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub pda_account: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> CollectCpi<'a> {
+impl<'a, 'b> CollectCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CollectCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CollectCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -139,7 +139,7 @@ impl<'a> CollectCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -155,7 +155,7 @@ impl<'a> CollectCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -193,12 +193,12 @@ impl<'a> CollectCpi<'a> {
 }
 
 /// `collect` CPI instruction builder.
-pub struct CollectCpiBuilder<'a> {
-    instruction: Box<CollectCpiBuilderInstruction<'a>>,
+pub struct CollectCpiBuilder<'a, 'b> {
+    instruction: Box<CollectCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CollectCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CollectCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CollectCpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -211,7 +211,7 @@ impl<'a> CollectCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -220,7 +220,7 @@ impl<'a> CollectCpiBuilder<'a> {
     #[inline(always)]
     pub fn pda_account(
         &mut self,
-        pda_account: &'a solana_program::account_info::AccountInfo<'a>,
+        pda_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.pda_account = Some(pda_account);
         self
@@ -228,7 +228,7 @@ impl<'a> CollectCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -236,7 +236,7 @@ impl<'a> CollectCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -270,9 +270,9 @@ impl<'a> CollectCpiBuilder<'a> {
     }
 }
 
-struct CollectCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    pda_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct CollectCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    pda_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/convert_master_edition_v1_to_v2.rs
+++ b/clients/rust/src/generated/instructions/convert_master_edition_v1_to_v2.rs
@@ -120,31 +120,31 @@ impl ConvertMasterEditionV1ToV2Builder {
 }
 
 /// `convert_master_edition_v1_to_v2` CPI accounts.
-pub struct ConvertMasterEditionV1ToV2CpiAccounts<'a> {
+pub struct ConvertMasterEditionV1ToV2CpiAccounts<'a, 'b> {
     /// Master Record Edition V1 (pda of ['metadata', program id, master metadata mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// One time authorization mint
-    pub one_time_auth: &'a solana_program::account_info::AccountInfo<'a>,
+    pub one_time_auth: &'b solana_program::account_info::AccountInfo<'a>,
     /// Printing mint
-    pub printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `convert_master_edition_v1_to_v2` CPI instruction.
-pub struct ConvertMasterEditionV1ToV2Cpi<'a> {
+pub struct ConvertMasterEditionV1ToV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Record Edition V1 (pda of ['metadata', program id, master metadata mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// One time authorization mint
-    pub one_time_auth: &'a solana_program::account_info::AccountInfo<'a>,
+    pub one_time_auth: &'b solana_program::account_info::AccountInfo<'a>,
     /// Printing mint
-    pub printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> ConvertMasterEditionV1ToV2Cpi<'a> {
+impl<'a, 'b> ConvertMasterEditionV1ToV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: ConvertMasterEditionV1ToV2CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: ConvertMasterEditionV1ToV2CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -160,7 +160,7 @@ impl<'a> ConvertMasterEditionV1ToV2Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -176,7 +176,7 @@ impl<'a> ConvertMasterEditionV1ToV2Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -221,12 +221,12 @@ impl<'a> ConvertMasterEditionV1ToV2Cpi<'a> {
 }
 
 /// `convert_master_edition_v1_to_v2` CPI instruction builder.
-pub struct ConvertMasterEditionV1ToV2CpiBuilder<'a> {
-    instruction: Box<ConvertMasterEditionV1ToV2CpiBuilderInstruction<'a>>,
+pub struct ConvertMasterEditionV1ToV2CpiBuilder<'a, 'b> {
+    instruction: Box<ConvertMasterEditionV1ToV2CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> ConvertMasterEditionV1ToV2CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> ConvertMasterEditionV1ToV2CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(ConvertMasterEditionV1ToV2CpiBuilderInstruction {
             __program: program,
             master_edition: None,
@@ -240,7 +240,7 @@ impl<'a> ConvertMasterEditionV1ToV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition = Some(master_edition);
         self
@@ -249,7 +249,7 @@ impl<'a> ConvertMasterEditionV1ToV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn one_time_auth(
         &mut self,
-        one_time_auth: &'a solana_program::account_info::AccountInfo<'a>,
+        one_time_auth: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.one_time_auth = Some(one_time_auth);
         self
@@ -258,7 +258,7 @@ impl<'a> ConvertMasterEditionV1ToV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn printing_mint(
         &mut self,
-        printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.printing_mint = Some(printing_mint);
         self
@@ -266,7 +266,7 @@ impl<'a> ConvertMasterEditionV1ToV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -274,7 +274,7 @@ impl<'a> ConvertMasterEditionV1ToV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -316,10 +316,10 @@ impl<'a> ConvertMasterEditionV1ToV2CpiBuilder<'a> {
     }
 }
 
-struct ConvertMasterEditionV1ToV2CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    one_time_auth: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    printing_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct ConvertMasterEditionV1ToV2CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    one_time_auth: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    printing_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/create_escrow_account.rs
+++ b/clients/rust/src/generated/instructions/create_escrow_account.rs
@@ -213,55 +213,55 @@ impl CreateEscrowAccountBuilder {
 }
 
 /// `create_escrow_account` CPI accounts.
-pub struct CreateEscrowAccountCpiAccounts<'a> {
+pub struct CreateEscrowAccountCpiAccounts<'a, 'b> {
     /// Escrow account
-    pub escrow: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of the token
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Wallet paying for the transaction and new account
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Authority/creator of the escrow account
-    pub authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `create_escrow_account` CPI instruction.
-pub struct CreateEscrowAccountCpi<'a> {
+pub struct CreateEscrowAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Escrow account
-    pub escrow: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of the token
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Wallet paying for the transaction and new account
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Authority/creator of the escrow account
-    pub authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> CreateEscrowAccountCpi<'a> {
+impl<'a, 'b> CreateEscrowAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CreateEscrowAccountCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CreateEscrowAccountCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -283,7 +283,7 @@ impl<'a> CreateEscrowAccountCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -299,7 +299,7 @@ impl<'a> CreateEscrowAccountCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -378,12 +378,12 @@ impl<'a> CreateEscrowAccountCpi<'a> {
 }
 
 /// `create_escrow_account` CPI instruction builder.
-pub struct CreateEscrowAccountCpiBuilder<'a> {
-    instruction: Box<CreateEscrowAccountCpiBuilderInstruction<'a>>,
+pub struct CreateEscrowAccountCpiBuilder<'a, 'b> {
+    instruction: Box<CreateEscrowAccountCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CreateEscrowAccountCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CreateEscrowAccountCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateEscrowAccountCpiBuilderInstruction {
             __program: program,
             escrow: None,
@@ -403,7 +403,7 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn escrow(
         &mut self,
-        escrow: &'a solana_program::account_info::AccountInfo<'a>,
+        escrow: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.escrow = Some(escrow);
         self
@@ -412,14 +412,14 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -427,7 +427,7 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account(
         &mut self,
-        token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account = Some(token_account);
         self
@@ -436,14 +436,14 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: &'a solana_program::account_info::AccountInfo<'a>,
+        edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition = Some(edition);
         self
     }
     /// Wallet paying for the transaction and new account
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -451,7 +451,7 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -460,7 +460,7 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -470,7 +470,7 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authority = authority;
         self
@@ -478,7 +478,7 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -486,7 +486,7 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -540,16 +540,16 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     }
 }
 
-struct CreateEscrowAccountCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    escrow: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct CreateEscrowAccountCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    escrow: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/create_master_edition_v3.rs
+++ b/clients/rust/src/generated/instructions/create_master_edition_v3.rs
@@ -235,57 +235,57 @@ impl CreateMasterEditionV3Builder {
 }
 
 /// `create_master_edition_v3` CPI accounts.
-pub struct CreateMasterEditionV3CpiAccounts<'a> {
+pub struct CreateMasterEditionV3CpiAccounts<'a, 'b> {
     /// Unallocated edition V2 account with address as pda of ['metadata', program id, mint, 'edition']
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata mint
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority on the metadata's mint - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `create_master_edition_v3` CPI instruction.
-pub struct CreateMasterEditionV3Cpi<'a> {
+pub struct CreateMasterEditionV3Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Unallocated edition V2 account with address as pda of ['metadata', program id, mint, 'edition']
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata mint
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority on the metadata's mint - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: CreateMasterEditionV3InstructionArgs,
 }
 
-impl<'a> CreateMasterEditionV3Cpi<'a> {
+impl<'a, 'b> CreateMasterEditionV3Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CreateMasterEditionV3CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CreateMasterEditionV3CpiAccounts<'a, 'b>,
         args: CreateMasterEditionV3InstructionArgs,
     ) -> Self {
         Self {
@@ -309,7 +309,7 @@ impl<'a> CreateMasterEditionV3Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -325,7 +325,7 @@ impl<'a> CreateMasterEditionV3Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -405,12 +405,12 @@ impl<'a> CreateMasterEditionV3Cpi<'a> {
 }
 
 /// `create_master_edition_v3` CPI instruction builder.
-pub struct CreateMasterEditionV3CpiBuilder<'a> {
-    instruction: Box<CreateMasterEditionV3CpiBuilderInstruction<'a>>,
+pub struct CreateMasterEditionV3CpiBuilder<'a, 'b> {
+    instruction: Box<CreateMasterEditionV3CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CreateMasterEditionV3CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateMasterEditionV3CpiBuilderInstruction {
             __program: program,
             edition: None,
@@ -431,14 +431,14 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: &'a solana_program::account_info::AccountInfo<'a>,
+        edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition = Some(edition);
         self
     }
     /// Metadata mint
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -446,7 +446,7 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -455,14 +455,14 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn mint_authority(
         &mut self,
-        mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.mint_authority = Some(mint_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -470,7 +470,7 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -479,7 +479,7 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -488,7 +488,7 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -498,7 +498,7 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn rent(
         &mut self,
-        rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.rent = rent;
         self
@@ -512,7 +512,7 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -520,7 +520,7 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -581,17 +581,17 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     }
 }
 
-struct CreateMasterEditionV3CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct CreateMasterEditionV3CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     max_supply: Option<u64>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/create_metadata_account_v3.rs
+++ b/clients/rust/src/generated/instructions/create_metadata_account_v3.rs
@@ -222,49 +222,49 @@ impl CreateMetadataAccountV3Builder {
 }
 
 /// `create_metadata_account_v3` CPI accounts.
-pub struct CreateMetadataAccountV3CpiAccounts<'a> {
+pub struct CreateMetadataAccountV3CpiAccounts<'a, 'b> {
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `create_metadata_account_v3` CPI instruction.
-pub struct CreateMetadataAccountV3Cpi<'a> {
+pub struct CreateMetadataAccountV3Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: CreateMetadataAccountV3InstructionArgs,
 }
 
-impl<'a> CreateMetadataAccountV3Cpi<'a> {
+impl<'a, 'b> CreateMetadataAccountV3Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CreateMetadataAccountV3CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CreateMetadataAccountV3CpiAccounts<'a, 'b>,
         args: CreateMetadataAccountV3InstructionArgs,
     ) -> Self {
         Self {
@@ -286,7 +286,7 @@ impl<'a> CreateMetadataAccountV3Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -302,7 +302,7 @@ impl<'a> CreateMetadataAccountV3Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -372,12 +372,12 @@ impl<'a> CreateMetadataAccountV3Cpi<'a> {
 }
 
 /// `create_metadata_account_v3` CPI instruction builder.
-pub struct CreateMetadataAccountV3CpiBuilder<'a> {
-    instruction: Box<CreateMetadataAccountV3CpiBuilderInstruction<'a>>,
+pub struct CreateMetadataAccountV3CpiBuilder<'a, 'b> {
+    instruction: Box<CreateMetadataAccountV3CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CreateMetadataAccountV3CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateMetadataAccountV3CpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -398,14 +398,14 @@ impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Mint of token asset
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -413,14 +413,14 @@ impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn mint_authority(
         &mut self,
-        mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.mint_authority = Some(mint_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -428,7 +428,7 @@ impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -437,7 +437,7 @@ impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -447,7 +447,7 @@ impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn rent(
         &mut self,
-        rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.rent = rent;
         self
@@ -471,7 +471,7 @@ impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -479,7 +479,7 @@ impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -539,17 +539,17 @@ impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
     }
 }
 
-struct CreateMetadataAccountV3CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct CreateMetadataAccountV3CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     data: Option<DataV2>,
     is_mutable: Option<bool>,
     collection_details: Option<CollectionDetails>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/create_v1.rs
+++ b/clients/rust/src/generated/instructions/create_v1.rs
@@ -383,57 +383,57 @@ impl CreateV1Builder {
 }
 
 /// `create_v1` CPI accounts.
-pub struct CreateV1CpiAccounts<'a> {
+pub struct CreateV1CpiAccounts<'a, 'b> {
     /// Unallocated metadata account with address as pda of ['metadata', program id, mint id]
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Unallocated edition account with address as pda of ['metadata', program id, mint, 'edition']
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of token asset
-    pub mint: (&'a solana_program::account_info::AccountInfo<'a>, bool),
+    pub mint: (&'b solana_program::account_info::AccountInfo<'a>, bool),
     /// Mint authority
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority for the metadata account
-    pub update_authority: (&'a solana_program::account_info::AccountInfo<'a>, bool),
+    pub update_authority: (&'b solana_program::account_info::AccountInfo<'a>, bool),
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `create_v1` CPI instruction.
-pub struct CreateV1Cpi<'a> {
+pub struct CreateV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Unallocated metadata account with address as pda of ['metadata', program id, mint id]
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Unallocated edition account with address as pda of ['metadata', program id, mint, 'edition']
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of token asset
-    pub mint: (&'a solana_program::account_info::AccountInfo<'a>, bool),
+    pub mint: (&'b solana_program::account_info::AccountInfo<'a>, bool),
     /// Mint authority
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority for the metadata account
-    pub update_authority: (&'a solana_program::account_info::AccountInfo<'a>, bool),
+    pub update_authority: (&'b solana_program::account_info::AccountInfo<'a>, bool),
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: CreateV1InstructionArgs,
 }
 
-impl<'a> CreateV1Cpi<'a> {
+impl<'a, 'b> CreateV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CreateV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CreateV1CpiAccounts<'a, 'b>,
         args: CreateV1InstructionArgs,
     ) -> Self {
         Self {
@@ -457,7 +457,7 @@ impl<'a> CreateV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -473,7 +473,7 @@ impl<'a> CreateV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -557,12 +557,12 @@ impl<'a> CreateV1Cpi<'a> {
 }
 
 /// `create_v1` CPI instruction builder.
-pub struct CreateV1CpiBuilder<'a> {
-    instruction: Box<CreateV1CpiBuilderInstruction<'a>>,
+pub struct CreateV1CpiBuilder<'a, 'b> {
+    instruction: Box<CreateV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CreateV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CreateV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateV1CpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -596,7 +596,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -606,7 +606,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -615,7 +615,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn mint(
         &mut self,
-        mint: &'a solana_program::account_info::AccountInfo<'a>,
+        mint: &'b solana_program::account_info::AccountInfo<'a>,
         as_signer: bool,
     ) -> &mut Self {
         self.instruction.mint = Some((mint, as_signer));
@@ -625,14 +625,14 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -640,7 +640,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
         as_signer: bool,
     ) -> &mut Self {
         self.instruction.update_authority = Some((update_authority, as_signer));
@@ -650,7 +650,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -659,7 +659,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -668,7 +668,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_token_program = Some(spl_token_program);
         self
@@ -756,7 +756,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -764,7 +764,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -850,17 +850,17 @@ impl<'a> CreateV1CpiBuilder<'a> {
     }
 }
 
-struct CreateV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<(&'a solana_program::account_info::AccountInfo<'a>, bool)>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<(&'a solana_program::account_info::AccountInfo<'a>, bool)>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct CreateV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<(&'b solana_program::account_info::AccountInfo<'a>, bool)>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<(&'b solana_program::account_info::AccountInfo<'a>, bool)>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     name: Option<String>,
     symbol: Option<String>,
     uri: Option<String>,
@@ -875,5 +875,5 @@ struct CreateV1CpiBuilderInstruction<'a> {
     rule_set: Option<Pubkey>,
     decimals: Option<u8>,
     print_supply: Option<PrintSupply>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/delegate_authority_item_v1.rs
+++ b/clients/rust/src/generated/instructions/delegate_authority_item_v1.rs
@@ -379,77 +379,77 @@ impl DelegateAuthorityItemV1Builder {
 }
 
 /// `delegate_authority_item_v1` CPI accounts.
-pub struct DelegateAuthorityItemV1CpiAccounts<'a> {
+pub struct DelegateAuthorityItemV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `delegate_authority_item_v1` CPI instruction.
-pub struct DelegateAuthorityItemV1Cpi<'a> {
+pub struct DelegateAuthorityItemV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: DelegateAuthorityItemV1InstructionArgs,
 }
 
-impl<'a> DelegateAuthorityItemV1Cpi<'a> {
+impl<'a, 'b> DelegateAuthorityItemV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DelegateAuthorityItemV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DelegateAuthorityItemV1CpiAccounts<'a, 'b>,
         args: DelegateAuthorityItemV1InstructionArgs,
     ) -> Self {
         Self {
@@ -478,7 +478,7 @@ impl<'a> DelegateAuthorityItemV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -494,7 +494,7 @@ impl<'a> DelegateAuthorityItemV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -658,12 +658,12 @@ impl<'a> DelegateAuthorityItemV1Cpi<'a> {
 }
 
 /// `delegate_authority_item_v1` CPI instruction builder.
-pub struct DelegateAuthorityItemV1CpiBuilder<'a> {
-    instruction: Box<DelegateAuthorityItemV1CpiBuilderInstruction<'a>>,
+pub struct DelegateAuthorityItemV1CpiBuilder<'a, 'b> {
+    instruction: Box<DelegateAuthorityItemV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DelegateAuthorityItemV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DelegateAuthorityItemV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DelegateAuthorityItemV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -690,7 +690,7 @@ impl<'a> DelegateAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -699,7 +699,7 @@ impl<'a> DelegateAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -708,7 +708,7 @@ impl<'a> DelegateAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -718,7 +718,7 @@ impl<'a> DelegateAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -728,14 +728,14 @@ impl<'a> DelegateAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -744,7 +744,7 @@ impl<'a> DelegateAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
@@ -753,14 +753,14 @@ impl<'a> DelegateAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -768,7 +768,7 @@ impl<'a> DelegateAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -777,7 +777,7 @@ impl<'a> DelegateAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -787,7 +787,7 @@ impl<'a> DelegateAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -797,7 +797,7 @@ impl<'a> DelegateAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -807,7 +807,7 @@ impl<'a> DelegateAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -821,7 +821,7 @@ impl<'a> DelegateAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -829,7 +829,7 @@ impl<'a> DelegateAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -894,22 +894,22 @@ impl<'a> DelegateAuthorityItemV1CpiBuilder<'a> {
     }
 }
 
-struct DelegateAuthorityItemV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DelegateAuthorityItemV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/delegate_collection_item_v1.rs
+++ b/clients/rust/src/generated/instructions/delegate_collection_item_v1.rs
@@ -379,77 +379,77 @@ impl DelegateCollectionItemV1Builder {
 }
 
 /// `delegate_collection_item_v1` CPI accounts.
-pub struct DelegateCollectionItemV1CpiAccounts<'a> {
+pub struct DelegateCollectionItemV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `delegate_collection_item_v1` CPI instruction.
-pub struct DelegateCollectionItemV1Cpi<'a> {
+pub struct DelegateCollectionItemV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: DelegateCollectionItemV1InstructionArgs,
 }
 
-impl<'a> DelegateCollectionItemV1Cpi<'a> {
+impl<'a, 'b> DelegateCollectionItemV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DelegateCollectionItemV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DelegateCollectionItemV1CpiAccounts<'a, 'b>,
         args: DelegateCollectionItemV1InstructionArgs,
     ) -> Self {
         Self {
@@ -478,7 +478,7 @@ impl<'a> DelegateCollectionItemV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -494,7 +494,7 @@ impl<'a> DelegateCollectionItemV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -658,12 +658,12 @@ impl<'a> DelegateCollectionItemV1Cpi<'a> {
 }
 
 /// `delegate_collection_item_v1` CPI instruction builder.
-pub struct DelegateCollectionItemV1CpiBuilder<'a> {
-    instruction: Box<DelegateCollectionItemV1CpiBuilderInstruction<'a>>,
+pub struct DelegateCollectionItemV1CpiBuilder<'a, 'b> {
+    instruction: Box<DelegateCollectionItemV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DelegateCollectionItemV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DelegateCollectionItemV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DelegateCollectionItemV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -690,7 +690,7 @@ impl<'a> DelegateCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -699,7 +699,7 @@ impl<'a> DelegateCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -708,7 +708,7 @@ impl<'a> DelegateCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -718,7 +718,7 @@ impl<'a> DelegateCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -728,14 +728,14 @@ impl<'a> DelegateCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -744,7 +744,7 @@ impl<'a> DelegateCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
@@ -753,14 +753,14 @@ impl<'a> DelegateCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -768,7 +768,7 @@ impl<'a> DelegateCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -777,7 +777,7 @@ impl<'a> DelegateCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -787,7 +787,7 @@ impl<'a> DelegateCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -797,7 +797,7 @@ impl<'a> DelegateCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -807,7 +807,7 @@ impl<'a> DelegateCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -821,7 +821,7 @@ impl<'a> DelegateCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -829,7 +829,7 @@ impl<'a> DelegateCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -894,22 +894,22 @@ impl<'a> DelegateCollectionItemV1CpiBuilder<'a> {
     }
 }
 
-struct DelegateCollectionItemV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DelegateCollectionItemV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/delegate_collection_v1.rs
+++ b/clients/rust/src/generated/instructions/delegate_collection_v1.rs
@@ -379,77 +379,77 @@ impl DelegateCollectionV1Builder {
 }
 
 /// `delegate_collection_v1` CPI accounts.
-pub struct DelegateCollectionV1CpiAccounts<'a> {
+pub struct DelegateCollectionV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `delegate_collection_v1` CPI instruction.
-pub struct DelegateCollectionV1Cpi<'a> {
+pub struct DelegateCollectionV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: DelegateCollectionV1InstructionArgs,
 }
 
-impl<'a> DelegateCollectionV1Cpi<'a> {
+impl<'a, 'b> DelegateCollectionV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DelegateCollectionV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DelegateCollectionV1CpiAccounts<'a, 'b>,
         args: DelegateCollectionV1InstructionArgs,
     ) -> Self {
         Self {
@@ -478,7 +478,7 @@ impl<'a> DelegateCollectionV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -494,7 +494,7 @@ impl<'a> DelegateCollectionV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -658,12 +658,12 @@ impl<'a> DelegateCollectionV1Cpi<'a> {
 }
 
 /// `delegate_collection_v1` CPI instruction builder.
-pub struct DelegateCollectionV1CpiBuilder<'a> {
-    instruction: Box<DelegateCollectionV1CpiBuilderInstruction<'a>>,
+pub struct DelegateCollectionV1CpiBuilder<'a, 'b> {
+    instruction: Box<DelegateCollectionV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DelegateCollectionV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DelegateCollectionV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DelegateCollectionV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -690,7 +690,7 @@ impl<'a> DelegateCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -699,7 +699,7 @@ impl<'a> DelegateCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -708,7 +708,7 @@ impl<'a> DelegateCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -718,7 +718,7 @@ impl<'a> DelegateCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -728,14 +728,14 @@ impl<'a> DelegateCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -744,7 +744,7 @@ impl<'a> DelegateCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
@@ -753,14 +753,14 @@ impl<'a> DelegateCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -768,7 +768,7 @@ impl<'a> DelegateCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -777,7 +777,7 @@ impl<'a> DelegateCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -787,7 +787,7 @@ impl<'a> DelegateCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -797,7 +797,7 @@ impl<'a> DelegateCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -807,7 +807,7 @@ impl<'a> DelegateCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -821,7 +821,7 @@ impl<'a> DelegateCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -829,7 +829,7 @@ impl<'a> DelegateCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -894,22 +894,22 @@ impl<'a> DelegateCollectionV1CpiBuilder<'a> {
     }
 }
 
-struct DelegateCollectionV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DelegateCollectionV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/delegate_data_item_v1.rs
+++ b/clients/rust/src/generated/instructions/delegate_data_item_v1.rs
@@ -379,77 +379,77 @@ impl DelegateDataItemV1Builder {
 }
 
 /// `delegate_data_item_v1` CPI accounts.
-pub struct DelegateDataItemV1CpiAccounts<'a> {
+pub struct DelegateDataItemV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `delegate_data_item_v1` CPI instruction.
-pub struct DelegateDataItemV1Cpi<'a> {
+pub struct DelegateDataItemV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: DelegateDataItemV1InstructionArgs,
 }
 
-impl<'a> DelegateDataItemV1Cpi<'a> {
+impl<'a, 'b> DelegateDataItemV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DelegateDataItemV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DelegateDataItemV1CpiAccounts<'a, 'b>,
         args: DelegateDataItemV1InstructionArgs,
     ) -> Self {
         Self {
@@ -478,7 +478,7 @@ impl<'a> DelegateDataItemV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -494,7 +494,7 @@ impl<'a> DelegateDataItemV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -658,12 +658,12 @@ impl<'a> DelegateDataItemV1Cpi<'a> {
 }
 
 /// `delegate_data_item_v1` CPI instruction builder.
-pub struct DelegateDataItemV1CpiBuilder<'a> {
-    instruction: Box<DelegateDataItemV1CpiBuilderInstruction<'a>>,
+pub struct DelegateDataItemV1CpiBuilder<'a, 'b> {
+    instruction: Box<DelegateDataItemV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DelegateDataItemV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DelegateDataItemV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DelegateDataItemV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -690,7 +690,7 @@ impl<'a> DelegateDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -699,7 +699,7 @@ impl<'a> DelegateDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -708,7 +708,7 @@ impl<'a> DelegateDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -718,7 +718,7 @@ impl<'a> DelegateDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -728,14 +728,14 @@ impl<'a> DelegateDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -744,7 +744,7 @@ impl<'a> DelegateDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
@@ -753,14 +753,14 @@ impl<'a> DelegateDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -768,7 +768,7 @@ impl<'a> DelegateDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -777,7 +777,7 @@ impl<'a> DelegateDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -787,7 +787,7 @@ impl<'a> DelegateDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -797,7 +797,7 @@ impl<'a> DelegateDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -807,7 +807,7 @@ impl<'a> DelegateDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -821,7 +821,7 @@ impl<'a> DelegateDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -829,7 +829,7 @@ impl<'a> DelegateDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -894,22 +894,22 @@ impl<'a> DelegateDataItemV1CpiBuilder<'a> {
     }
 }
 
-struct DelegateDataItemV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DelegateDataItemV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/delegate_data_v1.rs
+++ b/clients/rust/src/generated/instructions/delegate_data_v1.rs
@@ -377,77 +377,77 @@ impl DelegateDataV1Builder {
 }
 
 /// `delegate_data_v1` CPI accounts.
-pub struct DelegateDataV1CpiAccounts<'a> {
+pub struct DelegateDataV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `delegate_data_v1` CPI instruction.
-pub struct DelegateDataV1Cpi<'a> {
+pub struct DelegateDataV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: DelegateDataV1InstructionArgs,
 }
 
-impl<'a> DelegateDataV1Cpi<'a> {
+impl<'a, 'b> DelegateDataV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DelegateDataV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DelegateDataV1CpiAccounts<'a, 'b>,
         args: DelegateDataV1InstructionArgs,
     ) -> Self {
         Self {
@@ -476,7 +476,7 @@ impl<'a> DelegateDataV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -492,7 +492,7 @@ impl<'a> DelegateDataV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -654,12 +654,12 @@ impl<'a> DelegateDataV1Cpi<'a> {
 }
 
 /// `delegate_data_v1` CPI instruction builder.
-pub struct DelegateDataV1CpiBuilder<'a> {
-    instruction: Box<DelegateDataV1CpiBuilderInstruction<'a>>,
+pub struct DelegateDataV1CpiBuilder<'a, 'b> {
+    instruction: Box<DelegateDataV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DelegateDataV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DelegateDataV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DelegateDataV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -686,7 +686,7 @@ impl<'a> DelegateDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -695,7 +695,7 @@ impl<'a> DelegateDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -704,7 +704,7 @@ impl<'a> DelegateDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -714,7 +714,7 @@ impl<'a> DelegateDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -724,14 +724,14 @@ impl<'a> DelegateDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -740,7 +740,7 @@ impl<'a> DelegateDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
@@ -749,14 +749,14 @@ impl<'a> DelegateDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -764,7 +764,7 @@ impl<'a> DelegateDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -773,7 +773,7 @@ impl<'a> DelegateDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -783,7 +783,7 @@ impl<'a> DelegateDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -793,7 +793,7 @@ impl<'a> DelegateDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -803,7 +803,7 @@ impl<'a> DelegateDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -817,7 +817,7 @@ impl<'a> DelegateDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -825,7 +825,7 @@ impl<'a> DelegateDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -890,22 +890,22 @@ impl<'a> DelegateDataV1CpiBuilder<'a> {
     }
 }
 
-struct DelegateDataV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DelegateDataV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/delegate_locked_transfer_v1.rs
+++ b/clients/rust/src/generated/instructions/delegate_locked_transfer_v1.rs
@@ -394,77 +394,77 @@ impl DelegateLockedTransferV1Builder {
 }
 
 /// `delegate_locked_transfer_v1` CPI accounts.
-pub struct DelegateLockedTransferV1CpiAccounts<'a> {
+pub struct DelegateLockedTransferV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `delegate_locked_transfer_v1` CPI instruction.
-pub struct DelegateLockedTransferV1Cpi<'a> {
+pub struct DelegateLockedTransferV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: DelegateLockedTransferV1InstructionArgs,
 }
 
-impl<'a> DelegateLockedTransferV1Cpi<'a> {
+impl<'a, 'b> DelegateLockedTransferV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DelegateLockedTransferV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DelegateLockedTransferV1CpiAccounts<'a, 'b>,
         args: DelegateLockedTransferV1InstructionArgs,
     ) -> Self {
         Self {
@@ -493,7 +493,7 @@ impl<'a> DelegateLockedTransferV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -509,7 +509,7 @@ impl<'a> DelegateLockedTransferV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -665,12 +665,12 @@ impl<'a> DelegateLockedTransferV1Cpi<'a> {
 }
 
 /// `delegate_locked_transfer_v1` CPI instruction builder.
-pub struct DelegateLockedTransferV1CpiBuilder<'a> {
-    instruction: Box<DelegateLockedTransferV1CpiBuilderInstruction<'a>>,
+pub struct DelegateLockedTransferV1CpiBuilder<'a, 'b> {
+    instruction: Box<DelegateLockedTransferV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DelegateLockedTransferV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DelegateLockedTransferV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DelegateLockedTransferV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -699,7 +699,7 @@ impl<'a> DelegateLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -708,7 +708,7 @@ impl<'a> DelegateLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -717,7 +717,7 @@ impl<'a> DelegateLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -727,7 +727,7 @@ impl<'a> DelegateLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -737,20 +737,20 @@ impl<'a> DelegateLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     /// Token account of mint
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -758,14 +758,14 @@ impl<'a> DelegateLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -773,7 +773,7 @@ impl<'a> DelegateLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -782,7 +782,7 @@ impl<'a> DelegateLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -792,7 +792,7 @@ impl<'a> DelegateLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -802,7 +802,7 @@ impl<'a> DelegateLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -812,7 +812,7 @@ impl<'a> DelegateLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -837,7 +837,7 @@ impl<'a> DelegateLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -845,7 +845,7 @@ impl<'a> DelegateLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -916,24 +916,24 @@ impl<'a> DelegateLockedTransferV1CpiBuilder<'a> {
     }
 }
 
-struct DelegateLockedTransferV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DelegateLockedTransferV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     amount: Option<u64>,
     locked_address: Option<Pubkey>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/delegate_programmable_config_item_v1.rs
+++ b/clients/rust/src/generated/instructions/delegate_programmable_config_item_v1.rs
@@ -379,77 +379,77 @@ impl DelegateProgrammableConfigItemV1Builder {
 }
 
 /// `delegate_programmable_config_item_v1` CPI accounts.
-pub struct DelegateProgrammableConfigItemV1CpiAccounts<'a> {
+pub struct DelegateProgrammableConfigItemV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `delegate_programmable_config_item_v1` CPI instruction.
-pub struct DelegateProgrammableConfigItemV1Cpi<'a> {
+pub struct DelegateProgrammableConfigItemV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: DelegateProgrammableConfigItemV1InstructionArgs,
 }
 
-impl<'a> DelegateProgrammableConfigItemV1Cpi<'a> {
+impl<'a, 'b> DelegateProgrammableConfigItemV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DelegateProgrammableConfigItemV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DelegateProgrammableConfigItemV1CpiAccounts<'a, 'b>,
         args: DelegateProgrammableConfigItemV1InstructionArgs,
     ) -> Self {
         Self {
@@ -478,7 +478,7 @@ impl<'a> DelegateProgrammableConfigItemV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -494,7 +494,7 @@ impl<'a> DelegateProgrammableConfigItemV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -658,12 +658,12 @@ impl<'a> DelegateProgrammableConfigItemV1Cpi<'a> {
 }
 
 /// `delegate_programmable_config_item_v1` CPI instruction builder.
-pub struct DelegateProgrammableConfigItemV1CpiBuilder<'a> {
-    instruction: Box<DelegateProgrammableConfigItemV1CpiBuilderInstruction<'a>>,
+pub struct DelegateProgrammableConfigItemV1CpiBuilder<'a, 'b> {
+    instruction: Box<DelegateProgrammableConfigItemV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DelegateProgrammableConfigItemV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DelegateProgrammableConfigItemV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DelegateProgrammableConfigItemV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -690,7 +690,7 @@ impl<'a> DelegateProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -699,7 +699,7 @@ impl<'a> DelegateProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -708,7 +708,7 @@ impl<'a> DelegateProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -718,7 +718,7 @@ impl<'a> DelegateProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -728,14 +728,14 @@ impl<'a> DelegateProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -744,7 +744,7 @@ impl<'a> DelegateProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
@@ -753,14 +753,14 @@ impl<'a> DelegateProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -768,7 +768,7 @@ impl<'a> DelegateProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -777,7 +777,7 @@ impl<'a> DelegateProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -787,7 +787,7 @@ impl<'a> DelegateProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -797,7 +797,7 @@ impl<'a> DelegateProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -807,7 +807,7 @@ impl<'a> DelegateProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -821,7 +821,7 @@ impl<'a> DelegateProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -829,7 +829,7 @@ impl<'a> DelegateProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -894,22 +894,22 @@ impl<'a> DelegateProgrammableConfigItemV1CpiBuilder<'a> {
     }
 }
 
-struct DelegateProgrammableConfigItemV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DelegateProgrammableConfigItemV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/delegate_programmable_config_v1.rs
+++ b/clients/rust/src/generated/instructions/delegate_programmable_config_v1.rs
@@ -379,77 +379,77 @@ impl DelegateProgrammableConfigV1Builder {
 }
 
 /// `delegate_programmable_config_v1` CPI accounts.
-pub struct DelegateProgrammableConfigV1CpiAccounts<'a> {
+pub struct DelegateProgrammableConfigV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `delegate_programmable_config_v1` CPI instruction.
-pub struct DelegateProgrammableConfigV1Cpi<'a> {
+pub struct DelegateProgrammableConfigV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: DelegateProgrammableConfigV1InstructionArgs,
 }
 
-impl<'a> DelegateProgrammableConfigV1Cpi<'a> {
+impl<'a, 'b> DelegateProgrammableConfigV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DelegateProgrammableConfigV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DelegateProgrammableConfigV1CpiAccounts<'a, 'b>,
         args: DelegateProgrammableConfigV1InstructionArgs,
     ) -> Self {
         Self {
@@ -478,7 +478,7 @@ impl<'a> DelegateProgrammableConfigV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -494,7 +494,7 @@ impl<'a> DelegateProgrammableConfigV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -658,12 +658,12 @@ impl<'a> DelegateProgrammableConfigV1Cpi<'a> {
 }
 
 /// `delegate_programmable_config_v1` CPI instruction builder.
-pub struct DelegateProgrammableConfigV1CpiBuilder<'a> {
-    instruction: Box<DelegateProgrammableConfigV1CpiBuilderInstruction<'a>>,
+pub struct DelegateProgrammableConfigV1CpiBuilder<'a, 'b> {
+    instruction: Box<DelegateProgrammableConfigV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DelegateProgrammableConfigV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DelegateProgrammableConfigV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DelegateProgrammableConfigV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -690,7 +690,7 @@ impl<'a> DelegateProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -699,7 +699,7 @@ impl<'a> DelegateProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -708,7 +708,7 @@ impl<'a> DelegateProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -718,7 +718,7 @@ impl<'a> DelegateProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -728,14 +728,14 @@ impl<'a> DelegateProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -744,7 +744,7 @@ impl<'a> DelegateProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
@@ -753,14 +753,14 @@ impl<'a> DelegateProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -768,7 +768,7 @@ impl<'a> DelegateProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -777,7 +777,7 @@ impl<'a> DelegateProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -787,7 +787,7 @@ impl<'a> DelegateProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -797,7 +797,7 @@ impl<'a> DelegateProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -807,7 +807,7 @@ impl<'a> DelegateProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -821,7 +821,7 @@ impl<'a> DelegateProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -829,7 +829,7 @@ impl<'a> DelegateProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -894,22 +894,22 @@ impl<'a> DelegateProgrammableConfigV1CpiBuilder<'a> {
     }
 }
 
-struct DelegateProgrammableConfigV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DelegateProgrammableConfigV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/delegate_sale_v1.rs
+++ b/clients/rust/src/generated/instructions/delegate_sale_v1.rs
@@ -380,77 +380,77 @@ impl DelegateSaleV1Builder {
 }
 
 /// `delegate_sale_v1` CPI accounts.
-pub struct DelegateSaleV1CpiAccounts<'a> {
+pub struct DelegateSaleV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `delegate_sale_v1` CPI instruction.
-pub struct DelegateSaleV1Cpi<'a> {
+pub struct DelegateSaleV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: DelegateSaleV1InstructionArgs,
 }
 
-impl<'a> DelegateSaleV1Cpi<'a> {
+impl<'a, 'b> DelegateSaleV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DelegateSaleV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DelegateSaleV1CpiAccounts<'a, 'b>,
         args: DelegateSaleV1InstructionArgs,
     ) -> Self {
         Self {
@@ -479,7 +479,7 @@ impl<'a> DelegateSaleV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -495,7 +495,7 @@ impl<'a> DelegateSaleV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -649,12 +649,12 @@ impl<'a> DelegateSaleV1Cpi<'a> {
 }
 
 /// `delegate_sale_v1` CPI instruction builder.
-pub struct DelegateSaleV1CpiBuilder<'a> {
-    instruction: Box<DelegateSaleV1CpiBuilderInstruction<'a>>,
+pub struct DelegateSaleV1CpiBuilder<'a, 'b> {
+    instruction: Box<DelegateSaleV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DelegateSaleV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DelegateSaleV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DelegateSaleV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -682,7 +682,7 @@ impl<'a> DelegateSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -691,7 +691,7 @@ impl<'a> DelegateSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -700,7 +700,7 @@ impl<'a> DelegateSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -710,7 +710,7 @@ impl<'a> DelegateSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -720,20 +720,20 @@ impl<'a> DelegateSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     /// Token account of mint
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -741,14 +741,14 @@ impl<'a> DelegateSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -756,7 +756,7 @@ impl<'a> DelegateSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -765,7 +765,7 @@ impl<'a> DelegateSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -775,7 +775,7 @@ impl<'a> DelegateSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -785,7 +785,7 @@ impl<'a> DelegateSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -795,7 +795,7 @@ impl<'a> DelegateSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -815,7 +815,7 @@ impl<'a> DelegateSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -823,7 +823,7 @@ impl<'a> DelegateSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -889,23 +889,23 @@ impl<'a> DelegateSaleV1CpiBuilder<'a> {
     }
 }
 
-struct DelegateSaleV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DelegateSaleV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     amount: Option<u64>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/delegate_staking_v1.rs
+++ b/clients/rust/src/generated/instructions/delegate_staking_v1.rs
@@ -382,77 +382,77 @@ impl DelegateStakingV1Builder {
 }
 
 /// `delegate_staking_v1` CPI accounts.
-pub struct DelegateStakingV1CpiAccounts<'a> {
+pub struct DelegateStakingV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `delegate_staking_v1` CPI instruction.
-pub struct DelegateStakingV1Cpi<'a> {
+pub struct DelegateStakingV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: DelegateStakingV1InstructionArgs,
 }
 
-impl<'a> DelegateStakingV1Cpi<'a> {
+impl<'a, 'b> DelegateStakingV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DelegateStakingV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DelegateStakingV1CpiAccounts<'a, 'b>,
         args: DelegateStakingV1InstructionArgs,
     ) -> Self {
         Self {
@@ -481,7 +481,7 @@ impl<'a> DelegateStakingV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -497,7 +497,7 @@ impl<'a> DelegateStakingV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -653,12 +653,12 @@ impl<'a> DelegateStakingV1Cpi<'a> {
 }
 
 /// `delegate_staking_v1` CPI instruction builder.
-pub struct DelegateStakingV1CpiBuilder<'a> {
-    instruction: Box<DelegateStakingV1CpiBuilderInstruction<'a>>,
+pub struct DelegateStakingV1CpiBuilder<'a, 'b> {
+    instruction: Box<DelegateStakingV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DelegateStakingV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DelegateStakingV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DelegateStakingV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -686,7 +686,7 @@ impl<'a> DelegateStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -695,7 +695,7 @@ impl<'a> DelegateStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -704,7 +704,7 @@ impl<'a> DelegateStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -714,7 +714,7 @@ impl<'a> DelegateStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -724,20 +724,20 @@ impl<'a> DelegateStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     /// Token account of mint
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -745,14 +745,14 @@ impl<'a> DelegateStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -760,7 +760,7 @@ impl<'a> DelegateStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -769,7 +769,7 @@ impl<'a> DelegateStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -779,7 +779,7 @@ impl<'a> DelegateStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -789,7 +789,7 @@ impl<'a> DelegateStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -799,7 +799,7 @@ impl<'a> DelegateStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -819,7 +819,7 @@ impl<'a> DelegateStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -827,7 +827,7 @@ impl<'a> DelegateStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -893,23 +893,23 @@ impl<'a> DelegateStakingV1CpiBuilder<'a> {
     }
 }
 
-struct DelegateStakingV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DelegateStakingV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     amount: Option<u64>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/delegate_standard_v1.rs
+++ b/clients/rust/src/generated/instructions/delegate_standard_v1.rs
@@ -372,77 +372,77 @@ impl DelegateStandardV1Builder {
 }
 
 /// `delegate_standard_v1` CPI accounts.
-pub struct DelegateStandardV1CpiAccounts<'a> {
+pub struct DelegateStandardV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `delegate_standard_v1` CPI instruction.
-pub struct DelegateStandardV1Cpi<'a> {
+pub struct DelegateStandardV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: DelegateStandardV1InstructionArgs,
 }
 
-impl<'a> DelegateStandardV1Cpi<'a> {
+impl<'a, 'b> DelegateStandardV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DelegateStandardV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DelegateStandardV1CpiAccounts<'a, 'b>,
         args: DelegateStandardV1InstructionArgs,
     ) -> Self {
         Self {
@@ -471,7 +471,7 @@ impl<'a> DelegateStandardV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -487,7 +487,7 @@ impl<'a> DelegateStandardV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -643,12 +643,12 @@ impl<'a> DelegateStandardV1Cpi<'a> {
 }
 
 /// `delegate_standard_v1` CPI instruction builder.
-pub struct DelegateStandardV1CpiBuilder<'a> {
-    instruction: Box<DelegateStandardV1CpiBuilderInstruction<'a>>,
+pub struct DelegateStandardV1CpiBuilder<'a, 'b> {
+    instruction: Box<DelegateStandardV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DelegateStandardV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DelegateStandardV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DelegateStandardV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -675,7 +675,7 @@ impl<'a> DelegateStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -684,7 +684,7 @@ impl<'a> DelegateStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -693,7 +693,7 @@ impl<'a> DelegateStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -703,7 +703,7 @@ impl<'a> DelegateStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -713,20 +713,20 @@ impl<'a> DelegateStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     /// Token account of mint
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -734,14 +734,14 @@ impl<'a> DelegateStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -749,7 +749,7 @@ impl<'a> DelegateStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -758,7 +758,7 @@ impl<'a> DelegateStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -768,7 +768,7 @@ impl<'a> DelegateStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -778,7 +778,7 @@ impl<'a> DelegateStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -788,7 +788,7 @@ impl<'a> DelegateStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -802,7 +802,7 @@ impl<'a> DelegateStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -810,7 +810,7 @@ impl<'a> DelegateStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -875,22 +875,22 @@ impl<'a> DelegateStandardV1CpiBuilder<'a> {
     }
 }
 
-struct DelegateStandardV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DelegateStandardV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     amount: Option<u64>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/delegate_transfer_v1.rs
+++ b/clients/rust/src/generated/instructions/delegate_transfer_v1.rs
@@ -382,77 +382,77 @@ impl DelegateTransferV1Builder {
 }
 
 /// `delegate_transfer_v1` CPI accounts.
-pub struct DelegateTransferV1CpiAccounts<'a> {
+pub struct DelegateTransferV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `delegate_transfer_v1` CPI instruction.
-pub struct DelegateTransferV1Cpi<'a> {
+pub struct DelegateTransferV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: DelegateTransferV1InstructionArgs,
 }
 
-impl<'a> DelegateTransferV1Cpi<'a> {
+impl<'a, 'b> DelegateTransferV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DelegateTransferV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DelegateTransferV1CpiAccounts<'a, 'b>,
         args: DelegateTransferV1InstructionArgs,
     ) -> Self {
         Self {
@@ -481,7 +481,7 @@ impl<'a> DelegateTransferV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -497,7 +497,7 @@ impl<'a> DelegateTransferV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -653,12 +653,12 @@ impl<'a> DelegateTransferV1Cpi<'a> {
 }
 
 /// `delegate_transfer_v1` CPI instruction builder.
-pub struct DelegateTransferV1CpiBuilder<'a> {
-    instruction: Box<DelegateTransferV1CpiBuilderInstruction<'a>>,
+pub struct DelegateTransferV1CpiBuilder<'a, 'b> {
+    instruction: Box<DelegateTransferV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DelegateTransferV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DelegateTransferV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DelegateTransferV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -686,7 +686,7 @@ impl<'a> DelegateTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -695,7 +695,7 @@ impl<'a> DelegateTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -704,7 +704,7 @@ impl<'a> DelegateTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -714,7 +714,7 @@ impl<'a> DelegateTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -724,20 +724,20 @@ impl<'a> DelegateTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     /// Token account of mint
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -745,14 +745,14 @@ impl<'a> DelegateTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -760,7 +760,7 @@ impl<'a> DelegateTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -769,7 +769,7 @@ impl<'a> DelegateTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -779,7 +779,7 @@ impl<'a> DelegateTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -789,7 +789,7 @@ impl<'a> DelegateTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -799,7 +799,7 @@ impl<'a> DelegateTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -819,7 +819,7 @@ impl<'a> DelegateTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -827,7 +827,7 @@ impl<'a> DelegateTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -893,23 +893,23 @@ impl<'a> DelegateTransferV1CpiBuilder<'a> {
     }
 }
 
-struct DelegateTransferV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DelegateTransferV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     amount: Option<u64>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/delegate_utility_v1.rs
+++ b/clients/rust/src/generated/instructions/delegate_utility_v1.rs
@@ -382,77 +382,77 @@ impl DelegateUtilityV1Builder {
 }
 
 /// `delegate_utility_v1` CPI accounts.
-pub struct DelegateUtilityV1CpiAccounts<'a> {
+pub struct DelegateUtilityV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `delegate_utility_v1` CPI instruction.
-pub struct DelegateUtilityV1Cpi<'a> {
+pub struct DelegateUtilityV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: DelegateUtilityV1InstructionArgs,
 }
 
-impl<'a> DelegateUtilityV1Cpi<'a> {
+impl<'a, 'b> DelegateUtilityV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DelegateUtilityV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DelegateUtilityV1CpiAccounts<'a, 'b>,
         args: DelegateUtilityV1InstructionArgs,
     ) -> Self {
         Self {
@@ -481,7 +481,7 @@ impl<'a> DelegateUtilityV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -497,7 +497,7 @@ impl<'a> DelegateUtilityV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -653,12 +653,12 @@ impl<'a> DelegateUtilityV1Cpi<'a> {
 }
 
 /// `delegate_utility_v1` CPI instruction builder.
-pub struct DelegateUtilityV1CpiBuilder<'a> {
-    instruction: Box<DelegateUtilityV1CpiBuilderInstruction<'a>>,
+pub struct DelegateUtilityV1CpiBuilder<'a, 'b> {
+    instruction: Box<DelegateUtilityV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DelegateUtilityV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DelegateUtilityV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DelegateUtilityV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -686,7 +686,7 @@ impl<'a> DelegateUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -695,7 +695,7 @@ impl<'a> DelegateUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -704,7 +704,7 @@ impl<'a> DelegateUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -714,7 +714,7 @@ impl<'a> DelegateUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -724,20 +724,20 @@ impl<'a> DelegateUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     /// Token account of mint
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -745,14 +745,14 @@ impl<'a> DelegateUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -760,7 +760,7 @@ impl<'a> DelegateUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -769,7 +769,7 @@ impl<'a> DelegateUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -779,7 +779,7 @@ impl<'a> DelegateUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -789,7 +789,7 @@ impl<'a> DelegateUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -799,7 +799,7 @@ impl<'a> DelegateUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -819,7 +819,7 @@ impl<'a> DelegateUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -827,7 +827,7 @@ impl<'a> DelegateUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -893,23 +893,23 @@ impl<'a> DelegateUtilityV1CpiBuilder<'a> {
     }
 }
 
-struct DelegateUtilityV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DelegateUtilityV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     amount: Option<u64>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
+++ b/clients/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
@@ -327,83 +327,83 @@ impl DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenBuilder {
 }
 
 /// `deprecated_mint_new_edition_from_master_edition_via_printing_token` CPI accounts.
-pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiAccounts<'a> {
+pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiAccounts<'a, 'b> {
     /// New Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Edition V1 (pda of ['metadata', program id, mint id, 'edition'])
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Record Edition V1 (pda of ['metadata', program id, master metadata mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of new token - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority of new mint
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Printing Mint of master record edition
-    pub printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account containing Printing mint token to be transferred
-    pub master_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition pda to mark creation - will be checked for pre-existence. (pda of ['metadata', program id, master mint id, edition_number])
-    pub edition_marker: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_marker: &'b solana_program::account_info::AccountInfo<'a>,
     /// Burn authority for this token
-    pub burn_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub burn_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info for new metadata account
-    pub master_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master record metadata account
-    pub master_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
     /// Reservation List - If present, and you are on this list, you can get an edition number given by your position on the list.
-    pub reservation_list: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub reservation_list: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `deprecated_mint_new_edition_from_master_edition_via_printing_token` CPI instruction.
-pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a> {
+pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Edition V1 (pda of ['metadata', program id, mint id, 'edition'])
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Record Edition V1 (pda of ['metadata', program id, master metadata mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of new token - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority of new mint
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Printing Mint of master record edition
-    pub printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account containing Printing mint token to be transferred
-    pub master_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition pda to mark creation - will be checked for pre-existence. (pda of ['metadata', program id, master mint id, edition_number])
-    pub edition_marker: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_marker: &'b solana_program::account_info::AccountInfo<'a>,
     /// Burn authority for this token
-    pub burn_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub burn_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info for new metadata account
-    pub master_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master record metadata account
-    pub master_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
     /// Reservation List - If present, and you are on this list, you can get an edition number given by your position on the list.
-    pub reservation_list: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub reservation_list: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a> {
+impl<'a, 'b> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -432,7 +432,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -448,7 +448,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(16 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -562,13 +562,13 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a> {
 }
 
 /// `deprecated_mint_new_edition_from_master_edition_via_printing_token` CPI instruction builder.
-pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a> {
+pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a, 'b> {
     instruction:
-        Box<DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilderInstruction<'a>>,
+        Box<DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(
             DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilderInstruction {
                 __program: program,
@@ -597,7 +597,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -606,7 +606,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: &'a solana_program::account_info::AccountInfo<'a>,
+        edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition = Some(edition);
         self
@@ -615,14 +615,14 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition = Some(master_edition);
         self
     }
     /// Mint of new token - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -630,7 +630,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn mint_authority(
         &mut self,
-        mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.mint_authority = Some(mint_authority);
         self
@@ -639,7 +639,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn printing_mint(
         &mut self,
-        printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.printing_mint = Some(printing_mint);
         self
@@ -648,7 +648,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn master_token_account(
         &mut self,
-        master_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        master_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_token_account = Some(master_token_account);
         self
@@ -657,7 +657,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn edition_marker(
         &mut self,
-        edition_marker: &'a solana_program::account_info::AccountInfo<'a>,
+        edition_marker: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition_marker = Some(edition_marker);
         self
@@ -666,14 +666,14 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn burn_authority(
         &mut self,
-        burn_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        burn_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.burn_authority = Some(burn_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -681,7 +681,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn master_update_authority(
         &mut self,
-        master_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        master_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_update_authority = Some(master_update_authority);
         self
@@ -690,7 +690,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn master_metadata(
         &mut self,
-        master_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        master_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_metadata = Some(master_metadata);
         self
@@ -699,7 +699,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -708,14 +708,14 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     /// Rent info
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
@@ -724,7 +724,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn reservation_list(
         &mut self,
-        reservation_list: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        reservation_list: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.reservation_list = reservation_list;
         self
@@ -732,7 +732,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -740,7 +740,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -829,23 +829,23 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     }
 }
 
-struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    printing_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition_marker: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    burn_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    reservation_list: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    printing_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition_marker: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    burn_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    reservation_list: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/freeze_delegated_account.rs
+++ b/clients/rust/src/generated/instructions/freeze_delegated_account.rs
@@ -150,39 +150,39 @@ impl FreezeDelegatedAccountBuilder {
 }
 
 /// `freeze_delegated_account` CPI accounts.
-pub struct FreezeDelegatedAccountCpiAccounts<'a> {
+pub struct FreezeDelegatedAccountCpiAccounts<'a, 'b> {
     /// Delegate
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account to freeze
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token mint
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `freeze_delegated_account` CPI instruction.
-pub struct FreezeDelegatedAccountCpi<'a> {
+pub struct FreezeDelegatedAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account to freeze
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token mint
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> FreezeDelegatedAccountCpi<'a> {
+impl<'a, 'b> FreezeDelegatedAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: FreezeDelegatedAccountCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: FreezeDelegatedAccountCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -200,7 +200,7 @@ impl<'a> FreezeDelegatedAccountCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -216,7 +216,7 @@ impl<'a> FreezeDelegatedAccountCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -271,12 +271,12 @@ impl<'a> FreezeDelegatedAccountCpi<'a> {
 }
 
 /// `freeze_delegated_account` CPI instruction builder.
-pub struct FreezeDelegatedAccountCpiBuilder<'a> {
-    instruction: Box<FreezeDelegatedAccountCpiBuilderInstruction<'a>>,
+pub struct FreezeDelegatedAccountCpiBuilder<'a, 'b> {
+    instruction: Box<FreezeDelegatedAccountCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> FreezeDelegatedAccountCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> FreezeDelegatedAccountCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(FreezeDelegatedAccountCpiBuilderInstruction {
             __program: program,
             delegate: None,
@@ -292,7 +292,7 @@ impl<'a> FreezeDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -301,7 +301,7 @@ impl<'a> FreezeDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account(
         &mut self,
-        token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account = Some(token_account);
         self
@@ -310,14 +310,14 @@ impl<'a> FreezeDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: &'a solana_program::account_info::AccountInfo<'a>,
+        edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition = Some(edition);
         self
     }
     /// Token mint
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -325,7 +325,7 @@ impl<'a> FreezeDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -333,7 +333,7 @@ impl<'a> FreezeDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -341,7 +341,7 @@ impl<'a> FreezeDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -384,12 +384,12 @@ impl<'a> FreezeDelegatedAccountCpiBuilder<'a> {
     }
 }
 
-struct FreezeDelegatedAccountCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct FreezeDelegatedAccountCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/lock_v1.rs
+++ b/clients/rust/src/generated/instructions/lock_v1.rs
@@ -353,73 +353,73 @@ impl LockV1Builder {
 }
 
 /// `lock_v1` CPI accounts.
-pub struct LockV1CpiAccounts<'a> {
+pub struct LockV1CpiAccounts<'a, 'b> {
     /// Delegate or freeze authority
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token owner account
-    pub token_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `lock_v1` CPI instruction.
-pub struct LockV1Cpi<'a> {
+pub struct LockV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate or freeze authority
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token owner account
-    pub token_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: LockV1InstructionArgs,
 }
 
-impl<'a> LockV1Cpi<'a> {
+impl<'a, 'b> LockV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: LockV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: LockV1CpiAccounts<'a, 'b>,
         args: LockV1InstructionArgs,
     ) -> Self {
         Self {
@@ -447,7 +447,7 @@ impl<'a> LockV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -463,7 +463,7 @@ impl<'a> LockV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(13 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -612,12 +612,12 @@ impl<'a> LockV1Cpi<'a> {
 }
 
 /// `lock_v1` CPI instruction builder.
-pub struct LockV1CpiBuilder<'a> {
-    instruction: Box<LockV1CpiBuilderInstruction<'a>>,
+pub struct LockV1CpiBuilder<'a, 'b> {
+    instruction: Box<LockV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> LockV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> LockV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(LockV1CpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -642,7 +642,7 @@ impl<'a> LockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -652,20 +652,20 @@ impl<'a> LockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_owner(
         &mut self,
-        token_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_owner = token_owner;
         self
     }
     /// Token account
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -673,7 +673,7 @@ impl<'a> LockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -683,7 +683,7 @@ impl<'a> LockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition = edition;
         self
@@ -693,14 +693,14 @@ impl<'a> LockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -708,7 +708,7 @@ impl<'a> LockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -717,7 +717,7 @@ impl<'a> LockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -727,7 +727,7 @@ impl<'a> LockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -737,7 +737,7 @@ impl<'a> LockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -747,7 +747,7 @@ impl<'a> LockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -761,7 +761,7 @@ impl<'a> LockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -769,7 +769,7 @@ impl<'a> LockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -832,21 +832,21 @@ impl<'a> LockV1CpiBuilder<'a> {
     }
 }
 
-struct LockV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct LockV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/migrate.rs
+++ b/clients/rust/src/generated/instructions/migrate.rs
@@ -328,79 +328,79 @@ impl MigrateBuilder {
 }
 
 /// `migrate` CPI accounts.
-pub struct MigrateCpiAccounts<'a> {
+pub struct MigrateCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account owner
-    pub token_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection metadata account
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token record account
-    pub token_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instruction sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `migrate` CPI instruction.
-pub struct MigrateCpi<'a> {
+pub struct MigrateCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account owner
-    pub token_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection metadata account
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token record account
-    pub token_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instruction sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> MigrateCpi<'a> {
+impl<'a, 'b> MigrateCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: MigrateCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: MigrateCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -428,7 +428,7 @@ impl<'a> MigrateCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -444,7 +444,7 @@ impl<'a> MigrateCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(15 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -565,12 +565,12 @@ impl<'a> MigrateCpi<'a> {
 }
 
 /// `migrate` CPI instruction builder.
-pub struct MigrateCpiBuilder<'a> {
-    instruction: Box<MigrateCpiBuilderInstruction<'a>>,
+pub struct MigrateCpiBuilder<'a, 'b> {
+    instruction: Box<MigrateCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> MigrateCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> MigrateCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(MigrateCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -596,7 +596,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -605,14 +605,14 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: &'a solana_program::account_info::AccountInfo<'a>,
+        edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition = Some(edition);
         self
     }
     /// Token account
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -620,20 +620,20 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_owner(
         &mut self,
-        token_owner: &'a solana_program::account_info::AccountInfo<'a>,
+        token_owner: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner = Some(token_owner);
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -641,7 +641,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -650,7 +650,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_metadata(
         &mut self,
-        collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_metadata = Some(collection_metadata);
         self
@@ -659,7 +659,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate_record: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate_record = Some(delegate_record);
         self
@@ -668,7 +668,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: &'a solana_program::account_info::AccountInfo<'a>,
+        token_record: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_record = Some(token_record);
         self
@@ -677,7 +677,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -686,7 +686,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -695,7 +695,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_token_program = Some(spl_token_program);
         self
@@ -705,7 +705,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -715,7 +715,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -723,7 +723,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -731,7 +731,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -809,22 +809,22 @@ impl<'a> MigrateCpiBuilder<'a> {
     }
 }
 
-struct MigrateCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct MigrateCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
+++ b/clients/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
@@ -330,77 +330,77 @@ impl MintNewEditionFromMasterEditionViaTokenBuilder {
 }
 
 /// `mint_new_edition_from_master_edition_via_token` CPI accounts.
-pub struct MintNewEditionFromMasterEditionViaTokenCpiAccounts<'a> {
+pub struct MintNewEditionFromMasterEditionViaTokenCpiAccounts<'a, 'b> {
     /// New Metadata key (pda of ['metadata', program id, mint id])
-    pub new_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Edition (pda of ['metadata', program id, mint id, 'edition'])
-    pub new_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Record Edition V2 (pda of ['metadata', program id, master metadata mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of new token - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub new_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition pda to mark creation - will be checked for pre-existence. (pda of ['metadata', program id, master metadata mint id, 'edition', edition_number]) where edition_number is NOT the edition number you pass in args but actually edition_number = floor(edition/EDITION_MARKER_BIT_SIZE).
-    pub edition_mark_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_mark_pda: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority of new mint
-    pub new_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// owner of token account containing master token (#8)
-    pub token_account_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// token account containing token from master metadata mint
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority info for new metadata
-    pub new_metadata_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_metadata_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master record metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `mint_new_edition_from_master_edition_via_token` CPI instruction.
-pub struct MintNewEditionFromMasterEditionViaTokenCpi<'a> {
+pub struct MintNewEditionFromMasterEditionViaTokenCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Metadata key (pda of ['metadata', program id, mint id])
-    pub new_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Edition (pda of ['metadata', program id, mint id, 'edition'])
-    pub new_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Record Edition V2 (pda of ['metadata', program id, master metadata mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of new token - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub new_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition pda to mark creation - will be checked for pre-existence. (pda of ['metadata', program id, master metadata mint id, 'edition', edition_number]) where edition_number is NOT the edition number you pass in args but actually edition_number = floor(edition/EDITION_MARKER_BIT_SIZE).
-    pub edition_mark_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_mark_pda: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority of new mint
-    pub new_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// owner of token account containing master token (#8)
-    pub token_account_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// token account containing token from master metadata mint
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority info for new metadata
-    pub new_metadata_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_metadata_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master record metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: MintNewEditionFromMasterEditionViaTokenInstructionArgs,
 }
 
-impl<'a> MintNewEditionFromMasterEditionViaTokenCpi<'a> {
+impl<'a, 'b> MintNewEditionFromMasterEditionViaTokenCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: MintNewEditionFromMasterEditionViaTokenCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: MintNewEditionFromMasterEditionViaTokenCpiAccounts<'a, 'b>,
         args: MintNewEditionFromMasterEditionViaTokenInstructionArgs,
     ) -> Self {
         Self {
@@ -429,7 +429,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -445,7 +445,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -550,12 +550,12 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpi<'a> {
 }
 
 /// `mint_new_edition_from_master_edition_via_token` CPI instruction builder.
-pub struct MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
-    instruction: Box<MintNewEditionFromMasterEditionViaTokenCpiBuilderInstruction<'a>>,
+pub struct MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a, 'b> {
+    instruction: Box<MintNewEditionFromMasterEditionViaTokenCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(
             MintNewEditionFromMasterEditionViaTokenCpiBuilderInstruction {
                 __program: program,
@@ -583,7 +583,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_metadata(
         &mut self,
-        new_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        new_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_metadata = Some(new_metadata);
         self
@@ -592,7 +592,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_edition(
         &mut self,
-        new_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        new_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_edition = Some(new_edition);
         self
@@ -601,7 +601,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition = Some(master_edition);
         self
@@ -610,7 +610,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_mint(
         &mut self,
-        new_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        new_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_mint = Some(new_mint);
         self
@@ -619,7 +619,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition_mark_pda(
         &mut self,
-        edition_mark_pda: &'a solana_program::account_info::AccountInfo<'a>,
+        edition_mark_pda: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition_mark_pda = Some(edition_mark_pda);
         self
@@ -628,14 +628,14 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_mint_authority(
         &mut self,
-        new_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        new_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_mint_authority = Some(new_mint_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -643,7 +643,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account_owner(
         &mut self,
-        token_account_owner: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account_owner: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account_owner = Some(token_account_owner);
         self
@@ -652,7 +652,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account(
         &mut self,
-        token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account = Some(token_account);
         self
@@ -661,7 +661,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_metadata_update_authority(
         &mut self,
-        new_metadata_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        new_metadata_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_metadata_update_authority = Some(new_metadata_update_authority);
         self
@@ -670,7 +670,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -679,7 +679,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -688,7 +688,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -698,7 +698,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn rent(
         &mut self,
-        rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.rent = rent;
         self
@@ -716,7 +716,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -724,7 +724,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -817,23 +817,23 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     }
 }
 
-struct MintNewEditionFromMasterEditionViaTokenCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    new_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition_mark_pda: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_metadata_update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct MintNewEditionFromMasterEditionViaTokenCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    new_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition_mark_pda: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_metadata_update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     mint_new_edition_from_master_edition_via_token_args:
         Option<MintNewEditionFromMasterEditionViaTokenArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/clients/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -384,89 +384,89 @@ impl MintNewEditionFromMasterEditionViaVaultProxyBuilder {
 }
 
 /// `mint_new_edition_from_master_edition_via_vault_proxy` CPI accounts.
-pub struct MintNewEditionFromMasterEditionViaVaultProxyCpiAccounts<'a> {
+pub struct MintNewEditionFromMasterEditionViaVaultProxyCpiAccounts<'a, 'b> {
     /// New Metadata key (pda of ['metadata', program id, mint id])
-    pub new_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Edition (pda of ['metadata', program id, mint id, 'edition'])
-    pub new_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Record Edition V2 (pda of ['metadata', program id, master metadata mint id, 'edition']
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of new token - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub new_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition pda to mark creation - will be checked for pre-existence. (pda of ['metadata', program id, master metadata mint id, 'edition', edition_number]) where edition_number is NOT the edition number you pass in args but actually edition_number = floor(edition/EDITION_MARKER_BIT_SIZE).
-    pub edition_mark_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_mark_pda: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority of new mint
-    pub new_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Vault authority
-    pub vault_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub vault_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Safety deposit token store account
-    pub safety_deposit_store: &'a solana_program::account_info::AccountInfo<'a>,
+    pub safety_deposit_store: &'b solana_program::account_info::AccountInfo<'a>,
     /// Safety deposit box
-    pub safety_deposit_box: &'a solana_program::account_info::AccountInfo<'a>,
+    pub safety_deposit_box: &'b solana_program::account_info::AccountInfo<'a>,
     /// Vault
-    pub vault: &'a solana_program::account_info::AccountInfo<'a>,
+    pub vault: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority info for new metadata
-    pub new_metadata_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_metadata_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master record metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token vault program
-    pub token_vault_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `mint_new_edition_from_master_edition_via_vault_proxy` CPI instruction.
-pub struct MintNewEditionFromMasterEditionViaVaultProxyCpi<'a> {
+pub struct MintNewEditionFromMasterEditionViaVaultProxyCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Metadata key (pda of ['metadata', program id, mint id])
-    pub new_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Edition (pda of ['metadata', program id, mint id, 'edition'])
-    pub new_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Record Edition V2 (pda of ['metadata', program id, master metadata mint id, 'edition']
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of new token - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub new_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition pda to mark creation - will be checked for pre-existence. (pda of ['metadata', program id, master metadata mint id, 'edition', edition_number]) where edition_number is NOT the edition number you pass in args but actually edition_number = floor(edition/EDITION_MARKER_BIT_SIZE).
-    pub edition_mark_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_mark_pda: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority of new mint
-    pub new_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Vault authority
-    pub vault_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub vault_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Safety deposit token store account
-    pub safety_deposit_store: &'a solana_program::account_info::AccountInfo<'a>,
+    pub safety_deposit_store: &'b solana_program::account_info::AccountInfo<'a>,
     /// Safety deposit box
-    pub safety_deposit_box: &'a solana_program::account_info::AccountInfo<'a>,
+    pub safety_deposit_box: &'b solana_program::account_info::AccountInfo<'a>,
     /// Vault
-    pub vault: &'a solana_program::account_info::AccountInfo<'a>,
+    pub vault: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority info for new metadata
-    pub new_metadata_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_metadata_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master record metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token vault program
-    pub token_vault_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs,
 }
 
-impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpi<'a> {
+impl<'a, 'b> MintNewEditionFromMasterEditionViaVaultProxyCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: MintNewEditionFromMasterEditionViaVaultProxyCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: MintNewEditionFromMasterEditionViaVaultProxyCpiAccounts<'a, 'b>,
         args: MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs,
     ) -> Self {
         Self {
@@ -498,7 +498,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -514,7 +514,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(17 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -634,12 +634,12 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpi<'a> {
 }
 
 /// `mint_new_edition_from_master_edition_via_vault_proxy` CPI instruction builder.
-pub struct MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
-    instruction: Box<MintNewEditionFromMasterEditionViaVaultProxyCpiBuilderInstruction<'a>>,
+pub struct MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a, 'b> {
+    instruction: Box<MintNewEditionFromMasterEditionViaVaultProxyCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(
             MintNewEditionFromMasterEditionViaVaultProxyCpiBuilderInstruction {
                 __program: program,
@@ -670,7 +670,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_metadata(
         &mut self,
-        new_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        new_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_metadata = Some(new_metadata);
         self
@@ -679,7 +679,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_edition(
         &mut self,
-        new_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        new_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_edition = Some(new_edition);
         self
@@ -688,7 +688,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition = Some(master_edition);
         self
@@ -697,7 +697,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_mint(
         &mut self,
-        new_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        new_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_mint = Some(new_mint);
         self
@@ -706,7 +706,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition_mark_pda(
         &mut self,
-        edition_mark_pda: &'a solana_program::account_info::AccountInfo<'a>,
+        edition_mark_pda: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition_mark_pda = Some(edition_mark_pda);
         self
@@ -715,14 +715,14 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_mint_authority(
         &mut self,
-        new_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        new_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_mint_authority = Some(new_mint_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -730,7 +730,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn vault_authority(
         &mut self,
-        vault_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        vault_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.vault_authority = Some(vault_authority);
         self
@@ -739,7 +739,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn safety_deposit_store(
         &mut self,
-        safety_deposit_store: &'a solana_program::account_info::AccountInfo<'a>,
+        safety_deposit_store: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.safety_deposit_store = Some(safety_deposit_store);
         self
@@ -748,14 +748,14 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn safety_deposit_box(
         &mut self,
-        safety_deposit_box: &'a solana_program::account_info::AccountInfo<'a>,
+        safety_deposit_box: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.safety_deposit_box = Some(safety_deposit_box);
         self
     }
     /// Vault
     #[inline(always)]
-    pub fn vault(&mut self, vault: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn vault(&mut self, vault: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.vault = Some(vault);
         self
     }
@@ -763,7 +763,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_metadata_update_authority(
         &mut self,
-        new_metadata_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        new_metadata_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_metadata_update_authority = Some(new_metadata_update_authority);
         self
@@ -772,7 +772,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -781,7 +781,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -790,7 +790,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_vault_program(
         &mut self,
-        token_vault_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_vault_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_program = Some(token_vault_program);
         self
@@ -799,7 +799,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -809,7 +809,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn rent(
         &mut self,
-        rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.rent = rent;
         self
@@ -827,7 +827,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -835,7 +835,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -940,26 +940,26 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     }
 }
 
-struct MintNewEditionFromMasterEditionViaVaultProxyCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    new_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition_mark_pda: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    vault_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    safety_deposit_store: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    safety_deposit_box: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    vault: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_metadata_update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_vault_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct MintNewEditionFromMasterEditionViaVaultProxyCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    new_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition_mark_pda: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    vault_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    safety_deposit_store: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    safety_deposit_box: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    vault: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_metadata_update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_vault_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     mint_new_edition_from_master_edition_via_token_args:
         Option<MintNewEditionFromMasterEditionViaTokenArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/mint_v1.rs
+++ b/clients/rust/src/generated/instructions/mint_v1.rs
@@ -406,81 +406,81 @@ impl MintV1Builder {
 }
 
 /// `mint_v1` CPI accounts.
-pub struct MintV1CpiAccounts<'a> {
+pub struct MintV1CpiAccounts<'a, 'b> {
     /// Token or Associated Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner of the token account
-    pub token_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata account (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// (Mint or Update) authority
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata delegate record
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Associated Token Account program
-    pub spl_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `mint_v1` CPI instruction.
-pub struct MintV1Cpi<'a> {
+pub struct MintV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token or Associated Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner of the token account
-    pub token_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata account (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// (Mint or Update) authority
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata delegate record
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Associated Token Account program
-    pub spl_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: MintV1InstructionArgs,
 }
 
-impl<'a> MintV1Cpi<'a> {
+impl<'a, 'b> MintV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: MintV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: MintV1CpiAccounts<'a, 'b>,
         args: MintV1InstructionArgs,
     ) -> Self {
         Self {
@@ -510,7 +510,7 @@ impl<'a> MintV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -526,7 +526,7 @@ impl<'a> MintV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(15 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -685,12 +685,12 @@ impl<'a> MintV1Cpi<'a> {
 }
 
 /// `mint_v1` CPI instruction builder.
-pub struct MintV1CpiBuilder<'a> {
-    instruction: Box<MintV1CpiBuilderInstruction<'a>>,
+pub struct MintV1CpiBuilder<'a, 'b> {
+    instruction: Box<MintV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> MintV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> MintV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(MintV1CpiBuilderInstruction {
             __program: program,
             token: None,
@@ -716,7 +716,7 @@ impl<'a> MintV1CpiBuilder<'a> {
     }
     /// Token or Associated Token account
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -725,7 +725,7 @@ impl<'a> MintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_owner(
         &mut self,
-        token_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_owner = token_owner;
         self
@@ -734,7 +734,7 @@ impl<'a> MintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -744,7 +744,7 @@ impl<'a> MintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -754,14 +754,14 @@ impl<'a> MintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of token asset
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -769,7 +769,7 @@ impl<'a> MintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -779,14 +779,14 @@ impl<'a> MintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -794,7 +794,7 @@ impl<'a> MintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -803,7 +803,7 @@ impl<'a> MintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -812,7 +812,7 @@ impl<'a> MintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_token_program = Some(spl_token_program);
         self
@@ -821,7 +821,7 @@ impl<'a> MintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_ata_program(
         &mut self,
-        spl_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_ata_program = Some(spl_ata_program);
         self
@@ -831,7 +831,7 @@ impl<'a> MintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -841,7 +841,7 @@ impl<'a> MintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -861,7 +861,7 @@ impl<'a> MintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -869,7 +869,7 @@ impl<'a> MintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -943,24 +943,24 @@ impl<'a> MintV1CpiBuilder<'a> {
     }
 }
 
-struct MintV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_ata_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct MintV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_ata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     amount: Option<u64>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/mod.rs
+++ b/clients/rust/src/generated/instructions/mod.rs
@@ -197,14 +197,14 @@ impl InstructionAccount {
 }
 
 #[derive(Clone, Copy)]
-pub enum InstructionAccountInfo<'a> {
-    Readonly(&'a solana_program::account_info::AccountInfo<'a>),
-    ReadonlySigner(&'a solana_program::account_info::AccountInfo<'a>),
-    Writable(&'a solana_program::account_info::AccountInfo<'a>),
-    WritableSigner(&'a solana_program::account_info::AccountInfo<'a>),
+pub enum InstructionAccountInfo<'a, 'b> {
+    Readonly(&'b solana_program::account_info::AccountInfo<'a>),
+    ReadonlySigner(&'b solana_program::account_info::AccountInfo<'a>),
+    Writable(&'b solana_program::account_info::AccountInfo<'a>),
+    WritableSigner(&'b solana_program::account_info::AccountInfo<'a>),
 }
 
-impl<'a> InstructionAccountInfo<'a> {
+impl<'a, 'b> InstructionAccountInfo<'a, 'b> {
     pub fn to_account_meta(&self) -> solana_program::instruction::AccountMeta {
         let (pubkey, writable, signer) = match self {
             InstructionAccountInfo::Readonly(account_info) => (account_info.key, false, false),
@@ -219,7 +219,7 @@ impl<'a> InstructionAccountInfo<'a> {
             solana_program::instruction::AccountMeta::new_readonly(*pubkey, signer)
         }
     }
-    pub fn account_info(&self) -> &'a solana_program::account_info::AccountInfo<'a> {
+    pub fn account_info(&self) -> &'b solana_program::account_info::AccountInfo<'a> {
         match self {
             InstructionAccountInfo::Readonly(account_info)
             | InstructionAccountInfo::ReadonlySigner(account_info)

--- a/clients/rust/src/generated/instructions/print_v1.rs
+++ b/clients/rust/src/generated/instructions/print_v1.rs
@@ -430,93 +430,93 @@ impl PrintV1Builder {
 }
 
 /// `print_v1` CPI accounts.
-pub struct PrintV1CpiAccounts<'a> {
+pub struct PrintV1CpiAccounts<'a, 'b> {
     /// New Metadata key (pda of ['metadata', program id, mint id])
-    pub edition_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Edition (pda of ['metadata', program id, mint id, 'edition'])
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of new token - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub edition_mint: (&'a solana_program::account_info::AccountInfo<'a>, bool),
+    pub edition_mint: (&'b solana_program::account_info::AccountInfo<'a>, bool),
     /// Owner of the token account of new token
-    pub edition_token_account_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_token_account_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of new token
-    pub edition_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority of new mint
-    pub edition_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token record account
-    pub edition_token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Master Record Edition V2 (pda of ['metadata', program id, master metadata mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition pda to mark creation - will be checked for pre-existence. (pda of ['metadata', program id, master metadata mint id, 'edition', edition_number]) where edition_number is NOT the edition number you pass in args but actually edition_number = floor(edition/EDITION_MARKER_BIT_SIZE).
-    pub edition_marker_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_marker_pda: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// owner of token account containing master token
-    pub master_token_account_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_token_account_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// token account containing token from master metadata mint
-    pub master_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master record metadata account
-    pub master_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// The update authority of the master edition.
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Associated Token Account program
-    pub spl_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `print_v1` CPI instruction.
-pub struct PrintV1Cpi<'a> {
+pub struct PrintV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Metadata key (pda of ['metadata', program id, mint id])
-    pub edition_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Edition (pda of ['metadata', program id, mint id, 'edition'])
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of new token - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub edition_mint: (&'a solana_program::account_info::AccountInfo<'a>, bool),
+    pub edition_mint: (&'b solana_program::account_info::AccountInfo<'a>, bool),
     /// Owner of the token account of new token
-    pub edition_token_account_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_token_account_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of new token
-    pub edition_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority of new mint
-    pub edition_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token record account
-    pub edition_token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Master Record Edition V2 (pda of ['metadata', program id, master metadata mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition pda to mark creation - will be checked for pre-existence. (pda of ['metadata', program id, master metadata mint id, 'edition', edition_number]) where edition_number is NOT the edition number you pass in args but actually edition_number = floor(edition/EDITION_MARKER_BIT_SIZE).
-    pub edition_marker_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_marker_pda: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// owner of token account containing master token
-    pub master_token_account_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_token_account_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// token account containing token from master metadata mint
-    pub master_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master record metadata account
-    pub master_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// The update authority of the master edition.
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Associated Token Account program
-    pub spl_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: PrintV1InstructionArgs,
 }
 
-impl<'a> PrintV1Cpi<'a> {
+impl<'a, 'b> PrintV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: PrintV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: PrintV1CpiAccounts<'a, 'b>,
         args: PrintV1InstructionArgs,
     ) -> Self {
         Self {
@@ -549,7 +549,7 @@ impl<'a> PrintV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -565,7 +565,7 @@ impl<'a> PrintV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(18 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -694,12 +694,12 @@ impl<'a> PrintV1Cpi<'a> {
 }
 
 /// `print_v1` CPI instruction builder.
-pub struct PrintV1CpiBuilder<'a> {
-    instruction: Box<PrintV1CpiBuilderInstruction<'a>>,
+pub struct PrintV1CpiBuilder<'a, 'b> {
+    instruction: Box<PrintV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> PrintV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> PrintV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(PrintV1CpiBuilderInstruction {
             __program: program,
             edition_metadata: None,
@@ -729,7 +729,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition_metadata(
         &mut self,
-        edition_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        edition_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition_metadata = Some(edition_metadata);
         self
@@ -738,7 +738,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: &'a solana_program::account_info::AccountInfo<'a>,
+        edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition = Some(edition);
         self
@@ -747,7 +747,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition_mint(
         &mut self,
-        edition_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        edition_mint: &'b solana_program::account_info::AccountInfo<'a>,
         as_signer: bool,
     ) -> &mut Self {
         self.instruction.edition_mint = Some((edition_mint, as_signer));
@@ -757,7 +757,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition_token_account_owner(
         &mut self,
-        edition_token_account_owner: &'a solana_program::account_info::AccountInfo<'a>,
+        edition_token_account_owner: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition_token_account_owner = Some(edition_token_account_owner);
         self
@@ -766,7 +766,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition_token_account(
         &mut self,
-        edition_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        edition_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition_token_account = Some(edition_token_account);
         self
@@ -775,7 +775,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition_mint_authority(
         &mut self,
-        edition_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        edition_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition_mint_authority = Some(edition_mint_authority);
         self
@@ -785,7 +785,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition_token_record(
         &mut self,
-        edition_token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition_token_record = edition_token_record;
         self
@@ -794,7 +794,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition = Some(master_edition);
         self
@@ -803,14 +803,14 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition_marker_pda(
         &mut self,
-        edition_marker_pda: &'a solana_program::account_info::AccountInfo<'a>,
+        edition_marker_pda: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition_marker_pda = Some(edition_marker_pda);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -818,7 +818,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_token_account_owner(
         &mut self,
-        master_token_account_owner: &'a solana_program::account_info::AccountInfo<'a>,
+        master_token_account_owner: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_token_account_owner = Some(master_token_account_owner);
         self
@@ -827,7 +827,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_token_account(
         &mut self,
-        master_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        master_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_token_account = Some(master_token_account);
         self
@@ -836,7 +836,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_metadata(
         &mut self,
-        master_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        master_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_metadata = Some(master_metadata);
         self
@@ -845,7 +845,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -854,7 +854,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_token_program = Some(spl_token_program);
         self
@@ -863,7 +863,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_ata_program(
         &mut self,
-        spl_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_ata_program = Some(spl_ata_program);
         self
@@ -872,7 +872,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -881,7 +881,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -894,7 +894,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -902,7 +902,7 @@ impl<'a> PrintV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -1018,26 +1018,26 @@ impl<'a> PrintV1CpiBuilder<'a> {
     }
 }
 
-struct PrintV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    edition_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition_mint: Option<(&'a solana_program::account_info::AccountInfo<'a>, bool)>,
-    edition_token_account_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition_token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition_mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition_token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition_marker_pda: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_token_account_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_ata_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct PrintV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    edition_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition_mint: Option<(&'b solana_program::account_info::AccountInfo<'a>, bool)>,
+    edition_token_account_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition_mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition_marker_pda: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_token_account_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_ata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     edition_number: Option<u64>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/puff_metadata.rs
+++ b/clients/rust/src/generated/instructions/puff_metadata.rs
@@ -90,23 +90,23 @@ impl PuffMetadataBuilder {
 }
 
 /// `puff_metadata` CPI accounts.
-pub struct PuffMetadataCpiAccounts<'a> {
+pub struct PuffMetadataCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `puff_metadata` CPI instruction.
-pub struct PuffMetadataCpi<'a> {
+pub struct PuffMetadataCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> PuffMetadataCpi<'a> {
+impl<'a, 'b> PuffMetadataCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: PuffMetadataCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: PuffMetadataCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -120,7 +120,7 @@ impl<'a> PuffMetadataCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -136,7 +136,7 @@ impl<'a> PuffMetadataCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(1 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -169,12 +169,12 @@ impl<'a> PuffMetadataCpi<'a> {
 }
 
 /// `puff_metadata` CPI instruction builder.
-pub struct PuffMetadataCpiBuilder<'a> {
-    instruction: Box<PuffMetadataCpiBuilderInstruction<'a>>,
+pub struct PuffMetadataCpiBuilder<'a, 'b> {
+    instruction: Box<PuffMetadataCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> PuffMetadataCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> PuffMetadataCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(PuffMetadataCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -186,7 +186,7 @@ impl<'a> PuffMetadataCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -194,7 +194,7 @@ impl<'a> PuffMetadataCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -202,7 +202,7 @@ impl<'a> PuffMetadataCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -231,8 +231,8 @@ impl<'a> PuffMetadataCpiBuilder<'a> {
     }
 }
 
-struct PuffMetadataCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct PuffMetadataCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/remove_creator_verification.rs
+++ b/clients/rust/src/generated/instructions/remove_creator_verification.rs
@@ -106,27 +106,27 @@ impl RemoveCreatorVerificationBuilder {
 }
 
 /// `remove_creator_verification` CPI accounts.
-pub struct RemoveCreatorVerificationCpiAccounts<'a> {
+pub struct RemoveCreatorVerificationCpiAccounts<'a, 'b> {
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Creator
-    pub creator: &'a solana_program::account_info::AccountInfo<'a>,
+    pub creator: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `remove_creator_verification` CPI instruction.
-pub struct RemoveCreatorVerificationCpi<'a> {
+pub struct RemoveCreatorVerificationCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Creator
-    pub creator: &'a solana_program::account_info::AccountInfo<'a>,
+    pub creator: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> RemoveCreatorVerificationCpi<'a> {
+impl<'a, 'b> RemoveCreatorVerificationCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RemoveCreatorVerificationCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RemoveCreatorVerificationCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -141,7 +141,7 @@ impl<'a> RemoveCreatorVerificationCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -157,7 +157,7 @@ impl<'a> RemoveCreatorVerificationCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -197,12 +197,12 @@ impl<'a> RemoveCreatorVerificationCpi<'a> {
 }
 
 /// `remove_creator_verification` CPI instruction builder.
-pub struct RemoveCreatorVerificationCpiBuilder<'a> {
-    instruction: Box<RemoveCreatorVerificationCpiBuilderInstruction<'a>>,
+pub struct RemoveCreatorVerificationCpiBuilder<'a, 'b> {
+    instruction: Box<RemoveCreatorVerificationCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RemoveCreatorVerificationCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RemoveCreatorVerificationCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RemoveCreatorVerificationCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -215,7 +215,7 @@ impl<'a> RemoveCreatorVerificationCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -224,7 +224,7 @@ impl<'a> RemoveCreatorVerificationCpiBuilder<'a> {
     #[inline(always)]
     pub fn creator(
         &mut self,
-        creator: &'a solana_program::account_info::AccountInfo<'a>,
+        creator: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.creator = Some(creator);
         self
@@ -232,7 +232,7 @@ impl<'a> RemoveCreatorVerificationCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -240,7 +240,7 @@ impl<'a> RemoveCreatorVerificationCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -271,9 +271,9 @@ impl<'a> RemoveCreatorVerificationCpiBuilder<'a> {
     }
 }
 
-struct RemoveCreatorVerificationCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    creator: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RemoveCreatorVerificationCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    creator: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/revoke_authority_item_v1.rs
+++ b/clients/rust/src/generated/instructions/revoke_authority_item_v1.rs
@@ -356,75 +356,75 @@ impl RevokeAuthorityItemV1Builder {
 }
 
 /// `revoke_authority_item_v1` CPI accounts.
-pub struct RevokeAuthorityItemV1CpiAccounts<'a> {
+pub struct RevokeAuthorityItemV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `revoke_authority_item_v1` CPI instruction.
-pub struct RevokeAuthorityItemV1Cpi<'a> {
+pub struct RevokeAuthorityItemV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> RevokeAuthorityItemV1Cpi<'a> {
+impl<'a, 'b> RevokeAuthorityItemV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeAuthorityItemV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeAuthorityItemV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -451,7 +451,7 @@ impl<'a> RevokeAuthorityItemV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -467,7 +467,7 @@ impl<'a> RevokeAuthorityItemV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -629,12 +629,12 @@ impl<'a> RevokeAuthorityItemV1Cpi<'a> {
 }
 
 /// `revoke_authority_item_v1` CPI instruction builder.
-pub struct RevokeAuthorityItemV1CpiBuilder<'a> {
-    instruction: Box<RevokeAuthorityItemV1CpiBuilderInstruction<'a>>,
+pub struct RevokeAuthorityItemV1CpiBuilder<'a, 'b> {
+    instruction: Box<RevokeAuthorityItemV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeAuthorityItemV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeAuthorityItemV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeAuthorityItemV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -660,7 +660,7 @@ impl<'a> RevokeAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -669,7 +669,7 @@ impl<'a> RevokeAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -678,7 +678,7 @@ impl<'a> RevokeAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -688,7 +688,7 @@ impl<'a> RevokeAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -698,14 +698,14 @@ impl<'a> RevokeAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -714,7 +714,7 @@ impl<'a> RevokeAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
@@ -723,14 +723,14 @@ impl<'a> RevokeAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -738,7 +738,7 @@ impl<'a> RevokeAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -747,7 +747,7 @@ impl<'a> RevokeAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -757,7 +757,7 @@ impl<'a> RevokeAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -767,7 +767,7 @@ impl<'a> RevokeAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -777,7 +777,7 @@ impl<'a> RevokeAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -785,7 +785,7 @@ impl<'a> RevokeAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -793,7 +793,7 @@ impl<'a> RevokeAuthorityItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -854,21 +854,21 @@ impl<'a> RevokeAuthorityItemV1CpiBuilder<'a> {
     }
 }
 
-struct RevokeAuthorityItemV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeAuthorityItemV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/revoke_collection_authority.rs
+++ b/clients/rust/src/generated/instructions/revoke_collection_authority.rs
@@ -160,39 +160,39 @@ impl RevokeCollectionAuthorityBuilder {
 }
 
 /// `revoke_collection_authority` CPI accounts.
-pub struct RevokeCollectionAuthorityCpiAccounts<'a> {
+pub struct RevokeCollectionAuthorityCpiAccounts<'a, 'b> {
     /// Collection Authority Record PDA
-    pub collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegated Collection Authority
-    pub delegate_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update Authority, or Delegated Authority, of Collection NFT
-    pub revoke_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub revoke_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `revoke_collection_authority` CPI instruction.
-pub struct RevokeCollectionAuthorityCpi<'a> {
+pub struct RevokeCollectionAuthorityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegated Collection Authority
-    pub delegate_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update Authority, or Delegated Authority, of Collection NFT
-    pub revoke_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub revoke_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> RevokeCollectionAuthorityCpi<'a> {
+impl<'a, 'b> RevokeCollectionAuthorityCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeCollectionAuthorityCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeCollectionAuthorityCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -210,7 +210,7 @@ impl<'a> RevokeCollectionAuthorityCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -226,7 +226,7 @@ impl<'a> RevokeCollectionAuthorityCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -281,12 +281,12 @@ impl<'a> RevokeCollectionAuthorityCpi<'a> {
 }
 
 /// `revoke_collection_authority` CPI instruction builder.
-pub struct RevokeCollectionAuthorityCpiBuilder<'a> {
-    instruction: Box<RevokeCollectionAuthorityCpiBuilderInstruction<'a>>,
+pub struct RevokeCollectionAuthorityCpiBuilder<'a, 'b> {
+    instruction: Box<RevokeCollectionAuthorityCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeCollectionAuthorityCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeCollectionAuthorityCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeCollectionAuthorityCpiBuilderInstruction {
             __program: program,
             collection_authority_record: None,
@@ -302,7 +302,7 @@ impl<'a> RevokeCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = Some(collection_authority_record);
         self
@@ -311,7 +311,7 @@ impl<'a> RevokeCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_authority(
         &mut self,
-        delegate_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate_authority = Some(delegate_authority);
         self
@@ -320,7 +320,7 @@ impl<'a> RevokeCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn revoke_authority(
         &mut self,
-        revoke_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        revoke_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.revoke_authority = Some(revoke_authority);
         self
@@ -329,21 +329,21 @@ impl<'a> RevokeCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Mint of Metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -351,7 +351,7 @@ impl<'a> RevokeCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -397,12 +397,12 @@ impl<'a> RevokeCollectionAuthorityCpiBuilder<'a> {
     }
 }
 
-struct RevokeCollectionAuthorityCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    revoke_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeCollectionAuthorityCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    revoke_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/revoke_collection_item_v1.rs
+++ b/clients/rust/src/generated/instructions/revoke_collection_item_v1.rs
@@ -356,75 +356,75 @@ impl RevokeCollectionItemV1Builder {
 }
 
 /// `revoke_collection_item_v1` CPI accounts.
-pub struct RevokeCollectionItemV1CpiAccounts<'a> {
+pub struct RevokeCollectionItemV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `revoke_collection_item_v1` CPI instruction.
-pub struct RevokeCollectionItemV1Cpi<'a> {
+pub struct RevokeCollectionItemV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> RevokeCollectionItemV1Cpi<'a> {
+impl<'a, 'b> RevokeCollectionItemV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeCollectionItemV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeCollectionItemV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -451,7 +451,7 @@ impl<'a> RevokeCollectionItemV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -467,7 +467,7 @@ impl<'a> RevokeCollectionItemV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -629,12 +629,12 @@ impl<'a> RevokeCollectionItemV1Cpi<'a> {
 }
 
 /// `revoke_collection_item_v1` CPI instruction builder.
-pub struct RevokeCollectionItemV1CpiBuilder<'a> {
-    instruction: Box<RevokeCollectionItemV1CpiBuilderInstruction<'a>>,
+pub struct RevokeCollectionItemV1CpiBuilder<'a, 'b> {
+    instruction: Box<RevokeCollectionItemV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeCollectionItemV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeCollectionItemV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeCollectionItemV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -660,7 +660,7 @@ impl<'a> RevokeCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -669,7 +669,7 @@ impl<'a> RevokeCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -678,7 +678,7 @@ impl<'a> RevokeCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -688,7 +688,7 @@ impl<'a> RevokeCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -698,14 +698,14 @@ impl<'a> RevokeCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -714,7 +714,7 @@ impl<'a> RevokeCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
@@ -723,14 +723,14 @@ impl<'a> RevokeCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -738,7 +738,7 @@ impl<'a> RevokeCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -747,7 +747,7 @@ impl<'a> RevokeCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -757,7 +757,7 @@ impl<'a> RevokeCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -767,7 +767,7 @@ impl<'a> RevokeCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -777,7 +777,7 @@ impl<'a> RevokeCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -785,7 +785,7 @@ impl<'a> RevokeCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -793,7 +793,7 @@ impl<'a> RevokeCollectionItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -854,21 +854,21 @@ impl<'a> RevokeCollectionItemV1CpiBuilder<'a> {
     }
 }
 
-struct RevokeCollectionItemV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeCollectionItemV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/revoke_collection_v1.rs
+++ b/clients/rust/src/generated/instructions/revoke_collection_v1.rs
@@ -356,75 +356,75 @@ impl RevokeCollectionV1Builder {
 }
 
 /// `revoke_collection_v1` CPI accounts.
-pub struct RevokeCollectionV1CpiAccounts<'a> {
+pub struct RevokeCollectionV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `revoke_collection_v1` CPI instruction.
-pub struct RevokeCollectionV1Cpi<'a> {
+pub struct RevokeCollectionV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> RevokeCollectionV1Cpi<'a> {
+impl<'a, 'b> RevokeCollectionV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeCollectionV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeCollectionV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -451,7 +451,7 @@ impl<'a> RevokeCollectionV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -467,7 +467,7 @@ impl<'a> RevokeCollectionV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -629,12 +629,12 @@ impl<'a> RevokeCollectionV1Cpi<'a> {
 }
 
 /// `revoke_collection_v1` CPI instruction builder.
-pub struct RevokeCollectionV1CpiBuilder<'a> {
-    instruction: Box<RevokeCollectionV1CpiBuilderInstruction<'a>>,
+pub struct RevokeCollectionV1CpiBuilder<'a, 'b> {
+    instruction: Box<RevokeCollectionV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeCollectionV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeCollectionV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeCollectionV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -660,7 +660,7 @@ impl<'a> RevokeCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -669,7 +669,7 @@ impl<'a> RevokeCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -678,7 +678,7 @@ impl<'a> RevokeCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -688,7 +688,7 @@ impl<'a> RevokeCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -698,14 +698,14 @@ impl<'a> RevokeCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -714,7 +714,7 @@ impl<'a> RevokeCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
@@ -723,14 +723,14 @@ impl<'a> RevokeCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -738,7 +738,7 @@ impl<'a> RevokeCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -747,7 +747,7 @@ impl<'a> RevokeCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -757,7 +757,7 @@ impl<'a> RevokeCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -767,7 +767,7 @@ impl<'a> RevokeCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -777,7 +777,7 @@ impl<'a> RevokeCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -785,7 +785,7 @@ impl<'a> RevokeCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -793,7 +793,7 @@ impl<'a> RevokeCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -854,21 +854,21 @@ impl<'a> RevokeCollectionV1CpiBuilder<'a> {
     }
 }
 
-struct RevokeCollectionV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeCollectionV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/revoke_data_item_v1.rs
+++ b/clients/rust/src/generated/instructions/revoke_data_item_v1.rs
@@ -354,75 +354,75 @@ impl RevokeDataItemV1Builder {
 }
 
 /// `revoke_data_item_v1` CPI accounts.
-pub struct RevokeDataItemV1CpiAccounts<'a> {
+pub struct RevokeDataItemV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `revoke_data_item_v1` CPI instruction.
-pub struct RevokeDataItemV1Cpi<'a> {
+pub struct RevokeDataItemV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> RevokeDataItemV1Cpi<'a> {
+impl<'a, 'b> RevokeDataItemV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeDataItemV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeDataItemV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -449,7 +449,7 @@ impl<'a> RevokeDataItemV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -465,7 +465,7 @@ impl<'a> RevokeDataItemV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -625,12 +625,12 @@ impl<'a> RevokeDataItemV1Cpi<'a> {
 }
 
 /// `revoke_data_item_v1` CPI instruction builder.
-pub struct RevokeDataItemV1CpiBuilder<'a> {
-    instruction: Box<RevokeDataItemV1CpiBuilderInstruction<'a>>,
+pub struct RevokeDataItemV1CpiBuilder<'a, 'b> {
+    instruction: Box<RevokeDataItemV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeDataItemV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeDataItemV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeDataItemV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -656,7 +656,7 @@ impl<'a> RevokeDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -665,7 +665,7 @@ impl<'a> RevokeDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -674,7 +674,7 @@ impl<'a> RevokeDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -684,7 +684,7 @@ impl<'a> RevokeDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -694,14 +694,14 @@ impl<'a> RevokeDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -710,7 +710,7 @@ impl<'a> RevokeDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
@@ -719,14 +719,14 @@ impl<'a> RevokeDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -734,7 +734,7 @@ impl<'a> RevokeDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -743,7 +743,7 @@ impl<'a> RevokeDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -753,7 +753,7 @@ impl<'a> RevokeDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -763,7 +763,7 @@ impl<'a> RevokeDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -773,7 +773,7 @@ impl<'a> RevokeDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -781,7 +781,7 @@ impl<'a> RevokeDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -789,7 +789,7 @@ impl<'a> RevokeDataItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -850,21 +850,21 @@ impl<'a> RevokeDataItemV1CpiBuilder<'a> {
     }
 }
 
-struct RevokeDataItemV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeDataItemV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/revoke_data_v1.rs
+++ b/clients/rust/src/generated/instructions/revoke_data_v1.rs
@@ -354,75 +354,75 @@ impl RevokeDataV1Builder {
 }
 
 /// `revoke_data_v1` CPI accounts.
-pub struct RevokeDataV1CpiAccounts<'a> {
+pub struct RevokeDataV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `revoke_data_v1` CPI instruction.
-pub struct RevokeDataV1Cpi<'a> {
+pub struct RevokeDataV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> RevokeDataV1Cpi<'a> {
+impl<'a, 'b> RevokeDataV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeDataV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeDataV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -449,7 +449,7 @@ impl<'a> RevokeDataV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -465,7 +465,7 @@ impl<'a> RevokeDataV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -625,12 +625,12 @@ impl<'a> RevokeDataV1Cpi<'a> {
 }
 
 /// `revoke_data_v1` CPI instruction builder.
-pub struct RevokeDataV1CpiBuilder<'a> {
-    instruction: Box<RevokeDataV1CpiBuilderInstruction<'a>>,
+pub struct RevokeDataV1CpiBuilder<'a, 'b> {
+    instruction: Box<RevokeDataV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeDataV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeDataV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeDataV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -656,7 +656,7 @@ impl<'a> RevokeDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -665,7 +665,7 @@ impl<'a> RevokeDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -674,7 +674,7 @@ impl<'a> RevokeDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -684,7 +684,7 @@ impl<'a> RevokeDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -694,14 +694,14 @@ impl<'a> RevokeDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -710,7 +710,7 @@ impl<'a> RevokeDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
@@ -719,14 +719,14 @@ impl<'a> RevokeDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -734,7 +734,7 @@ impl<'a> RevokeDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -743,7 +743,7 @@ impl<'a> RevokeDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -753,7 +753,7 @@ impl<'a> RevokeDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -763,7 +763,7 @@ impl<'a> RevokeDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -773,7 +773,7 @@ impl<'a> RevokeDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -781,7 +781,7 @@ impl<'a> RevokeDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -789,7 +789,7 @@ impl<'a> RevokeDataV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -850,21 +850,21 @@ impl<'a> RevokeDataV1CpiBuilder<'a> {
     }
 }
 
-struct RevokeDataV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeDataV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/revoke_locked_transfer_v1.rs
+++ b/clients/rust/src/generated/instructions/revoke_locked_transfer_v1.rs
@@ -350,75 +350,75 @@ impl RevokeLockedTransferV1Builder {
 }
 
 /// `revoke_locked_transfer_v1` CPI accounts.
-pub struct RevokeLockedTransferV1CpiAccounts<'a> {
+pub struct RevokeLockedTransferV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `revoke_locked_transfer_v1` CPI instruction.
-pub struct RevokeLockedTransferV1Cpi<'a> {
+pub struct RevokeLockedTransferV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> RevokeLockedTransferV1Cpi<'a> {
+impl<'a, 'b> RevokeLockedTransferV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeLockedTransferV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeLockedTransferV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -445,7 +445,7 @@ impl<'a> RevokeLockedTransferV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -461,7 +461,7 @@ impl<'a> RevokeLockedTransferV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -615,12 +615,12 @@ impl<'a> RevokeLockedTransferV1Cpi<'a> {
 }
 
 /// `revoke_locked_transfer_v1` CPI instruction builder.
-pub struct RevokeLockedTransferV1CpiBuilder<'a> {
-    instruction: Box<RevokeLockedTransferV1CpiBuilderInstruction<'a>>,
+pub struct RevokeLockedTransferV1CpiBuilder<'a, 'b> {
+    instruction: Box<RevokeLockedTransferV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeLockedTransferV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeLockedTransferV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeLockedTransferV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -646,7 +646,7 @@ impl<'a> RevokeLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -655,7 +655,7 @@ impl<'a> RevokeLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -664,7 +664,7 @@ impl<'a> RevokeLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -674,7 +674,7 @@ impl<'a> RevokeLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -684,20 +684,20 @@ impl<'a> RevokeLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     /// Token account of mint
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -705,14 +705,14 @@ impl<'a> RevokeLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -720,7 +720,7 @@ impl<'a> RevokeLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -729,7 +729,7 @@ impl<'a> RevokeLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -739,7 +739,7 @@ impl<'a> RevokeLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -749,7 +749,7 @@ impl<'a> RevokeLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -759,7 +759,7 @@ impl<'a> RevokeLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -767,7 +767,7 @@ impl<'a> RevokeLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -775,7 +775,7 @@ impl<'a> RevokeLockedTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -836,21 +836,21 @@ impl<'a> RevokeLockedTransferV1CpiBuilder<'a> {
     }
 }
 
-struct RevokeLockedTransferV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeLockedTransferV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/revoke_migration_v1.rs
+++ b/clients/rust/src/generated/instructions/revoke_migration_v1.rs
@@ -350,75 +350,75 @@ impl RevokeMigrationV1Builder {
 }
 
 /// `revoke_migration_v1` CPI accounts.
-pub struct RevokeMigrationV1CpiAccounts<'a> {
+pub struct RevokeMigrationV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `revoke_migration_v1` CPI instruction.
-pub struct RevokeMigrationV1Cpi<'a> {
+pub struct RevokeMigrationV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> RevokeMigrationV1Cpi<'a> {
+impl<'a, 'b> RevokeMigrationV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeMigrationV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeMigrationV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -445,7 +445,7 @@ impl<'a> RevokeMigrationV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -461,7 +461,7 @@ impl<'a> RevokeMigrationV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -615,12 +615,12 @@ impl<'a> RevokeMigrationV1Cpi<'a> {
 }
 
 /// `revoke_migration_v1` CPI instruction builder.
-pub struct RevokeMigrationV1CpiBuilder<'a> {
-    instruction: Box<RevokeMigrationV1CpiBuilderInstruction<'a>>,
+pub struct RevokeMigrationV1CpiBuilder<'a, 'b> {
+    instruction: Box<RevokeMigrationV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeMigrationV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeMigrationV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeMigrationV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -646,7 +646,7 @@ impl<'a> RevokeMigrationV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -655,7 +655,7 @@ impl<'a> RevokeMigrationV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -664,7 +664,7 @@ impl<'a> RevokeMigrationV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -674,7 +674,7 @@ impl<'a> RevokeMigrationV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -684,20 +684,20 @@ impl<'a> RevokeMigrationV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     /// Token account of mint
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -705,14 +705,14 @@ impl<'a> RevokeMigrationV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -720,7 +720,7 @@ impl<'a> RevokeMigrationV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -729,7 +729,7 @@ impl<'a> RevokeMigrationV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -739,7 +739,7 @@ impl<'a> RevokeMigrationV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -749,7 +749,7 @@ impl<'a> RevokeMigrationV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -759,7 +759,7 @@ impl<'a> RevokeMigrationV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -767,7 +767,7 @@ impl<'a> RevokeMigrationV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -775,7 +775,7 @@ impl<'a> RevokeMigrationV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -836,21 +836,21 @@ impl<'a> RevokeMigrationV1CpiBuilder<'a> {
     }
 }
 
-struct RevokeMigrationV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeMigrationV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/revoke_programmable_config_item_v1.rs
+++ b/clients/rust/src/generated/instructions/revoke_programmable_config_item_v1.rs
@@ -356,75 +356,75 @@ impl RevokeProgrammableConfigItemV1Builder {
 }
 
 /// `revoke_programmable_config_item_v1` CPI accounts.
-pub struct RevokeProgrammableConfigItemV1CpiAccounts<'a> {
+pub struct RevokeProgrammableConfigItemV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `revoke_programmable_config_item_v1` CPI instruction.
-pub struct RevokeProgrammableConfigItemV1Cpi<'a> {
+pub struct RevokeProgrammableConfigItemV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> RevokeProgrammableConfigItemV1Cpi<'a> {
+impl<'a, 'b> RevokeProgrammableConfigItemV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeProgrammableConfigItemV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeProgrammableConfigItemV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -451,7 +451,7 @@ impl<'a> RevokeProgrammableConfigItemV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -467,7 +467,7 @@ impl<'a> RevokeProgrammableConfigItemV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -629,12 +629,12 @@ impl<'a> RevokeProgrammableConfigItemV1Cpi<'a> {
 }
 
 /// `revoke_programmable_config_item_v1` CPI instruction builder.
-pub struct RevokeProgrammableConfigItemV1CpiBuilder<'a> {
-    instruction: Box<RevokeProgrammableConfigItemV1CpiBuilderInstruction<'a>>,
+pub struct RevokeProgrammableConfigItemV1CpiBuilder<'a, 'b> {
+    instruction: Box<RevokeProgrammableConfigItemV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeProgrammableConfigItemV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeProgrammableConfigItemV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeProgrammableConfigItemV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -660,7 +660,7 @@ impl<'a> RevokeProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -669,7 +669,7 @@ impl<'a> RevokeProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -678,7 +678,7 @@ impl<'a> RevokeProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -688,7 +688,7 @@ impl<'a> RevokeProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -698,14 +698,14 @@ impl<'a> RevokeProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -714,7 +714,7 @@ impl<'a> RevokeProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
@@ -723,14 +723,14 @@ impl<'a> RevokeProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -738,7 +738,7 @@ impl<'a> RevokeProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -747,7 +747,7 @@ impl<'a> RevokeProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -757,7 +757,7 @@ impl<'a> RevokeProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -767,7 +767,7 @@ impl<'a> RevokeProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -777,7 +777,7 @@ impl<'a> RevokeProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -785,7 +785,7 @@ impl<'a> RevokeProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -793,7 +793,7 @@ impl<'a> RevokeProgrammableConfigItemV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -854,21 +854,21 @@ impl<'a> RevokeProgrammableConfigItemV1CpiBuilder<'a> {
     }
 }
 
-struct RevokeProgrammableConfigItemV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeProgrammableConfigItemV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/revoke_programmable_config_v1.rs
+++ b/clients/rust/src/generated/instructions/revoke_programmable_config_v1.rs
@@ -356,75 +356,75 @@ impl RevokeProgrammableConfigV1Builder {
 }
 
 /// `revoke_programmable_config_v1` CPI accounts.
-pub struct RevokeProgrammableConfigV1CpiAccounts<'a> {
+pub struct RevokeProgrammableConfigV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `revoke_programmable_config_v1` CPI instruction.
-pub struct RevokeProgrammableConfigV1Cpi<'a> {
+pub struct RevokeProgrammableConfigV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> RevokeProgrammableConfigV1Cpi<'a> {
+impl<'a, 'b> RevokeProgrammableConfigV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeProgrammableConfigV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeProgrammableConfigV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -451,7 +451,7 @@ impl<'a> RevokeProgrammableConfigV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -467,7 +467,7 @@ impl<'a> RevokeProgrammableConfigV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -629,12 +629,12 @@ impl<'a> RevokeProgrammableConfigV1Cpi<'a> {
 }
 
 /// `revoke_programmable_config_v1` CPI instruction builder.
-pub struct RevokeProgrammableConfigV1CpiBuilder<'a> {
-    instruction: Box<RevokeProgrammableConfigV1CpiBuilderInstruction<'a>>,
+pub struct RevokeProgrammableConfigV1CpiBuilder<'a, 'b> {
+    instruction: Box<RevokeProgrammableConfigV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeProgrammableConfigV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeProgrammableConfigV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeProgrammableConfigV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -660,7 +660,7 @@ impl<'a> RevokeProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -669,7 +669,7 @@ impl<'a> RevokeProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -678,7 +678,7 @@ impl<'a> RevokeProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -688,7 +688,7 @@ impl<'a> RevokeProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -698,14 +698,14 @@ impl<'a> RevokeProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -714,7 +714,7 @@ impl<'a> RevokeProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
@@ -723,14 +723,14 @@ impl<'a> RevokeProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -738,7 +738,7 @@ impl<'a> RevokeProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -747,7 +747,7 @@ impl<'a> RevokeProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -757,7 +757,7 @@ impl<'a> RevokeProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -767,7 +767,7 @@ impl<'a> RevokeProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -777,7 +777,7 @@ impl<'a> RevokeProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -785,7 +785,7 @@ impl<'a> RevokeProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -793,7 +793,7 @@ impl<'a> RevokeProgrammableConfigV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -854,21 +854,21 @@ impl<'a> RevokeProgrammableConfigV1CpiBuilder<'a> {
     }
 }
 
-struct RevokeProgrammableConfigV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeProgrammableConfigV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/revoke_sale_v1.rs
+++ b/clients/rust/src/generated/instructions/revoke_sale_v1.rs
@@ -348,75 +348,75 @@ impl RevokeSaleV1Builder {
 }
 
 /// `revoke_sale_v1` CPI accounts.
-pub struct RevokeSaleV1CpiAccounts<'a> {
+pub struct RevokeSaleV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `revoke_sale_v1` CPI instruction.
-pub struct RevokeSaleV1Cpi<'a> {
+pub struct RevokeSaleV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> RevokeSaleV1Cpi<'a> {
+impl<'a, 'b> RevokeSaleV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeSaleV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeSaleV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -443,7 +443,7 @@ impl<'a> RevokeSaleV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -459,7 +459,7 @@ impl<'a> RevokeSaleV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -611,12 +611,12 @@ impl<'a> RevokeSaleV1Cpi<'a> {
 }
 
 /// `revoke_sale_v1` CPI instruction builder.
-pub struct RevokeSaleV1CpiBuilder<'a> {
-    instruction: Box<RevokeSaleV1CpiBuilderInstruction<'a>>,
+pub struct RevokeSaleV1CpiBuilder<'a, 'b> {
+    instruction: Box<RevokeSaleV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeSaleV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeSaleV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeSaleV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -642,7 +642,7 @@ impl<'a> RevokeSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -651,7 +651,7 @@ impl<'a> RevokeSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -660,7 +660,7 @@ impl<'a> RevokeSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -670,7 +670,7 @@ impl<'a> RevokeSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -680,20 +680,20 @@ impl<'a> RevokeSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     /// Token account of mint
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -701,14 +701,14 @@ impl<'a> RevokeSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -716,7 +716,7 @@ impl<'a> RevokeSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -725,7 +725,7 @@ impl<'a> RevokeSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -735,7 +735,7 @@ impl<'a> RevokeSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -745,7 +745,7 @@ impl<'a> RevokeSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -755,7 +755,7 @@ impl<'a> RevokeSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -763,7 +763,7 @@ impl<'a> RevokeSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -771,7 +771,7 @@ impl<'a> RevokeSaleV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -832,21 +832,21 @@ impl<'a> RevokeSaleV1CpiBuilder<'a> {
     }
 }
 
-struct RevokeSaleV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeSaleV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/revoke_staking_v1.rs
+++ b/clients/rust/src/generated/instructions/revoke_staking_v1.rs
@@ -348,75 +348,75 @@ impl RevokeStakingV1Builder {
 }
 
 /// `revoke_staking_v1` CPI accounts.
-pub struct RevokeStakingV1CpiAccounts<'a> {
+pub struct RevokeStakingV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `revoke_staking_v1` CPI instruction.
-pub struct RevokeStakingV1Cpi<'a> {
+pub struct RevokeStakingV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> RevokeStakingV1Cpi<'a> {
+impl<'a, 'b> RevokeStakingV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeStakingV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeStakingV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -443,7 +443,7 @@ impl<'a> RevokeStakingV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -459,7 +459,7 @@ impl<'a> RevokeStakingV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -611,12 +611,12 @@ impl<'a> RevokeStakingV1Cpi<'a> {
 }
 
 /// `revoke_staking_v1` CPI instruction builder.
-pub struct RevokeStakingV1CpiBuilder<'a> {
-    instruction: Box<RevokeStakingV1CpiBuilderInstruction<'a>>,
+pub struct RevokeStakingV1CpiBuilder<'a, 'b> {
+    instruction: Box<RevokeStakingV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeStakingV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeStakingV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeStakingV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -642,7 +642,7 @@ impl<'a> RevokeStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -651,7 +651,7 @@ impl<'a> RevokeStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -660,7 +660,7 @@ impl<'a> RevokeStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -670,7 +670,7 @@ impl<'a> RevokeStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -680,20 +680,20 @@ impl<'a> RevokeStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     /// Token account of mint
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -701,14 +701,14 @@ impl<'a> RevokeStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -716,7 +716,7 @@ impl<'a> RevokeStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -725,7 +725,7 @@ impl<'a> RevokeStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -735,7 +735,7 @@ impl<'a> RevokeStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -745,7 +745,7 @@ impl<'a> RevokeStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -755,7 +755,7 @@ impl<'a> RevokeStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -763,7 +763,7 @@ impl<'a> RevokeStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -771,7 +771,7 @@ impl<'a> RevokeStakingV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -832,21 +832,21 @@ impl<'a> RevokeStakingV1CpiBuilder<'a> {
     }
 }
 
-struct RevokeStakingV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeStakingV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/revoke_standard_v1.rs
+++ b/clients/rust/src/generated/instructions/revoke_standard_v1.rs
@@ -348,75 +348,75 @@ impl RevokeStandardV1Builder {
 }
 
 /// `revoke_standard_v1` CPI accounts.
-pub struct RevokeStandardV1CpiAccounts<'a> {
+pub struct RevokeStandardV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `revoke_standard_v1` CPI instruction.
-pub struct RevokeStandardV1Cpi<'a> {
+pub struct RevokeStandardV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> RevokeStandardV1Cpi<'a> {
+impl<'a, 'b> RevokeStandardV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeStandardV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeStandardV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -443,7 +443,7 @@ impl<'a> RevokeStandardV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -459,7 +459,7 @@ impl<'a> RevokeStandardV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -611,12 +611,12 @@ impl<'a> RevokeStandardV1Cpi<'a> {
 }
 
 /// `revoke_standard_v1` CPI instruction builder.
-pub struct RevokeStandardV1CpiBuilder<'a> {
-    instruction: Box<RevokeStandardV1CpiBuilderInstruction<'a>>,
+pub struct RevokeStandardV1CpiBuilder<'a, 'b> {
+    instruction: Box<RevokeStandardV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeStandardV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeStandardV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeStandardV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -642,7 +642,7 @@ impl<'a> RevokeStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -651,7 +651,7 @@ impl<'a> RevokeStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -660,7 +660,7 @@ impl<'a> RevokeStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -670,7 +670,7 @@ impl<'a> RevokeStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -680,20 +680,20 @@ impl<'a> RevokeStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     /// Token account of mint
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -701,14 +701,14 @@ impl<'a> RevokeStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -716,7 +716,7 @@ impl<'a> RevokeStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -725,7 +725,7 @@ impl<'a> RevokeStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -735,7 +735,7 @@ impl<'a> RevokeStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -745,7 +745,7 @@ impl<'a> RevokeStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -755,7 +755,7 @@ impl<'a> RevokeStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -763,7 +763,7 @@ impl<'a> RevokeStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -771,7 +771,7 @@ impl<'a> RevokeStandardV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -832,21 +832,21 @@ impl<'a> RevokeStandardV1CpiBuilder<'a> {
     }
 }
 
-struct RevokeStandardV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeStandardV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/revoke_transfer_v1.rs
+++ b/clients/rust/src/generated/instructions/revoke_transfer_v1.rs
@@ -348,75 +348,75 @@ impl RevokeTransferV1Builder {
 }
 
 /// `revoke_transfer_v1` CPI accounts.
-pub struct RevokeTransferV1CpiAccounts<'a> {
+pub struct RevokeTransferV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `revoke_transfer_v1` CPI instruction.
-pub struct RevokeTransferV1Cpi<'a> {
+pub struct RevokeTransferV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> RevokeTransferV1Cpi<'a> {
+impl<'a, 'b> RevokeTransferV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeTransferV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeTransferV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -443,7 +443,7 @@ impl<'a> RevokeTransferV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -459,7 +459,7 @@ impl<'a> RevokeTransferV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -611,12 +611,12 @@ impl<'a> RevokeTransferV1Cpi<'a> {
 }
 
 /// `revoke_transfer_v1` CPI instruction builder.
-pub struct RevokeTransferV1CpiBuilder<'a> {
-    instruction: Box<RevokeTransferV1CpiBuilderInstruction<'a>>,
+pub struct RevokeTransferV1CpiBuilder<'a, 'b> {
+    instruction: Box<RevokeTransferV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeTransferV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeTransferV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeTransferV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -642,7 +642,7 @@ impl<'a> RevokeTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -651,7 +651,7 @@ impl<'a> RevokeTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -660,7 +660,7 @@ impl<'a> RevokeTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -670,7 +670,7 @@ impl<'a> RevokeTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -680,20 +680,20 @@ impl<'a> RevokeTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     /// Token account of mint
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -701,14 +701,14 @@ impl<'a> RevokeTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -716,7 +716,7 @@ impl<'a> RevokeTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -725,7 +725,7 @@ impl<'a> RevokeTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -735,7 +735,7 @@ impl<'a> RevokeTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -745,7 +745,7 @@ impl<'a> RevokeTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -755,7 +755,7 @@ impl<'a> RevokeTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -763,7 +763,7 @@ impl<'a> RevokeTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -771,7 +771,7 @@ impl<'a> RevokeTransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -832,21 +832,21 @@ impl<'a> RevokeTransferV1CpiBuilder<'a> {
     }
 }
 
-struct RevokeTransferV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeTransferV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/revoke_use_authority.rs
+++ b/clients/rust/src/generated/instructions/revoke_use_authority.rs
@@ -219,55 +219,55 @@ impl RevokeUseAuthorityBuilder {
 }
 
 /// `revoke_use_authority` CPI accounts.
-pub struct RevokeUseAuthorityCpiAccounts<'a> {
+pub struct RevokeUseAuthorityCpiAccounts<'a, 'b> {
     /// Use Authority Record PDA
-    pub use_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub use_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// A Use Authority
-    pub user: &'a solana_program::account_info::AccountInfo<'a>,
+    pub user: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owned Token Account Of Mint
-    pub owner_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `revoke_use_authority` CPI instruction.
-pub struct RevokeUseAuthorityCpi<'a> {
+pub struct RevokeUseAuthorityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Use Authority Record PDA
-    pub use_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub use_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// A Use Authority
-    pub user: &'a solana_program::account_info::AccountInfo<'a>,
+    pub user: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owned Token Account Of Mint
-    pub owner_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> RevokeUseAuthorityCpi<'a> {
+impl<'a, 'b> RevokeUseAuthorityCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeUseAuthorityCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeUseAuthorityCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -289,7 +289,7 @@ impl<'a> RevokeUseAuthorityCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -305,7 +305,7 @@ impl<'a> RevokeUseAuthorityCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -383,12 +383,12 @@ impl<'a> RevokeUseAuthorityCpi<'a> {
 }
 
 /// `revoke_use_authority` CPI instruction builder.
-pub struct RevokeUseAuthorityCpiBuilder<'a> {
-    instruction: Box<RevokeUseAuthorityCpiBuilderInstruction<'a>>,
+pub struct RevokeUseAuthorityCpiBuilder<'a, 'b> {
+    instruction: Box<RevokeUseAuthorityCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeUseAuthorityCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeUseAuthorityCpiBuilderInstruction {
             __program: program,
             use_authority_record: None,
@@ -408,20 +408,20 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn use_authority_record(
         &mut self,
-        use_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+        use_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.use_authority_record = Some(use_authority_record);
         self
     }
     /// Owner
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
     /// A Use Authority
     #[inline(always)]
-    pub fn user(&mut self, user: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn user(&mut self, user: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.user = Some(user);
         self
     }
@@ -429,14 +429,14 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn owner_token_account(
         &mut self,
-        owner_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        owner_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.owner_token_account = Some(owner_token_account);
         self
     }
     /// Mint of Metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -444,7 +444,7 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -453,7 +453,7 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -462,7 +462,7 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -472,7 +472,7 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn rent(
         &mut self,
-        rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.rent = rent;
         self
@@ -480,7 +480,7 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -488,7 +488,7 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -545,16 +545,16 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     }
 }
 
-struct RevokeUseAuthorityCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    use_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    user: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner_token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeUseAuthorityCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    user: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/revoke_utility_v1.rs
+++ b/clients/rust/src/generated/instructions/revoke_utility_v1.rs
@@ -348,75 +348,75 @@ impl RevokeUtilityV1Builder {
 }
 
 /// `revoke_utility_v1` CPI accounts.
-pub struct RevokeUtilityV1CpiAccounts<'a> {
+pub struct RevokeUtilityV1CpiAccounts<'a, 'b> {
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `revoke_utility_v1` CPI instruction.
-pub struct RevokeUtilityV1Cpi<'a> {
+pub struct RevokeUtilityV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record account
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or token owner
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> RevokeUtilityV1Cpi<'a> {
+impl<'a, 'b> RevokeUtilityV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeUtilityV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeUtilityV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -443,7 +443,7 @@ impl<'a> RevokeUtilityV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -459,7 +459,7 @@ impl<'a> RevokeUtilityV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         if let Some(delegate_record) = self.delegate_record {
@@ -611,12 +611,12 @@ impl<'a> RevokeUtilityV1Cpi<'a> {
 }
 
 /// `revoke_utility_v1` CPI instruction builder.
-pub struct RevokeUtilityV1CpiBuilder<'a> {
-    instruction: Box<RevokeUtilityV1CpiBuilderInstruction<'a>>,
+pub struct RevokeUtilityV1CpiBuilder<'a, 'b> {
+    instruction: Box<RevokeUtilityV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeUtilityV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeUtilityV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeUtilityV1CpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -642,7 +642,7 @@ impl<'a> RevokeUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -651,7 +651,7 @@ impl<'a> RevokeUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -660,7 +660,7 @@ impl<'a> RevokeUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -670,7 +670,7 @@ impl<'a> RevokeUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -680,20 +680,20 @@ impl<'a> RevokeUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     /// Token account of mint
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -701,14 +701,14 @@ impl<'a> RevokeUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -716,7 +716,7 @@ impl<'a> RevokeUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -725,7 +725,7 @@ impl<'a> RevokeUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -735,7 +735,7 @@ impl<'a> RevokeUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -745,7 +745,7 @@ impl<'a> RevokeUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -755,7 +755,7 @@ impl<'a> RevokeUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -763,7 +763,7 @@ impl<'a> RevokeUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -771,7 +771,7 @@ impl<'a> RevokeUtilityV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -832,21 +832,21 @@ impl<'a> RevokeUtilityV1CpiBuilder<'a> {
     }
 }
 
-struct RevokeUtilityV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeUtilityV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/set_and_verify_collection.rs
+++ b/clients/rust/src/generated/instructions/set_and_verify_collection.rs
@@ -211,51 +211,51 @@ impl SetAndVerifyCollectionBuilder {
 }
 
 /// `set_and_verify_collection` CPI accounts.
-pub struct SetAndVerifyCollectionCpiAccounts<'a> {
+pub struct SetAndVerifyCollectionCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update Authority of Collection NFT and NFT
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `set_and_verify_collection` CPI instruction.
-pub struct SetAndVerifyCollectionCpi<'a> {
+pub struct SetAndVerifyCollectionCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update Authority of Collection NFT and NFT
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> SetAndVerifyCollectionCpi<'a> {
+impl<'a, 'b> SetAndVerifyCollectionCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: SetAndVerifyCollectionCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: SetAndVerifyCollectionCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -276,7 +276,7 @@ impl<'a> SetAndVerifyCollectionCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -292,7 +292,7 @@ impl<'a> SetAndVerifyCollectionCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -366,12 +366,12 @@ impl<'a> SetAndVerifyCollectionCpi<'a> {
 }
 
 /// `set_and_verify_collection` CPI instruction builder.
-pub struct SetAndVerifyCollectionCpiBuilder<'a> {
-    instruction: Box<SetAndVerifyCollectionCpiBuilderInstruction<'a>>,
+pub struct SetAndVerifyCollectionCpiBuilder<'a, 'b> {
+    instruction: Box<SetAndVerifyCollectionCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> SetAndVerifyCollectionCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetAndVerifyCollectionCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -390,7 +390,7 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -399,14 +399,14 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority(
         &mut self,
-        collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority = Some(collection_authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -414,7 +414,7 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -423,7 +423,7 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -432,7 +432,7 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection(
         &mut self,
-        collection: &'a solana_program::account_info::AccountInfo<'a>,
+        collection: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection = Some(collection);
         self
@@ -441,7 +441,7 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_master_edition_account(
         &mut self,
-        collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_master_edition_account =
             Some(collection_master_edition_account);
@@ -452,7 +452,7 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = collection_authority_record;
         self
@@ -460,7 +460,7 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -468,7 +468,7 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -523,15 +523,15 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     }
 }
 
-struct SetAndVerifyCollectionCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_master_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct SetAndVerifyCollectionCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_master_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
+++ b/clients/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
@@ -211,51 +211,51 @@ impl SetAndVerifySizedCollectionItemBuilder {
 }
 
 /// `set_and_verify_sized_collection_item` CPI accounts.
-pub struct SetAndVerifySizedCollectionItemCpiAccounts<'a> {
+pub struct SetAndVerifySizedCollectionItemCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update Authority of Collection NFT and NFT
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `set_and_verify_sized_collection_item` CPI instruction.
-pub struct SetAndVerifySizedCollectionItemCpi<'a> {
+pub struct SetAndVerifySizedCollectionItemCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update Authority of Collection NFT and NFT
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> SetAndVerifySizedCollectionItemCpi<'a> {
+impl<'a, 'b> SetAndVerifySizedCollectionItemCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: SetAndVerifySizedCollectionItemCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: SetAndVerifySizedCollectionItemCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -276,7 +276,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -292,7 +292,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -366,12 +366,12 @@ impl<'a> SetAndVerifySizedCollectionItemCpi<'a> {
 }
 
 /// `set_and_verify_sized_collection_item` CPI instruction builder.
-pub struct SetAndVerifySizedCollectionItemCpiBuilder<'a> {
-    instruction: Box<SetAndVerifySizedCollectionItemCpiBuilderInstruction<'a>>,
+pub struct SetAndVerifySizedCollectionItemCpiBuilder<'a, 'b> {
+    instruction: Box<SetAndVerifySizedCollectionItemCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> SetAndVerifySizedCollectionItemCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetAndVerifySizedCollectionItemCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -390,7 +390,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -399,14 +399,14 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority(
         &mut self,
-        collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority = Some(collection_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -414,7 +414,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -423,7 +423,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -432,7 +432,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection(
         &mut self,
-        collection: &'a solana_program::account_info::AccountInfo<'a>,
+        collection: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection = Some(collection);
         self
@@ -441,7 +441,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_master_edition_account(
         &mut self,
-        collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_master_edition_account =
             Some(collection_master_edition_account);
@@ -452,7 +452,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = collection_authority_record;
         self
@@ -460,7 +460,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -468,7 +468,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -523,15 +523,15 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     }
 }
 
-struct SetAndVerifySizedCollectionItemCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_master_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct SetAndVerifySizedCollectionItemCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_master_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/set_collection_size.rs
+++ b/clients/rust/src/generated/instructions/set_collection_size.rs
@@ -181,37 +181,37 @@ impl SetCollectionSizeBuilder {
 }
 
 /// `set_collection_size` CPI accounts.
-pub struct SetCollectionSizeCpiAccounts<'a> {
+pub struct SetCollectionSizeCpiAccounts<'a, 'b> {
     /// Collection Metadata account
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `set_collection_size` CPI instruction.
-pub struct SetCollectionSizeCpi<'a> {
+pub struct SetCollectionSizeCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Metadata account
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: SetCollectionSizeInstructionArgs,
 }
 
-impl<'a> SetCollectionSizeCpi<'a> {
+impl<'a, 'b> SetCollectionSizeCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: SetCollectionSizeCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: SetCollectionSizeCpiAccounts<'a, 'b>,
         args: SetCollectionSizeInstructionArgs,
     ) -> Self {
         Self {
@@ -230,7 +230,7 @@ impl<'a> SetCollectionSizeCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -246,7 +246,7 @@ impl<'a> SetCollectionSizeCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -302,12 +302,12 @@ impl<'a> SetCollectionSizeCpi<'a> {
 }
 
 /// `set_collection_size` CPI instruction builder.
-pub struct SetCollectionSizeCpiBuilder<'a> {
-    instruction: Box<SetCollectionSizeCpiBuilderInstruction<'a>>,
+pub struct SetCollectionSizeCpiBuilder<'a, 'b> {
+    instruction: Box<SetCollectionSizeCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> SetCollectionSizeCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> SetCollectionSizeCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetCollectionSizeCpiBuilderInstruction {
             __program: program,
             collection_metadata: None,
@@ -323,7 +323,7 @@ impl<'a> SetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_metadata(
         &mut self,
-        collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_metadata = Some(collection_metadata);
         self
@@ -332,7 +332,7 @@ impl<'a> SetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority(
         &mut self,
-        collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority = Some(collection_authority);
         self
@@ -341,7 +341,7 @@ impl<'a> SetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -351,7 +351,7 @@ impl<'a> SetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = collection_authority_record;
         self
@@ -367,7 +367,7 @@ impl<'a> SetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -375,7 +375,7 @@ impl<'a> SetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -427,12 +427,12 @@ impl<'a> SetCollectionSizeCpiBuilder<'a> {
     }
 }
 
-struct SetCollectionSizeCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct SetCollectionSizeCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     set_collection_size_args: Option<SetCollectionSizeArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/set_token_standard.rs
+++ b/clients/rust/src/generated/instructions/set_token_standard.rs
@@ -136,35 +136,35 @@ impl SetTokenStandardBuilder {
 }
 
 /// `set_token_standard` CPI accounts.
-pub struct SetTokenStandardCpiAccounts<'a> {
+pub struct SetTokenStandardCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata update authority
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `set_token_standard` CPI instruction.
-pub struct SetTokenStandardCpi<'a> {
+pub struct SetTokenStandardCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata update authority
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> SetTokenStandardCpi<'a> {
+impl<'a, 'b> SetTokenStandardCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: SetTokenStandardCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: SetTokenStandardCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -181,7 +181,7 @@ impl<'a> SetTokenStandardCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -197,7 +197,7 @@ impl<'a> SetTokenStandardCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -249,12 +249,12 @@ impl<'a> SetTokenStandardCpi<'a> {
 }
 
 /// `set_token_standard` CPI instruction builder.
-pub struct SetTokenStandardCpiBuilder<'a> {
-    instruction: Box<SetTokenStandardCpiBuilderInstruction<'a>>,
+pub struct SetTokenStandardCpiBuilder<'a, 'b> {
+    instruction: Box<SetTokenStandardCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> SetTokenStandardCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> SetTokenStandardCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetTokenStandardCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -269,7 +269,7 @@ impl<'a> SetTokenStandardCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -278,14 +278,14 @@ impl<'a> SetTokenStandardCpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -294,7 +294,7 @@ impl<'a> SetTokenStandardCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition = edition;
         self
@@ -302,7 +302,7 @@ impl<'a> SetTokenStandardCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -310,7 +310,7 @@ impl<'a> SetTokenStandardCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -348,11 +348,11 @@ impl<'a> SetTokenStandardCpiBuilder<'a> {
     }
 }
 
-struct SetTokenStandardCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct SetTokenStandardCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/sign_metadata.rs
+++ b/clients/rust/src/generated/instructions/sign_metadata.rs
@@ -104,27 +104,27 @@ impl SignMetadataBuilder {
 }
 
 /// `sign_metadata` CPI accounts.
-pub struct SignMetadataCpiAccounts<'a> {
+pub struct SignMetadataCpiAccounts<'a, 'b> {
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Creator
-    pub creator: &'a solana_program::account_info::AccountInfo<'a>,
+    pub creator: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `sign_metadata` CPI instruction.
-pub struct SignMetadataCpi<'a> {
+pub struct SignMetadataCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Creator
-    pub creator: &'a solana_program::account_info::AccountInfo<'a>,
+    pub creator: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> SignMetadataCpi<'a> {
+impl<'a, 'b> SignMetadataCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: SignMetadataCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: SignMetadataCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -139,7 +139,7 @@ impl<'a> SignMetadataCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -155,7 +155,7 @@ impl<'a> SignMetadataCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -193,12 +193,12 @@ impl<'a> SignMetadataCpi<'a> {
 }
 
 /// `sign_metadata` CPI instruction builder.
-pub struct SignMetadataCpiBuilder<'a> {
-    instruction: Box<SignMetadataCpiBuilderInstruction<'a>>,
+pub struct SignMetadataCpiBuilder<'a, 'b> {
+    instruction: Box<SignMetadataCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> SignMetadataCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> SignMetadataCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SignMetadataCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -211,7 +211,7 @@ impl<'a> SignMetadataCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -220,7 +220,7 @@ impl<'a> SignMetadataCpiBuilder<'a> {
     #[inline(always)]
     pub fn creator(
         &mut self,
-        creator: &'a solana_program::account_info::AccountInfo<'a>,
+        creator: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.creator = Some(creator);
         self
@@ -228,7 +228,7 @@ impl<'a> SignMetadataCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -236,7 +236,7 @@ impl<'a> SignMetadataCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -267,9 +267,9 @@ impl<'a> SignMetadataCpiBuilder<'a> {
     }
 }
 
-struct SignMetadataCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    creator: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct SignMetadataCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    creator: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/thaw_delegated_account.rs
+++ b/clients/rust/src/generated/instructions/thaw_delegated_account.rs
@@ -150,39 +150,39 @@ impl ThawDelegatedAccountBuilder {
 }
 
 /// `thaw_delegated_account` CPI accounts.
-pub struct ThawDelegatedAccountCpiAccounts<'a> {
+pub struct ThawDelegatedAccountCpiAccounts<'a, 'b> {
     /// Delegate
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account to thaw
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token mint
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `thaw_delegated_account` CPI instruction.
-pub struct ThawDelegatedAccountCpi<'a> {
+pub struct ThawDelegatedAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account to thaw
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token mint
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> ThawDelegatedAccountCpi<'a> {
+impl<'a, 'b> ThawDelegatedAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: ThawDelegatedAccountCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: ThawDelegatedAccountCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -200,7 +200,7 @@ impl<'a> ThawDelegatedAccountCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -216,7 +216,7 @@ impl<'a> ThawDelegatedAccountCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -271,12 +271,12 @@ impl<'a> ThawDelegatedAccountCpi<'a> {
 }
 
 /// `thaw_delegated_account` CPI instruction builder.
-pub struct ThawDelegatedAccountCpiBuilder<'a> {
-    instruction: Box<ThawDelegatedAccountCpiBuilderInstruction<'a>>,
+pub struct ThawDelegatedAccountCpiBuilder<'a, 'b> {
+    instruction: Box<ThawDelegatedAccountCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> ThawDelegatedAccountCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> ThawDelegatedAccountCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(ThawDelegatedAccountCpiBuilderInstruction {
             __program: program,
             delegate: None,
@@ -292,7 +292,7 @@ impl<'a> ThawDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -301,7 +301,7 @@ impl<'a> ThawDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account(
         &mut self,
-        token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account = Some(token_account);
         self
@@ -310,14 +310,14 @@ impl<'a> ThawDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: &'a solana_program::account_info::AccountInfo<'a>,
+        edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition = Some(edition);
         self
     }
     /// Token mint
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -325,7 +325,7 @@ impl<'a> ThawDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -333,7 +333,7 @@ impl<'a> ThawDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -341,7 +341,7 @@ impl<'a> ThawDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -384,12 +384,12 @@ impl<'a> ThawDelegatedAccountCpiBuilder<'a> {
     }
 }
 
-struct ThawDelegatedAccountCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct ThawDelegatedAccountCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/transfer_out_of_escrow.rs
+++ b/clients/rust/src/generated/instructions/transfer_out_of_escrow.rs
@@ -298,73 +298,73 @@ impl TransferOutOfEscrowBuilder {
 }
 
 /// `transfer_out_of_escrow` CPI accounts.
-pub struct TransferOutOfEscrowCpiAccounts<'a> {
+pub struct TransferOutOfEscrowCpiAccounts<'a, 'b> {
     /// Escrow account
-    pub escrow: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Wallet paying for the transaction and new account
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account for the new attribute
-    pub attribute_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub attribute_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account source for the new attribute
-    pub attribute_src: &'a solana_program::account_info::AccountInfo<'a>,
+    pub attribute_src: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account, owned by TM, destination for the new attribute
-    pub attribute_dst: &'a solana_program::account_info::AccountInfo<'a>,
+    pub attribute_dst: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account that the escrow is attached
-    pub escrow_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account that holds the token the escrow is attached to
-    pub escrow_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Associated Token program
-    pub ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Authority/creator of the escrow account
-    pub authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `transfer_out_of_escrow` CPI instruction.
-pub struct TransferOutOfEscrowCpi<'a> {
+pub struct TransferOutOfEscrowCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Escrow account
-    pub escrow: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Wallet paying for the transaction and new account
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account for the new attribute
-    pub attribute_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub attribute_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account source for the new attribute
-    pub attribute_src: &'a solana_program::account_info::AccountInfo<'a>,
+    pub attribute_src: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account, owned by TM, destination for the new attribute
-    pub attribute_dst: &'a solana_program::account_info::AccountInfo<'a>,
+    pub attribute_dst: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account that the escrow is attached
-    pub escrow_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account that holds the token the escrow is attached to
-    pub escrow_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Associated Token program
-    pub ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Authority/creator of the escrow account
-    pub authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: TransferOutOfEscrowInstructionArgs,
 }
 
-impl<'a> TransferOutOfEscrowCpi<'a> {
+impl<'a, 'b> TransferOutOfEscrowCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: TransferOutOfEscrowCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: TransferOutOfEscrowCpiAccounts<'a, 'b>,
         args: TransferOutOfEscrowInstructionArgs,
     ) -> Self {
         Self {
@@ -392,7 +392,7 @@ impl<'a> TransferOutOfEscrowCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -408,7 +408,7 @@ impl<'a> TransferOutOfEscrowCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(13 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -509,12 +509,12 @@ impl<'a> TransferOutOfEscrowCpi<'a> {
 }
 
 /// `transfer_out_of_escrow` CPI instruction builder.
-pub struct TransferOutOfEscrowCpiBuilder<'a> {
-    instruction: Box<TransferOutOfEscrowCpiBuilderInstruction<'a>>,
+pub struct TransferOutOfEscrowCpiBuilder<'a, 'b> {
+    instruction: Box<TransferOutOfEscrowCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> TransferOutOfEscrowCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(TransferOutOfEscrowCpiBuilderInstruction {
             __program: program,
             escrow: None,
@@ -539,7 +539,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn escrow(
         &mut self,
-        escrow: &'a solana_program::account_info::AccountInfo<'a>,
+        escrow: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.escrow = Some(escrow);
         self
@@ -548,14 +548,14 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Wallet paying for the transaction and new account
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -563,7 +563,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn attribute_mint(
         &mut self,
-        attribute_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        attribute_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.attribute_mint = Some(attribute_mint);
         self
@@ -572,7 +572,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn attribute_src(
         &mut self,
-        attribute_src: &'a solana_program::account_info::AccountInfo<'a>,
+        attribute_src: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.attribute_src = Some(attribute_src);
         self
@@ -581,7 +581,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn attribute_dst(
         &mut self,
-        attribute_dst: &'a solana_program::account_info::AccountInfo<'a>,
+        attribute_dst: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.attribute_dst = Some(attribute_dst);
         self
@@ -590,7 +590,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn escrow_mint(
         &mut self,
-        escrow_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        escrow_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.escrow_mint = Some(escrow_mint);
         self
@@ -599,7 +599,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn escrow_account(
         &mut self,
-        escrow_account: &'a solana_program::account_info::AccountInfo<'a>,
+        escrow_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.escrow_account = Some(escrow_account);
         self
@@ -608,7 +608,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -617,7 +617,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn ata_program(
         &mut self,
-        ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+        ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.ata_program = Some(ata_program);
         self
@@ -626,7 +626,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -635,7 +635,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -645,7 +645,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authority = authority;
         self
@@ -659,7 +659,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -667,7 +667,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -751,21 +751,21 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     }
 }
 
-struct TransferOutOfEscrowCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    escrow: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    attribute_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    attribute_src: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    attribute_dst: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    escrow_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    escrow_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    ata_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct TransferOutOfEscrowCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    escrow: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    attribute_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    attribute_src: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    attribute_dst: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    escrow_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    escrow_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    ata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     amount: Option<u64>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/transfer_v1.rs
+++ b/clients/rust/src/generated/instructions/transfer_v1.rs
@@ -429,89 +429,89 @@ impl TransferV1Builder {
 }
 
 /// `transfer_v1` CPI accounts.
-pub struct TransferV1CpiAccounts<'a> {
+pub struct TransferV1CpiAccounts<'a, 'b> {
     /// Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account owner
-    pub token_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Destination token account
-    pub destination_token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub destination_token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Destination token account owner
-    pub destination_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub destination_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition of token asset
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Destination token record account
-    pub destination_token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub destination_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Transfer authority (token owner or delegate)
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Associated Token Account program
-    pub spl_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `transfer_v1` CPI instruction.
-pub struct TransferV1Cpi<'a> {
+pub struct TransferV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account owner
-    pub token_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Destination token account
-    pub destination_token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub destination_token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Destination token account owner
-    pub destination_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub destination_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition of token asset
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Owner token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Destination token record account
-    pub destination_token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub destination_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Transfer authority (token owner or delegate)
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Associated Token Account program
-    pub spl_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: TransferV1InstructionArgs,
 }
 
-impl<'a> TransferV1Cpi<'a> {
+impl<'a, 'b> TransferV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: TransferV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: TransferV1CpiAccounts<'a, 'b>,
         args: TransferV1InstructionArgs,
     ) -> Self {
         Self {
@@ -543,7 +543,7 @@ impl<'a> TransferV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -559,7 +559,7 @@ impl<'a> TransferV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(17 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -719,12 +719,12 @@ impl<'a> TransferV1Cpi<'a> {
 }
 
 /// `transfer_v1` CPI instruction builder.
-pub struct TransferV1CpiBuilder<'a> {
-    instruction: Box<TransferV1CpiBuilderInstruction<'a>>,
+pub struct TransferV1CpiBuilder<'a, 'b> {
+    instruction: Box<TransferV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> TransferV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> TransferV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(TransferV1CpiBuilderInstruction {
             __program: program,
             token: None,
@@ -752,7 +752,7 @@ impl<'a> TransferV1CpiBuilder<'a> {
     }
     /// Token account
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -760,7 +760,7 @@ impl<'a> TransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_owner(
         &mut self,
-        token_owner: &'a solana_program::account_info::AccountInfo<'a>,
+        token_owner: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner = Some(token_owner);
         self
@@ -769,7 +769,7 @@ impl<'a> TransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn destination_token(
         &mut self,
-        destination_token: &'a solana_program::account_info::AccountInfo<'a>,
+        destination_token: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.destination_token = Some(destination_token);
         self
@@ -778,14 +778,14 @@ impl<'a> TransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn destination_owner(
         &mut self,
-        destination_owner: &'a solana_program::account_info::AccountInfo<'a>,
+        destination_owner: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.destination_owner = Some(destination_owner);
         self
     }
     /// Mint of token asset
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -793,7 +793,7 @@ impl<'a> TransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -803,7 +803,7 @@ impl<'a> TransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition = edition;
         self
@@ -813,7 +813,7 @@ impl<'a> TransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
@@ -823,7 +823,7 @@ impl<'a> TransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn destination_token_record(
         &mut self,
-        destination_token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        destination_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.destination_token_record = destination_token_record;
         self
@@ -832,14 +832,14 @@ impl<'a> TransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -847,7 +847,7 @@ impl<'a> TransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -856,7 +856,7 @@ impl<'a> TransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -865,7 +865,7 @@ impl<'a> TransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_token_program = Some(spl_token_program);
         self
@@ -874,7 +874,7 @@ impl<'a> TransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_ata_program(
         &mut self,
-        spl_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_ata_program = Some(spl_ata_program);
         self
@@ -884,7 +884,7 @@ impl<'a> TransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -894,7 +894,7 @@ impl<'a> TransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -914,7 +914,7 @@ impl<'a> TransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -922,7 +922,7 @@ impl<'a> TransferV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -1009,26 +1009,26 @@ impl<'a> TransferV1CpiBuilder<'a> {
     }
 }
 
-struct TransferV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    destination_token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    destination_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    destination_token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_ata_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct TransferV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    destination_token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    destination_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    destination_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_ata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     amount: Option<u64>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/unlock_v1.rs
+++ b/clients/rust/src/generated/instructions/unlock_v1.rs
@@ -353,73 +353,73 @@ impl UnlockV1Builder {
 }
 
 /// `unlock_v1` CPI accounts.
-pub struct UnlockV1CpiAccounts<'a> {
+pub struct UnlockV1CpiAccounts<'a, 'b> {
     /// Delegate or freeze authority
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token owner account
-    pub token_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `unlock_v1` CPI instruction.
-pub struct UnlockV1Cpi<'a> {
+pub struct UnlockV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate or freeze authority
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token owner account
-    pub token_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token record account
-    pub token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: UnlockV1InstructionArgs,
 }
 
-impl<'a> UnlockV1Cpi<'a> {
+impl<'a, 'b> UnlockV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UnlockV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UnlockV1CpiAccounts<'a, 'b>,
         args: UnlockV1InstructionArgs,
     ) -> Self {
         Self {
@@ -447,7 +447,7 @@ impl<'a> UnlockV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -463,7 +463,7 @@ impl<'a> UnlockV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(13 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -612,12 +612,12 @@ impl<'a> UnlockV1Cpi<'a> {
 }
 
 /// `unlock_v1` CPI instruction builder.
-pub struct UnlockV1CpiBuilder<'a> {
-    instruction: Box<UnlockV1CpiBuilderInstruction<'a>>,
+pub struct UnlockV1CpiBuilder<'a, 'b> {
+    instruction: Box<UnlockV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UnlockV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UnlockV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UnlockV1CpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -642,7 +642,7 @@ impl<'a> UnlockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -652,20 +652,20 @@ impl<'a> UnlockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_owner(
         &mut self,
-        token_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_owner = token_owner;
         self
     }
     /// Token account
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -673,7 +673,7 @@ impl<'a> UnlockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -683,7 +683,7 @@ impl<'a> UnlockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition = edition;
         self
@@ -693,14 +693,14 @@ impl<'a> UnlockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_record(
         &mut self,
-        token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token_record = token_record;
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -708,7 +708,7 @@ impl<'a> UnlockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -717,7 +717,7 @@ impl<'a> UnlockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -727,7 +727,7 @@ impl<'a> UnlockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -737,7 +737,7 @@ impl<'a> UnlockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -747,7 +747,7 @@ impl<'a> UnlockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -761,7 +761,7 @@ impl<'a> UnlockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -769,7 +769,7 @@ impl<'a> UnlockV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -832,21 +832,21 @@ impl<'a> UnlockV1CpiBuilder<'a> {
     }
 }
 
-struct UnlockV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UnlockV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/unverify_collection.rs
+++ b/clients/rust/src/generated/instructions/unverify_collection.rs
@@ -181,43 +181,43 @@ impl UnverifyCollectionBuilder {
 }
 
 /// `unverify_collection` CPI accounts.
-pub struct UnverifyCollectionCpiAccounts<'a> {
+pub struct UnverifyCollectionCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `unverify_collection` CPI instruction.
-pub struct UnverifyCollectionCpi<'a> {
+pub struct UnverifyCollectionCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> UnverifyCollectionCpi<'a> {
+impl<'a, 'b> UnverifyCollectionCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UnverifyCollectionCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UnverifyCollectionCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -236,7 +236,7 @@ impl<'a> UnverifyCollectionCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -252,7 +252,7 @@ impl<'a> UnverifyCollectionCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -316,12 +316,12 @@ impl<'a> UnverifyCollectionCpi<'a> {
 }
 
 /// `unverify_collection` CPI instruction builder.
-pub struct UnverifyCollectionCpiBuilder<'a> {
-    instruction: Box<UnverifyCollectionCpiBuilderInstruction<'a>>,
+pub struct UnverifyCollectionCpiBuilder<'a, 'b> {
+    instruction: Box<UnverifyCollectionCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UnverifyCollectionCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UnverifyCollectionCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UnverifyCollectionCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -338,7 +338,7 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -347,7 +347,7 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority(
         &mut self,
-        collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority = Some(collection_authority);
         self
@@ -356,7 +356,7 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -365,7 +365,7 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection(
         &mut self,
-        collection: &'a solana_program::account_info::AccountInfo<'a>,
+        collection: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection = Some(collection);
         self
@@ -374,7 +374,7 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_master_edition_account(
         &mut self,
-        collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_master_edition_account =
             Some(collection_master_edition_account);
@@ -385,7 +385,7 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = collection_authority_record;
         self
@@ -393,7 +393,7 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -401,7 +401,7 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -449,13 +449,13 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     }
 }
 
-struct UnverifyCollectionCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_master_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct UnverifyCollectionCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_master_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/unverify_collection_v1.rs
+++ b/clients/rust/src/generated/instructions/unverify_collection_v1.rs
@@ -214,47 +214,47 @@ impl UnverifyCollectionV1Builder {
 }
 
 /// `unverify_collection_v1` CPI accounts.
-pub struct UnverifyCollectionV1CpiAccounts<'a> {
+pub struct UnverifyCollectionV1CpiAccounts<'a, 'b> {
     /// Creator to verify, collection (or metadata if parent burned) update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `unverify_collection_v1` CPI instruction.
-pub struct UnverifyCollectionV1Cpi<'a> {
+pub struct UnverifyCollectionV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Creator to verify, collection (or metadata if parent burned) update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> UnverifyCollectionV1Cpi<'a> {
+impl<'a, 'b> UnverifyCollectionV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UnverifyCollectionV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UnverifyCollectionV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -274,7 +274,7 @@ impl<'a> UnverifyCollectionV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -290,7 +290,7 @@ impl<'a> UnverifyCollectionV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -373,12 +373,12 @@ impl<'a> UnverifyCollectionV1Cpi<'a> {
 }
 
 /// `unverify_collection_v1` CPI instruction builder.
-pub struct UnverifyCollectionV1CpiBuilder<'a> {
-    instruction: Box<UnverifyCollectionV1CpiBuilderInstruction<'a>>,
+pub struct UnverifyCollectionV1CpiBuilder<'a, 'b> {
+    instruction: Box<UnverifyCollectionV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UnverifyCollectionV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UnverifyCollectionV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UnverifyCollectionV1CpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -396,7 +396,7 @@ impl<'a> UnverifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -406,7 +406,7 @@ impl<'a> UnverifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -415,7 +415,7 @@ impl<'a> UnverifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -424,7 +424,7 @@ impl<'a> UnverifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -434,7 +434,7 @@ impl<'a> UnverifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_metadata(
         &mut self,
-        collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_metadata = collection_metadata;
         self
@@ -443,7 +443,7 @@ impl<'a> UnverifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -452,7 +452,7 @@ impl<'a> UnverifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -460,7 +460,7 @@ impl<'a> UnverifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -468,7 +468,7 @@ impl<'a> UnverifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -518,14 +518,14 @@ impl<'a> UnverifyCollectionV1CpiBuilder<'a> {
     }
 }
 
-struct UnverifyCollectionV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct UnverifyCollectionV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/unverify_creator_v1.rs
+++ b/clients/rust/src/generated/instructions/unverify_creator_v1.rs
@@ -222,47 +222,47 @@ impl UnverifyCreatorV1Builder {
 }
 
 /// `unverify_creator_v1` CPI accounts.
-pub struct UnverifyCreatorV1CpiAccounts<'a> {
+pub struct UnverifyCreatorV1CpiAccounts<'a, 'b> {
     /// Creator to verify, collection (or metadata if parent burned) update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata Account of the Collection
-    pub collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `unverify_creator_v1` CPI instruction.
-pub struct UnverifyCreatorV1Cpi<'a> {
+pub struct UnverifyCreatorV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Creator to verify, collection (or metadata if parent burned) update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata Account of the Collection
-    pub collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> UnverifyCreatorV1Cpi<'a> {
+impl<'a, 'b> UnverifyCreatorV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UnverifyCreatorV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UnverifyCreatorV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -282,7 +282,7 @@ impl<'a> UnverifyCreatorV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -298,7 +298,7 @@ impl<'a> UnverifyCreatorV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -390,12 +390,12 @@ impl<'a> UnverifyCreatorV1Cpi<'a> {
 }
 
 /// `unverify_creator_v1` CPI instruction builder.
-pub struct UnverifyCreatorV1CpiBuilder<'a> {
-    instruction: Box<UnverifyCreatorV1CpiBuilderInstruction<'a>>,
+pub struct UnverifyCreatorV1CpiBuilder<'a, 'b> {
+    instruction: Box<UnverifyCreatorV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UnverifyCreatorV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UnverifyCreatorV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UnverifyCreatorV1CpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -413,7 +413,7 @@ impl<'a> UnverifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -423,7 +423,7 @@ impl<'a> UnverifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -432,7 +432,7 @@ impl<'a> UnverifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -442,7 +442,7 @@ impl<'a> UnverifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_mint = collection_mint;
         self
@@ -452,7 +452,7 @@ impl<'a> UnverifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_metadata(
         &mut self,
-        collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_metadata = collection_metadata;
         self
@@ -461,7 +461,7 @@ impl<'a> UnverifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -470,7 +470,7 @@ impl<'a> UnverifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -478,7 +478,7 @@ impl<'a> UnverifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -486,7 +486,7 @@ impl<'a> UnverifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -533,14 +533,14 @@ impl<'a> UnverifyCreatorV1CpiBuilder<'a> {
     }
 }
 
-struct UnverifyCreatorV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct UnverifyCreatorV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/unverify_sized_collection_item.rs
+++ b/clients/rust/src/generated/instructions/unverify_sized_collection_item.rs
@@ -194,47 +194,47 @@ impl UnverifySizedCollectionItemBuilder {
 }
 
 /// `unverify_sized_collection_item` CPI accounts.
-pub struct UnverifySizedCollectionItemCpiAccounts<'a> {
+pub struct UnverifySizedCollectionItemCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `unverify_sized_collection_item` CPI instruction.
-pub struct UnverifySizedCollectionItemCpi<'a> {
+pub struct UnverifySizedCollectionItemCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> UnverifySizedCollectionItemCpi<'a> {
+impl<'a, 'b> UnverifySizedCollectionItemCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UnverifySizedCollectionItemCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UnverifySizedCollectionItemCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -254,7 +254,7 @@ impl<'a> UnverifySizedCollectionItemCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -270,7 +270,7 @@ impl<'a> UnverifySizedCollectionItemCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -339,12 +339,12 @@ impl<'a> UnverifySizedCollectionItemCpi<'a> {
 }
 
 /// `unverify_sized_collection_item` CPI instruction builder.
-pub struct UnverifySizedCollectionItemCpiBuilder<'a> {
-    instruction: Box<UnverifySizedCollectionItemCpiBuilderInstruction<'a>>,
+pub struct UnverifySizedCollectionItemCpiBuilder<'a, 'b> {
+    instruction: Box<UnverifySizedCollectionItemCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UnverifySizedCollectionItemCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UnverifySizedCollectionItemCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -362,7 +362,7 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -371,14 +371,14 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority(
         &mut self,
-        collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority = Some(collection_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -386,7 +386,7 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -395,7 +395,7 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection(
         &mut self,
-        collection: &'a solana_program::account_info::AccountInfo<'a>,
+        collection: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection = Some(collection);
         self
@@ -404,7 +404,7 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_master_edition_account(
         &mut self,
-        collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_master_edition_account =
             Some(collection_master_edition_account);
@@ -415,7 +415,7 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = collection_authority_record;
         self
@@ -423,7 +423,7 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -431,7 +431,7 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -481,14 +481,14 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     }
 }
 
-struct UnverifySizedCollectionItemCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_master_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct UnverifySizedCollectionItemCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_master_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/update_as_authority_item_delegate_v2.rs
+++ b/clients/rust/src/generated/instructions/update_as_authority_item_delegate_v2.rs
@@ -351,65 +351,65 @@ impl UpdateAsAuthorityItemDelegateV2Builder {
 }
 
 /// `update_as_authority_item_delegate_v2` CPI accounts.
-pub struct UpdateAsAuthorityItemDelegateV2CpiAccounts<'a> {
+pub struct UpdateAsAuthorityItemDelegateV2CpiAccounts<'a, 'b> {
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `update_as_authority_item_delegate_v2` CPI instruction.
-pub struct UpdateAsAuthorityItemDelegateV2Cpi<'a> {
+pub struct UpdateAsAuthorityItemDelegateV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: UpdateAsAuthorityItemDelegateV2InstructionArgs,
 }
 
-impl<'a> UpdateAsAuthorityItemDelegateV2Cpi<'a> {
+impl<'a, 'b> UpdateAsAuthorityItemDelegateV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UpdateAsAuthorityItemDelegateV2CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UpdateAsAuthorityItemDelegateV2CpiAccounts<'a, 'b>,
         args: UpdateAsAuthorityItemDelegateV2InstructionArgs,
     ) -> Self {
         Self {
@@ -435,7 +435,7 @@ impl<'a> UpdateAsAuthorityItemDelegateV2Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -451,7 +451,7 @@ impl<'a> UpdateAsAuthorityItemDelegateV2Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -582,12 +582,12 @@ impl<'a> UpdateAsAuthorityItemDelegateV2Cpi<'a> {
 }
 
 /// `update_as_authority_item_delegate_v2` CPI instruction builder.
-pub struct UpdateAsAuthorityItemDelegateV2CpiBuilder<'a> {
-    instruction: Box<UpdateAsAuthorityItemDelegateV2CpiBuilderInstruction<'a>>,
+pub struct UpdateAsAuthorityItemDelegateV2CpiBuilder<'a, 'b> {
+    instruction: Box<UpdateAsAuthorityItemDelegateV2CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UpdateAsAuthorityItemDelegateV2CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UpdateAsAuthorityItemDelegateV2CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpdateAsAuthorityItemDelegateV2CpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -614,7 +614,7 @@ impl<'a> UpdateAsAuthorityItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -624,7 +624,7 @@ impl<'a> UpdateAsAuthorityItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -634,14 +634,14 @@ impl<'a> UpdateAsAuthorityItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -649,7 +649,7 @@ impl<'a> UpdateAsAuthorityItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -659,14 +659,14 @@ impl<'a> UpdateAsAuthorityItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition = edition;
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -674,7 +674,7 @@ impl<'a> UpdateAsAuthorityItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -683,7 +683,7 @@ impl<'a> UpdateAsAuthorityItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -693,7 +693,7 @@ impl<'a> UpdateAsAuthorityItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -703,7 +703,7 @@ impl<'a> UpdateAsAuthorityItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -741,7 +741,7 @@ impl<'a> UpdateAsAuthorityItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -749,7 +749,7 @@ impl<'a> UpdateAsAuthorityItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -812,23 +812,23 @@ impl<'a> UpdateAsAuthorityItemDelegateV2CpiBuilder<'a> {
     }
 }
 
-struct UpdateAsAuthorityItemDelegateV2CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UpdateAsAuthorityItemDelegateV2CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     new_update_authority: Option<Pubkey>,
     primary_sale_happened: Option<bool>,
     is_mutable: Option<bool>,
     token_standard: Option<TokenStandard>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/update_as_collection_delegate_v2.rs
+++ b/clients/rust/src/generated/instructions/update_as_collection_delegate_v2.rs
@@ -323,65 +323,65 @@ impl UpdateAsCollectionDelegateV2Builder {
 }
 
 /// `update_as_collection_delegate_v2` CPI accounts.
-pub struct UpdateAsCollectionDelegateV2CpiAccounts<'a> {
+pub struct UpdateAsCollectionDelegateV2CpiAccounts<'a, 'b> {
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `update_as_collection_delegate_v2` CPI instruction.
-pub struct UpdateAsCollectionDelegateV2Cpi<'a> {
+pub struct UpdateAsCollectionDelegateV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: UpdateAsCollectionDelegateV2InstructionArgs,
 }
 
-impl<'a> UpdateAsCollectionDelegateV2Cpi<'a> {
+impl<'a, 'b> UpdateAsCollectionDelegateV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UpdateAsCollectionDelegateV2CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UpdateAsCollectionDelegateV2CpiAccounts<'a, 'b>,
         args: UpdateAsCollectionDelegateV2InstructionArgs,
     ) -> Self {
         Self {
@@ -407,7 +407,7 @@ impl<'a> UpdateAsCollectionDelegateV2Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -423,7 +423,7 @@ impl<'a> UpdateAsCollectionDelegateV2Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -554,12 +554,12 @@ impl<'a> UpdateAsCollectionDelegateV2Cpi<'a> {
 }
 
 /// `update_as_collection_delegate_v2` CPI instruction builder.
-pub struct UpdateAsCollectionDelegateV2CpiBuilder<'a> {
-    instruction: Box<UpdateAsCollectionDelegateV2CpiBuilderInstruction<'a>>,
+pub struct UpdateAsCollectionDelegateV2CpiBuilder<'a, 'b> {
+    instruction: Box<UpdateAsCollectionDelegateV2CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UpdateAsCollectionDelegateV2CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UpdateAsCollectionDelegateV2CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpdateAsCollectionDelegateV2CpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -583,7 +583,7 @@ impl<'a> UpdateAsCollectionDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -593,7 +593,7 @@ impl<'a> UpdateAsCollectionDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -603,14 +603,14 @@ impl<'a> UpdateAsCollectionDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -618,7 +618,7 @@ impl<'a> UpdateAsCollectionDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -628,14 +628,14 @@ impl<'a> UpdateAsCollectionDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition = edition;
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -643,7 +643,7 @@ impl<'a> UpdateAsCollectionDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -652,7 +652,7 @@ impl<'a> UpdateAsCollectionDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -662,7 +662,7 @@ impl<'a> UpdateAsCollectionDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -672,7 +672,7 @@ impl<'a> UpdateAsCollectionDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -692,7 +692,7 @@ impl<'a> UpdateAsCollectionDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -700,7 +700,7 @@ impl<'a> UpdateAsCollectionDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -764,20 +764,20 @@ impl<'a> UpdateAsCollectionDelegateV2CpiBuilder<'a> {
     }
 }
 
-struct UpdateAsCollectionDelegateV2CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UpdateAsCollectionDelegateV2CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     collection: Option<CollectionToggle>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/update_as_collection_item_delegate_v2.rs
+++ b/clients/rust/src/generated/instructions/update_as_collection_item_delegate_v2.rs
@@ -323,65 +323,65 @@ impl UpdateAsCollectionItemDelegateV2Builder {
 }
 
 /// `update_as_collection_item_delegate_v2` CPI accounts.
-pub struct UpdateAsCollectionItemDelegateV2CpiAccounts<'a> {
+pub struct UpdateAsCollectionItemDelegateV2CpiAccounts<'a, 'b> {
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `update_as_collection_item_delegate_v2` CPI instruction.
-pub struct UpdateAsCollectionItemDelegateV2Cpi<'a> {
+pub struct UpdateAsCollectionItemDelegateV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: UpdateAsCollectionItemDelegateV2InstructionArgs,
 }
 
-impl<'a> UpdateAsCollectionItemDelegateV2Cpi<'a> {
+impl<'a, 'b> UpdateAsCollectionItemDelegateV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UpdateAsCollectionItemDelegateV2CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UpdateAsCollectionItemDelegateV2CpiAccounts<'a, 'b>,
         args: UpdateAsCollectionItemDelegateV2InstructionArgs,
     ) -> Self {
         Self {
@@ -407,7 +407,7 @@ impl<'a> UpdateAsCollectionItemDelegateV2Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -423,7 +423,7 @@ impl<'a> UpdateAsCollectionItemDelegateV2Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -554,12 +554,12 @@ impl<'a> UpdateAsCollectionItemDelegateV2Cpi<'a> {
 }
 
 /// `update_as_collection_item_delegate_v2` CPI instruction builder.
-pub struct UpdateAsCollectionItemDelegateV2CpiBuilder<'a> {
-    instruction: Box<UpdateAsCollectionItemDelegateV2CpiBuilderInstruction<'a>>,
+pub struct UpdateAsCollectionItemDelegateV2CpiBuilder<'a, 'b> {
+    instruction: Box<UpdateAsCollectionItemDelegateV2CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UpdateAsCollectionItemDelegateV2CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UpdateAsCollectionItemDelegateV2CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpdateAsCollectionItemDelegateV2CpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -583,7 +583,7 @@ impl<'a> UpdateAsCollectionItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -593,7 +593,7 @@ impl<'a> UpdateAsCollectionItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -603,14 +603,14 @@ impl<'a> UpdateAsCollectionItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -618,7 +618,7 @@ impl<'a> UpdateAsCollectionItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -628,14 +628,14 @@ impl<'a> UpdateAsCollectionItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition = edition;
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -643,7 +643,7 @@ impl<'a> UpdateAsCollectionItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -652,7 +652,7 @@ impl<'a> UpdateAsCollectionItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -662,7 +662,7 @@ impl<'a> UpdateAsCollectionItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -672,7 +672,7 @@ impl<'a> UpdateAsCollectionItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -692,7 +692,7 @@ impl<'a> UpdateAsCollectionItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -700,7 +700,7 @@ impl<'a> UpdateAsCollectionItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -764,20 +764,20 @@ impl<'a> UpdateAsCollectionItemDelegateV2CpiBuilder<'a> {
     }
 }
 
-struct UpdateAsCollectionItemDelegateV2CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UpdateAsCollectionItemDelegateV2CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     collection: Option<CollectionToggle>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/update_as_data_delegate_v2.rs
+++ b/clients/rust/src/generated/instructions/update_as_data_delegate_v2.rs
@@ -323,65 +323,65 @@ impl UpdateAsDataDelegateV2Builder {
 }
 
 /// `update_as_data_delegate_v2` CPI accounts.
-pub struct UpdateAsDataDelegateV2CpiAccounts<'a> {
+pub struct UpdateAsDataDelegateV2CpiAccounts<'a, 'b> {
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `update_as_data_delegate_v2` CPI instruction.
-pub struct UpdateAsDataDelegateV2Cpi<'a> {
+pub struct UpdateAsDataDelegateV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: UpdateAsDataDelegateV2InstructionArgs,
 }
 
-impl<'a> UpdateAsDataDelegateV2Cpi<'a> {
+impl<'a, 'b> UpdateAsDataDelegateV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UpdateAsDataDelegateV2CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UpdateAsDataDelegateV2CpiAccounts<'a, 'b>,
         args: UpdateAsDataDelegateV2InstructionArgs,
     ) -> Self {
         Self {
@@ -407,7 +407,7 @@ impl<'a> UpdateAsDataDelegateV2Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -423,7 +423,7 @@ impl<'a> UpdateAsDataDelegateV2Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -554,12 +554,12 @@ impl<'a> UpdateAsDataDelegateV2Cpi<'a> {
 }
 
 /// `update_as_data_delegate_v2` CPI instruction builder.
-pub struct UpdateAsDataDelegateV2CpiBuilder<'a> {
-    instruction: Box<UpdateAsDataDelegateV2CpiBuilderInstruction<'a>>,
+pub struct UpdateAsDataDelegateV2CpiBuilder<'a, 'b> {
+    instruction: Box<UpdateAsDataDelegateV2CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UpdateAsDataDelegateV2CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UpdateAsDataDelegateV2CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpdateAsDataDelegateV2CpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -583,7 +583,7 @@ impl<'a> UpdateAsDataDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -593,7 +593,7 @@ impl<'a> UpdateAsDataDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -603,14 +603,14 @@ impl<'a> UpdateAsDataDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -618,7 +618,7 @@ impl<'a> UpdateAsDataDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -628,14 +628,14 @@ impl<'a> UpdateAsDataDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition = edition;
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -643,7 +643,7 @@ impl<'a> UpdateAsDataDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -652,7 +652,7 @@ impl<'a> UpdateAsDataDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -662,7 +662,7 @@ impl<'a> UpdateAsDataDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -672,7 +672,7 @@ impl<'a> UpdateAsDataDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -692,7 +692,7 @@ impl<'a> UpdateAsDataDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -700,7 +700,7 @@ impl<'a> UpdateAsDataDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -760,20 +760,20 @@ impl<'a> UpdateAsDataDelegateV2CpiBuilder<'a> {
     }
 }
 
-struct UpdateAsDataDelegateV2CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UpdateAsDataDelegateV2CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     data: Option<Data>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/update_as_data_item_delegate_v2.rs
+++ b/clients/rust/src/generated/instructions/update_as_data_item_delegate_v2.rs
@@ -323,65 +323,65 @@ impl UpdateAsDataItemDelegateV2Builder {
 }
 
 /// `update_as_data_item_delegate_v2` CPI accounts.
-pub struct UpdateAsDataItemDelegateV2CpiAccounts<'a> {
+pub struct UpdateAsDataItemDelegateV2CpiAccounts<'a, 'b> {
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `update_as_data_item_delegate_v2` CPI instruction.
-pub struct UpdateAsDataItemDelegateV2Cpi<'a> {
+pub struct UpdateAsDataItemDelegateV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: UpdateAsDataItemDelegateV2InstructionArgs,
 }
 
-impl<'a> UpdateAsDataItemDelegateV2Cpi<'a> {
+impl<'a, 'b> UpdateAsDataItemDelegateV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UpdateAsDataItemDelegateV2CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UpdateAsDataItemDelegateV2CpiAccounts<'a, 'b>,
         args: UpdateAsDataItemDelegateV2InstructionArgs,
     ) -> Self {
         Self {
@@ -407,7 +407,7 @@ impl<'a> UpdateAsDataItemDelegateV2Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -423,7 +423,7 @@ impl<'a> UpdateAsDataItemDelegateV2Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -554,12 +554,12 @@ impl<'a> UpdateAsDataItemDelegateV2Cpi<'a> {
 }
 
 /// `update_as_data_item_delegate_v2` CPI instruction builder.
-pub struct UpdateAsDataItemDelegateV2CpiBuilder<'a> {
-    instruction: Box<UpdateAsDataItemDelegateV2CpiBuilderInstruction<'a>>,
+pub struct UpdateAsDataItemDelegateV2CpiBuilder<'a, 'b> {
+    instruction: Box<UpdateAsDataItemDelegateV2CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UpdateAsDataItemDelegateV2CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UpdateAsDataItemDelegateV2CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpdateAsDataItemDelegateV2CpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -583,7 +583,7 @@ impl<'a> UpdateAsDataItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -593,7 +593,7 @@ impl<'a> UpdateAsDataItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -603,14 +603,14 @@ impl<'a> UpdateAsDataItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -618,7 +618,7 @@ impl<'a> UpdateAsDataItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -628,14 +628,14 @@ impl<'a> UpdateAsDataItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition = edition;
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -643,7 +643,7 @@ impl<'a> UpdateAsDataItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -652,7 +652,7 @@ impl<'a> UpdateAsDataItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -662,7 +662,7 @@ impl<'a> UpdateAsDataItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -672,7 +672,7 @@ impl<'a> UpdateAsDataItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -692,7 +692,7 @@ impl<'a> UpdateAsDataItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -700,7 +700,7 @@ impl<'a> UpdateAsDataItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -760,20 +760,20 @@ impl<'a> UpdateAsDataItemDelegateV2CpiBuilder<'a> {
     }
 }
 
-struct UpdateAsDataItemDelegateV2CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UpdateAsDataItemDelegateV2CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     data: Option<Data>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/update_as_programmable_config_delegate_v2.rs
+++ b/clients/rust/src/generated/instructions/update_as_programmable_config_delegate_v2.rs
@@ -315,65 +315,65 @@ impl UpdateAsProgrammableConfigDelegateV2Builder {
 }
 
 /// `update_as_programmable_config_delegate_v2` CPI accounts.
-pub struct UpdateAsProgrammableConfigDelegateV2CpiAccounts<'a> {
+pub struct UpdateAsProgrammableConfigDelegateV2CpiAccounts<'a, 'b> {
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `update_as_programmable_config_delegate_v2` CPI instruction.
-pub struct UpdateAsProgrammableConfigDelegateV2Cpi<'a> {
+pub struct UpdateAsProgrammableConfigDelegateV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: UpdateAsProgrammableConfigDelegateV2InstructionArgs,
 }
 
-impl<'a> UpdateAsProgrammableConfigDelegateV2Cpi<'a> {
+impl<'a, 'b> UpdateAsProgrammableConfigDelegateV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UpdateAsProgrammableConfigDelegateV2CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UpdateAsProgrammableConfigDelegateV2CpiAccounts<'a, 'b>,
         args: UpdateAsProgrammableConfigDelegateV2InstructionArgs,
     ) -> Self {
         Self {
@@ -399,7 +399,7 @@ impl<'a> UpdateAsProgrammableConfigDelegateV2Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -415,7 +415,7 @@ impl<'a> UpdateAsProgrammableConfigDelegateV2Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -538,12 +538,12 @@ impl<'a> UpdateAsProgrammableConfigDelegateV2Cpi<'a> {
 }
 
 /// `update_as_programmable_config_delegate_v2` CPI instruction builder.
-pub struct UpdateAsProgrammableConfigDelegateV2CpiBuilder<'a> {
-    instruction: Box<UpdateAsProgrammableConfigDelegateV2CpiBuilderInstruction<'a>>,
+pub struct UpdateAsProgrammableConfigDelegateV2CpiBuilder<'a, 'b> {
+    instruction: Box<UpdateAsProgrammableConfigDelegateV2CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UpdateAsProgrammableConfigDelegateV2CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UpdateAsProgrammableConfigDelegateV2CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpdateAsProgrammableConfigDelegateV2CpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -567,7 +567,7 @@ impl<'a> UpdateAsProgrammableConfigDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -577,20 +577,20 @@ impl<'a> UpdateAsProgrammableConfigDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
     }
     /// Token account
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -598,7 +598,7 @@ impl<'a> UpdateAsProgrammableConfigDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -608,14 +608,14 @@ impl<'a> UpdateAsProgrammableConfigDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition = edition;
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -623,7 +623,7 @@ impl<'a> UpdateAsProgrammableConfigDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -632,7 +632,7 @@ impl<'a> UpdateAsProgrammableConfigDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -642,7 +642,7 @@ impl<'a> UpdateAsProgrammableConfigDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -652,7 +652,7 @@ impl<'a> UpdateAsProgrammableConfigDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -672,7 +672,7 @@ impl<'a> UpdateAsProgrammableConfigDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -680,7 +680,7 @@ impl<'a> UpdateAsProgrammableConfigDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -744,20 +744,20 @@ impl<'a> UpdateAsProgrammableConfigDelegateV2CpiBuilder<'a> {
     }
 }
 
-struct UpdateAsProgrammableConfigDelegateV2CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UpdateAsProgrammableConfigDelegateV2CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     rule_set: Option<RuleSetToggle>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/update_as_programmable_config_item_delegate_v2.rs
+++ b/clients/rust/src/generated/instructions/update_as_programmable_config_item_delegate_v2.rs
@@ -315,65 +315,65 @@ impl UpdateAsProgrammableConfigItemDelegateV2Builder {
 }
 
 /// `update_as_programmable_config_item_delegate_v2` CPI accounts.
-pub struct UpdateAsProgrammableConfigItemDelegateV2CpiAccounts<'a> {
+pub struct UpdateAsProgrammableConfigItemDelegateV2CpiAccounts<'a, 'b> {
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `update_as_programmable_config_item_delegate_v2` CPI instruction.
-pub struct UpdateAsProgrammableConfigItemDelegateV2Cpi<'a> {
+pub struct UpdateAsProgrammableConfigItemDelegateV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: UpdateAsProgrammableConfigItemDelegateV2InstructionArgs,
 }
 
-impl<'a> UpdateAsProgrammableConfigItemDelegateV2Cpi<'a> {
+impl<'a, 'b> UpdateAsProgrammableConfigItemDelegateV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UpdateAsProgrammableConfigItemDelegateV2CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UpdateAsProgrammableConfigItemDelegateV2CpiAccounts<'a, 'b>,
         args: UpdateAsProgrammableConfigItemDelegateV2InstructionArgs,
     ) -> Self {
         Self {
@@ -399,7 +399,7 @@ impl<'a> UpdateAsProgrammableConfigItemDelegateV2Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -415,7 +415,7 @@ impl<'a> UpdateAsProgrammableConfigItemDelegateV2Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -538,12 +538,12 @@ impl<'a> UpdateAsProgrammableConfigItemDelegateV2Cpi<'a> {
 }
 
 /// `update_as_programmable_config_item_delegate_v2` CPI instruction builder.
-pub struct UpdateAsProgrammableConfigItemDelegateV2CpiBuilder<'a> {
-    instruction: Box<UpdateAsProgrammableConfigItemDelegateV2CpiBuilderInstruction<'a>>,
+pub struct UpdateAsProgrammableConfigItemDelegateV2CpiBuilder<'a, 'b> {
+    instruction: Box<UpdateAsProgrammableConfigItemDelegateV2CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UpdateAsProgrammableConfigItemDelegateV2CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UpdateAsProgrammableConfigItemDelegateV2CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(
             UpdateAsProgrammableConfigItemDelegateV2CpiBuilderInstruction {
                 __program: program,
@@ -569,7 +569,7 @@ impl<'a> UpdateAsProgrammableConfigItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -579,20 +579,20 @@ impl<'a> UpdateAsProgrammableConfigItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
     }
     /// Token account
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -600,7 +600,7 @@ impl<'a> UpdateAsProgrammableConfigItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -610,14 +610,14 @@ impl<'a> UpdateAsProgrammableConfigItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition = edition;
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -625,7 +625,7 @@ impl<'a> UpdateAsProgrammableConfigItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -634,7 +634,7 @@ impl<'a> UpdateAsProgrammableConfigItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -644,7 +644,7 @@ impl<'a> UpdateAsProgrammableConfigItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -654,7 +654,7 @@ impl<'a> UpdateAsProgrammableConfigItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -674,7 +674,7 @@ impl<'a> UpdateAsProgrammableConfigItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -682,7 +682,7 @@ impl<'a> UpdateAsProgrammableConfigItemDelegateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -746,20 +746,20 @@ impl<'a> UpdateAsProgrammableConfigItemDelegateV2CpiBuilder<'a> {
     }
 }
 
-struct UpdateAsProgrammableConfigItemDelegateV2CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UpdateAsProgrammableConfigItemDelegateV2CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     rule_set: Option<RuleSetToggle>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/update_as_update_authority_v2.rs
+++ b/clients/rust/src/generated/instructions/update_as_update_authority_v2.rs
@@ -404,65 +404,65 @@ impl UpdateAsUpdateAuthorityV2Builder {
 }
 
 /// `update_as_update_authority_v2` CPI accounts.
-pub struct UpdateAsUpdateAuthorityV2CpiAccounts<'a> {
+pub struct UpdateAsUpdateAuthorityV2CpiAccounts<'a, 'b> {
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `update_as_update_authority_v2` CPI instruction.
-pub struct UpdateAsUpdateAuthorityV2Cpi<'a> {
+pub struct UpdateAsUpdateAuthorityV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: UpdateAsUpdateAuthorityV2InstructionArgs,
 }
 
-impl<'a> UpdateAsUpdateAuthorityV2Cpi<'a> {
+impl<'a, 'b> UpdateAsUpdateAuthorityV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UpdateAsUpdateAuthorityV2CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UpdateAsUpdateAuthorityV2CpiAccounts<'a, 'b>,
         args: UpdateAsUpdateAuthorityV2InstructionArgs,
     ) -> Self {
         Self {
@@ -488,7 +488,7 @@ impl<'a> UpdateAsUpdateAuthorityV2Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -504,7 +504,7 @@ impl<'a> UpdateAsUpdateAuthorityV2Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -635,12 +635,12 @@ impl<'a> UpdateAsUpdateAuthorityV2Cpi<'a> {
 }
 
 /// `update_as_update_authority_v2` CPI instruction builder.
-pub struct UpdateAsUpdateAuthorityV2CpiBuilder<'a> {
-    instruction: Box<UpdateAsUpdateAuthorityV2CpiBuilderInstruction<'a>>,
+pub struct UpdateAsUpdateAuthorityV2CpiBuilder<'a, 'b> {
+    instruction: Box<UpdateAsUpdateAuthorityV2CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UpdateAsUpdateAuthorityV2CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UpdateAsUpdateAuthorityV2CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpdateAsUpdateAuthorityV2CpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -672,7 +672,7 @@ impl<'a> UpdateAsUpdateAuthorityV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -682,7 +682,7 @@ impl<'a> UpdateAsUpdateAuthorityV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -692,14 +692,14 @@ impl<'a> UpdateAsUpdateAuthorityV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -707,7 +707,7 @@ impl<'a> UpdateAsUpdateAuthorityV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -717,14 +717,14 @@ impl<'a> UpdateAsUpdateAuthorityV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition = edition;
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -732,7 +732,7 @@ impl<'a> UpdateAsUpdateAuthorityV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -741,7 +741,7 @@ impl<'a> UpdateAsUpdateAuthorityV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -751,7 +751,7 @@ impl<'a> UpdateAsUpdateAuthorityV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -761,7 +761,7 @@ impl<'a> UpdateAsUpdateAuthorityV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -829,7 +829,7 @@ impl<'a> UpdateAsUpdateAuthorityV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -837,7 +837,7 @@ impl<'a> UpdateAsUpdateAuthorityV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -917,19 +917,19 @@ impl<'a> UpdateAsUpdateAuthorityV2CpiBuilder<'a> {
     }
 }
 
-struct UpdateAsUpdateAuthorityV2CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UpdateAsUpdateAuthorityV2CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     new_update_authority: Option<Pubkey>,
     data: Option<Data>,
     primary_sale_happened: Option<bool>,
@@ -940,5 +940,5 @@ struct UpdateAsUpdateAuthorityV2CpiBuilderInstruction<'a> {
     rule_set: Option<RuleSetToggle>,
     token_standard: Option<TokenStandard>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/update_metadata_account_v2.rs
+++ b/clients/rust/src/generated/instructions/update_metadata_account_v2.rs
@@ -160,29 +160,29 @@ impl UpdateMetadataAccountV2Builder {
 }
 
 /// `update_metadata_account_v2` CPI accounts.
-pub struct UpdateMetadataAccountV2CpiAccounts<'a> {
+pub struct UpdateMetadataAccountV2CpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority key
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `update_metadata_account_v2` CPI instruction.
-pub struct UpdateMetadataAccountV2Cpi<'a> {
+pub struct UpdateMetadataAccountV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority key
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: UpdateMetadataAccountV2InstructionArgs,
 }
 
-impl<'a> UpdateMetadataAccountV2Cpi<'a> {
+impl<'a, 'b> UpdateMetadataAccountV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UpdateMetadataAccountV2CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UpdateMetadataAccountV2CpiAccounts<'a, 'b>,
         args: UpdateMetadataAccountV2InstructionArgs,
     ) -> Self {
         Self {
@@ -199,7 +199,7 @@ impl<'a> UpdateMetadataAccountV2Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -215,7 +215,7 @@ impl<'a> UpdateMetadataAccountV2Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -257,12 +257,12 @@ impl<'a> UpdateMetadataAccountV2Cpi<'a> {
 }
 
 /// `update_metadata_account_v2` CPI instruction builder.
-pub struct UpdateMetadataAccountV2CpiBuilder<'a> {
-    instruction: Box<UpdateMetadataAccountV2CpiBuilderInstruction<'a>>,
+pub struct UpdateMetadataAccountV2CpiBuilder<'a, 'b> {
+    instruction: Box<UpdateMetadataAccountV2CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UpdateMetadataAccountV2CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UpdateMetadataAccountV2CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpdateMetadataAccountV2CpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -279,7 +279,7 @@ impl<'a> UpdateMetadataAccountV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -288,7 +288,7 @@ impl<'a> UpdateMetadataAccountV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -320,7 +320,7 @@ impl<'a> UpdateMetadataAccountV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -328,7 +328,7 @@ impl<'a> UpdateMetadataAccountV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -369,13 +369,13 @@ impl<'a> UpdateMetadataAccountV2CpiBuilder<'a> {
     }
 }
 
-struct UpdateMetadataAccountV2CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UpdateMetadataAccountV2CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     data: Option<DataV2>,
     new_update_authority: Option<Pubkey>,
     primary_sale_happened: Option<bool>,
     is_mutable: Option<bool>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/update_primary_sale_happened_via_token.rs
+++ b/clients/rust/src/generated/instructions/update_primary_sale_happened_via_token.rs
@@ -118,31 +118,31 @@ impl UpdatePrimarySaleHappenedViaTokenBuilder {
 }
 
 /// `update_primary_sale_happened_via_token` CPI accounts.
-pub struct UpdatePrimarySaleHappenedViaTokenCpiAccounts<'a> {
+pub struct UpdatePrimarySaleHappenedViaTokenCpiAccounts<'a, 'b> {
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner on the token account
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Account containing tokens from the metadata's mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `update_primary_sale_happened_via_token` CPI instruction.
-pub struct UpdatePrimarySaleHappenedViaTokenCpi<'a> {
+pub struct UpdatePrimarySaleHappenedViaTokenCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner on the token account
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Account containing tokens from the metadata's mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> UpdatePrimarySaleHappenedViaTokenCpi<'a> {
+impl<'a, 'b> UpdatePrimarySaleHappenedViaTokenCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UpdatePrimarySaleHappenedViaTokenCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UpdatePrimarySaleHappenedViaTokenCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -158,7 +158,7 @@ impl<'a> UpdatePrimarySaleHappenedViaTokenCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -174,7 +174,7 @@ impl<'a> UpdatePrimarySaleHappenedViaTokenCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -219,12 +219,12 @@ impl<'a> UpdatePrimarySaleHappenedViaTokenCpi<'a> {
 }
 
 /// `update_primary_sale_happened_via_token` CPI instruction builder.
-pub struct UpdatePrimarySaleHappenedViaTokenCpiBuilder<'a> {
-    instruction: Box<UpdatePrimarySaleHappenedViaTokenCpiBuilderInstruction<'a>>,
+pub struct UpdatePrimarySaleHappenedViaTokenCpiBuilder<'a, 'b> {
+    instruction: Box<UpdatePrimarySaleHappenedViaTokenCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UpdatePrimarySaleHappenedViaTokenCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UpdatePrimarySaleHappenedViaTokenCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpdatePrimarySaleHappenedViaTokenCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -238,27 +238,27 @@ impl<'a> UpdatePrimarySaleHappenedViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Owner on the token account
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
     /// Account containing tokens from the metadata's mint
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -266,7 +266,7 @@ impl<'a> UpdatePrimarySaleHappenedViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -299,10 +299,10 @@ impl<'a> UpdatePrimarySaleHappenedViaTokenCpiBuilder<'a> {
     }
 }
 
-struct UpdatePrimarySaleHappenedViaTokenCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct UpdatePrimarySaleHappenedViaTokenCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/update_v1.rs
+++ b/clients/rust/src/generated/instructions/update_v1.rs
@@ -392,65 +392,65 @@ impl UpdateV1Builder {
 }
 
 /// `update_v1` CPI accounts.
-pub struct UpdateV1CpiAccounts<'a> {
+pub struct UpdateV1CpiAccounts<'a, 'b> {
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `update_v1` CPI instruction.
-pub struct UpdateV1Cpi<'a> {
+pub struct UpdateV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: UpdateV1InstructionArgs,
 }
 
-impl<'a> UpdateV1Cpi<'a> {
+impl<'a, 'b> UpdateV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UpdateV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UpdateV1CpiAccounts<'a, 'b>,
         args: UpdateV1InstructionArgs,
     ) -> Self {
         Self {
@@ -476,7 +476,7 @@ impl<'a> UpdateV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -492,7 +492,7 @@ impl<'a> UpdateV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -621,12 +621,12 @@ impl<'a> UpdateV1Cpi<'a> {
 }
 
 /// `update_v1` CPI instruction builder.
-pub struct UpdateV1CpiBuilder<'a> {
-    instruction: Box<UpdateV1CpiBuilderInstruction<'a>>,
+pub struct UpdateV1CpiBuilder<'a, 'b> {
+    instruction: Box<UpdateV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UpdateV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UpdateV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpdateV1CpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -657,7 +657,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -667,7 +667,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -677,14 +677,14 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -692,7 +692,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -702,14 +702,14 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition = edition;
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -717,7 +717,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -726,7 +726,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -736,7 +736,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -746,7 +746,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -808,7 +808,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -816,7 +816,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -895,19 +895,19 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     }
 }
 
-struct UpdateV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UpdateV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     new_update_authority: Option<Pubkey>,
     data: Option<Data>,
     primary_sale_happened: Option<bool>,
@@ -917,5 +917,5 @@ struct UpdateV1CpiBuilderInstruction<'a> {
     uses: Option<UsesToggle>,
     rule_set: Option<RuleSetToggle>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/use_v1.rs
+++ b/clients/rust/src/generated/instructions/use_v1.rs
@@ -334,69 +334,69 @@ impl UseV1Builder {
 }
 
 /// `use_v1` CPI accounts.
-pub struct UseV1CpiAccounts<'a> {
+pub struct UseV1CpiAccounts<'a, 'b> {
     /// Token owner or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `use_v1` CPI instruction.
-pub struct UseV1Cpi<'a> {
+pub struct UseV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token owner or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: UseV1InstructionArgs,
 }
 
-impl<'a> UseV1Cpi<'a> {
+impl<'a, 'b> UseV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UseV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UseV1CpiAccounts<'a, 'b>,
         args: UseV1InstructionArgs,
     ) -> Self {
         Self {
@@ -423,7 +423,7 @@ impl<'a> UseV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -439,7 +439,7 @@ impl<'a> UseV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(12 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -582,12 +582,12 @@ impl<'a> UseV1Cpi<'a> {
 }
 
 /// `use_v1` CPI instruction builder.
-pub struct UseV1CpiBuilder<'a> {
-    instruction: Box<UseV1CpiBuilderInstruction<'a>>,
+pub struct UseV1CpiBuilder<'a, 'b> {
+    instruction: Box<UseV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UseV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UseV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UseV1CpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -611,7 +611,7 @@ impl<'a> UseV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -621,7 +621,7 @@ impl<'a> UseV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -631,14 +631,14 @@ impl<'a> UseV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -646,7 +646,7 @@ impl<'a> UseV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -656,14 +656,14 @@ impl<'a> UseV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition = edition;
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -671,7 +671,7 @@ impl<'a> UseV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -680,7 +680,7 @@ impl<'a> UseV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -690,7 +690,7 @@ impl<'a> UseV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -700,7 +700,7 @@ impl<'a> UseV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -710,7 +710,7 @@ impl<'a> UseV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -724,7 +724,7 @@ impl<'a> UseV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -732,7 +732,7 @@ impl<'a> UseV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -793,20 +793,20 @@ impl<'a> UseV1CpiBuilder<'a> {
     }
 }
 
-struct UseV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UseV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     authorization_data: Option<AuthorizationData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/utilize.rs
+++ b/clients/rust/src/generated/instructions/utilize.rs
@@ -271,65 +271,65 @@ impl UtilizeBuilder {
 }
 
 /// `utilize` CPI accounts.
-pub struct UtilizeCpiAccounts<'a> {
+pub struct UtilizeCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Account Of NFT
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// A Use Authority / Can be the current Owner of the NFT
-    pub use_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub use_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Associated Token program
-    pub ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
     /// Use Authority Record PDA If present the program Assumes a delegated use authority
-    pub use_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Program As Signer (Burner)
-    pub burner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub burner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `utilize` CPI instruction.
-pub struct UtilizeCpi<'a> {
+pub struct UtilizeCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Account Of NFT
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// A Use Authority / Can be the current Owner of the NFT
-    pub use_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub use_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Associated Token program
-    pub ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
     /// Use Authority Record PDA If present the program Assumes a delegated use authority
-    pub use_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Program As Signer (Burner)
-    pub burner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub burner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: UtilizeInstructionArgs,
 }
 
-impl<'a> UtilizeCpi<'a> {
+impl<'a, 'b> UtilizeCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UtilizeCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UtilizeCpiAccounts<'a, 'b>,
         args: UtilizeInstructionArgs,
     ) -> Self {
         Self {
@@ -355,7 +355,7 @@ impl<'a> UtilizeCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -371,7 +371,7 @@ impl<'a> UtilizeCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -464,12 +464,12 @@ impl<'a> UtilizeCpi<'a> {
 }
 
 /// `utilize` CPI instruction builder.
-pub struct UtilizeCpiBuilder<'a> {
-    instruction: Box<UtilizeCpiBuilderInstruction<'a>>,
+pub struct UtilizeCpiBuilder<'a, 'b> {
+    instruction: Box<UtilizeCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UtilizeCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UtilizeCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UtilizeCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -492,7 +492,7 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -501,14 +501,14 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account(
         &mut self,
-        token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account = Some(token_account);
         self
     }
     /// Mint of the Metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -516,14 +516,14 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn use_authority(
         &mut self,
-        use_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        use_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.use_authority = Some(use_authority);
         self
     }
     /// Owner
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
@@ -531,7 +531,7 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -540,7 +540,7 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn ata_program(
         &mut self,
-        ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+        ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.ata_program = Some(ata_program);
         self
@@ -549,14 +549,14 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     /// Rent info
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
@@ -565,7 +565,7 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn use_authority_record(
         &mut self,
-        use_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.use_authority_record = use_authority_record;
         self
@@ -575,7 +575,7 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn burner(
         &mut self,
-        burner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        burner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.burner = burner;
         self
@@ -588,7 +588,7 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -596,7 +596,7 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -668,19 +668,19 @@ impl<'a> UtilizeCpiBuilder<'a> {
     }
 }
 
-struct UtilizeCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    use_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    ata_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    use_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    burner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UtilizeCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    use_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    ata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    burner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     number_of_uses: Option<u64>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/verify_collection.rs
+++ b/clients/rust/src/generated/instructions/verify_collection.rs
@@ -192,47 +192,47 @@ impl VerifyCollectionBuilder {
 }
 
 /// `verify_collection` CPI accounts.
-pub struct VerifyCollectionCpiAccounts<'a> {
+pub struct VerifyCollectionCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `verify_collection` CPI instruction.
-pub struct VerifyCollectionCpi<'a> {
+pub struct VerifyCollectionCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> VerifyCollectionCpi<'a> {
+impl<'a, 'b> VerifyCollectionCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: VerifyCollectionCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: VerifyCollectionCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -252,7 +252,7 @@ impl<'a> VerifyCollectionCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -268,7 +268,7 @@ impl<'a> VerifyCollectionCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -335,12 +335,12 @@ impl<'a> VerifyCollectionCpi<'a> {
 }
 
 /// `verify_collection` CPI instruction builder.
-pub struct VerifyCollectionCpiBuilder<'a> {
-    instruction: Box<VerifyCollectionCpiBuilderInstruction<'a>>,
+pub struct VerifyCollectionCpiBuilder<'a, 'b> {
+    instruction: Box<VerifyCollectionCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> VerifyCollectionCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> VerifyCollectionCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(VerifyCollectionCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -358,7 +358,7 @@ impl<'a> VerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -367,14 +367,14 @@ impl<'a> VerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority(
         &mut self,
-        collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority = Some(collection_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -382,7 +382,7 @@ impl<'a> VerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -391,7 +391,7 @@ impl<'a> VerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection(
         &mut self,
-        collection: &'a solana_program::account_info::AccountInfo<'a>,
+        collection: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection = Some(collection);
         self
@@ -400,7 +400,7 @@ impl<'a> VerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_master_edition_account(
         &mut self,
-        collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_master_edition_account =
             Some(collection_master_edition_account);
@@ -411,7 +411,7 @@ impl<'a> VerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = collection_authority_record;
         self
@@ -419,7 +419,7 @@ impl<'a> VerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -427,7 +427,7 @@ impl<'a> VerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -477,14 +477,14 @@ impl<'a> VerifyCollectionCpiBuilder<'a> {
     }
 }
 
-struct VerifyCollectionCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_master_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct VerifyCollectionCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_master_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/verify_collection_v1.rs
+++ b/clients/rust/src/generated/instructions/verify_collection_v1.rs
@@ -239,51 +239,51 @@ impl VerifyCollectionV1Builder {
 }
 
 /// `verify_collection_v1` CPI accounts.
-pub struct VerifyCollectionV1CpiAccounts<'a> {
+pub struct VerifyCollectionV1CpiAccounts<'a, 'b> {
     /// Creator to verify, collection update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Master Edition Account of the Collection Token
-    pub collection_master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `verify_collection_v1` CPI instruction.
-pub struct VerifyCollectionV1Cpi<'a> {
+pub struct VerifyCollectionV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Creator to verify, collection update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Master Edition Account of the Collection Token
-    pub collection_master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> VerifyCollectionV1Cpi<'a> {
+impl<'a, 'b> VerifyCollectionV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: VerifyCollectionV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: VerifyCollectionV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -304,7 +304,7 @@ impl<'a> VerifyCollectionV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -320,7 +320,7 @@ impl<'a> VerifyCollectionV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -417,12 +417,12 @@ impl<'a> VerifyCollectionV1Cpi<'a> {
 }
 
 /// `verify_collection_v1` CPI instruction builder.
-pub struct VerifyCollectionV1CpiBuilder<'a> {
-    instruction: Box<VerifyCollectionV1CpiBuilderInstruction<'a>>,
+pub struct VerifyCollectionV1CpiBuilder<'a, 'b> {
+    instruction: Box<VerifyCollectionV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> VerifyCollectionV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> VerifyCollectionV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(VerifyCollectionV1CpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -441,7 +441,7 @@ impl<'a> VerifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -451,7 +451,7 @@ impl<'a> VerifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -460,7 +460,7 @@ impl<'a> VerifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -469,7 +469,7 @@ impl<'a> VerifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -479,7 +479,7 @@ impl<'a> VerifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_metadata(
         &mut self,
-        collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_metadata = collection_metadata;
         self
@@ -489,7 +489,7 @@ impl<'a> VerifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_master_edition(
         &mut self,
-        collection_master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_master_edition = collection_master_edition;
         self
@@ -498,7 +498,7 @@ impl<'a> VerifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -507,7 +507,7 @@ impl<'a> VerifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -515,7 +515,7 @@ impl<'a> VerifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -523,7 +523,7 @@ impl<'a> VerifyCollectionV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -575,15 +575,15 @@ impl<'a> VerifyCollectionV1CpiBuilder<'a> {
     }
 }
 
-struct VerifyCollectionV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct VerifyCollectionV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/verify_creator_v1.rs
+++ b/clients/rust/src/generated/instructions/verify_creator_v1.rs
@@ -245,51 +245,51 @@ impl VerifyCreatorV1Builder {
 }
 
 /// `verify_creator_v1` CPI accounts.
-pub struct VerifyCreatorV1CpiAccounts<'a> {
+pub struct VerifyCreatorV1CpiAccounts<'a, 'b> {
     /// Creator to verify, collection update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata Account of the Collection
-    pub collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Master Edition Account of the Collection Token
-    pub collection_master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `verify_creator_v1` CPI instruction.
-pub struct VerifyCreatorV1Cpi<'a> {
+pub struct VerifyCreatorV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Creator to verify, collection update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata Account of the Collection
-    pub collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Master Edition Account of the Collection Token
-    pub collection_master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> VerifyCreatorV1Cpi<'a> {
+impl<'a, 'b> VerifyCreatorV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: VerifyCreatorV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: VerifyCreatorV1CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -310,7 +310,7 @@ impl<'a> VerifyCreatorV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -326,7 +326,7 @@ impl<'a> VerifyCreatorV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -430,12 +430,12 @@ impl<'a> VerifyCreatorV1Cpi<'a> {
 }
 
 /// `verify_creator_v1` CPI instruction builder.
-pub struct VerifyCreatorV1CpiBuilder<'a> {
-    instruction: Box<VerifyCreatorV1CpiBuilderInstruction<'a>>,
+pub struct VerifyCreatorV1CpiBuilder<'a, 'b> {
+    instruction: Box<VerifyCreatorV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> VerifyCreatorV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> VerifyCreatorV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(VerifyCreatorV1CpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -454,7 +454,7 @@ impl<'a> VerifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -464,7 +464,7 @@ impl<'a> VerifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -473,7 +473,7 @@ impl<'a> VerifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -483,7 +483,7 @@ impl<'a> VerifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_mint = collection_mint;
         self
@@ -493,7 +493,7 @@ impl<'a> VerifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_metadata(
         &mut self,
-        collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_metadata = collection_metadata;
         self
@@ -503,7 +503,7 @@ impl<'a> VerifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_master_edition(
         &mut self,
-        collection_master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_master_edition = collection_master_edition;
         self
@@ -512,7 +512,7 @@ impl<'a> VerifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -521,7 +521,7 @@ impl<'a> VerifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -529,7 +529,7 @@ impl<'a> VerifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -537,7 +537,7 @@ impl<'a> VerifyCreatorV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -586,15 +586,15 @@ impl<'a> VerifyCreatorV1CpiBuilder<'a> {
     }
 }
 
-struct VerifyCreatorV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct VerifyCreatorV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/clients/rust/src/generated/instructions/verify_sized_collection_item.rs
+++ b/clients/rust/src/generated/instructions/verify_sized_collection_item.rs
@@ -194,47 +194,47 @@ impl VerifySizedCollectionItemBuilder {
 }
 
 /// `verify_sized_collection_item` CPI accounts.
-pub struct VerifySizedCollectionItemCpiAccounts<'a> {
+pub struct VerifySizedCollectionItemCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `verify_sized_collection_item` CPI instruction.
-pub struct VerifySizedCollectionItemCpi<'a> {
+pub struct VerifySizedCollectionItemCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> VerifySizedCollectionItemCpi<'a> {
+impl<'a, 'b> VerifySizedCollectionItemCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: VerifySizedCollectionItemCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: VerifySizedCollectionItemCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -254,7 +254,7 @@ impl<'a> VerifySizedCollectionItemCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -270,7 +270,7 @@ impl<'a> VerifySizedCollectionItemCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -339,12 +339,12 @@ impl<'a> VerifySizedCollectionItemCpi<'a> {
 }
 
 /// `verify_sized_collection_item` CPI instruction builder.
-pub struct VerifySizedCollectionItemCpiBuilder<'a> {
-    instruction: Box<VerifySizedCollectionItemCpiBuilderInstruction<'a>>,
+pub struct VerifySizedCollectionItemCpiBuilder<'a, 'b> {
+    instruction: Box<VerifySizedCollectionItemCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> VerifySizedCollectionItemCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(VerifySizedCollectionItemCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -362,7 +362,7 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -371,14 +371,14 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority(
         &mut self,
-        collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority = Some(collection_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -386,7 +386,7 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -395,7 +395,7 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection(
         &mut self,
-        collection: &'a solana_program::account_info::AccountInfo<'a>,
+        collection: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection = Some(collection);
         self
@@ -404,7 +404,7 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_master_edition_account(
         &mut self,
-        collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_master_edition_account =
             Some(collection_master_edition_account);
@@ -415,7 +415,7 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = collection_authority_record;
         self
@@ -423,7 +423,7 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -431,7 +431,7 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -481,14 +481,14 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     }
 }
 
-struct VerifySizedCollectionItemCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_master_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct VerifySizedCollectionItemCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_master_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@metaplex-foundation/amman": "^0.12.1",
-    "@metaplex-foundation/kinobi": "^0.15.0",
+    "@metaplex-foundation/kinobi": "^0.15.1",
     "@metaplex-foundation/shank-js": "^0.1.0",
     "typescript": "^4.9.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ devDependencies:
     specifier: ^0.12.1
     version: 0.12.1(typescript@4.9.5)
   '@metaplex-foundation/kinobi':
-    specifier: ^0.15.0
-    version: 0.15.0
+    specifier: ^0.15.1
+    version: 0.15.1
   '@metaplex-foundation/shank-js':
     specifier: ^0.1.0
     version: 0.1.0
@@ -85,8 +85,8 @@ packages:
     resolution: {integrity: sha512-S9RulC2fFCFOQraz61bij+5YCHhSO9llJegK8c8Y6731fSi6snUSQJdCUqYS8AIgR0TKbQvdvgSyIIdbDFZbBA==}
     dev: true
 
-  /@metaplex-foundation/kinobi@0.15.0:
-    resolution: {integrity: sha512-wIkuZd04qM1UwmV1/vNN9fmze0YE/uWn7iOhBNsU+j/wQJSJn2sYrNYcMGDzJCDS9bZmZPDp6K9N7jaEtSdMRA==}
+  /@metaplex-foundation/kinobi@0.15.1:
+    resolution: {integrity: sha512-K3RpmvgfB2fr9+Xqrffm9aH0/5mhm78wBhTNwsfs+sYIMZhP01vkJxciX4KTSNHJ776keLbuc8glyh2t5dAOPA==}
     dependencies:
       '@noble/hashes': 1.2.0
       chalk: 4.1.2


### PR DESCRIPTION
PR bumps Kinobi to `0.15.1`, which includes improvements for using CPI builders on Anchor programs.