### PR TITLE
Downgrade mpl-utils dependency

### DIFF
--- a/programs/token-metadata/Cargo.lock
+++ b/programs/token-metadata/Cargo.lock
@@ -5074,7 +5074,7 @@ dependencies = [
  "borsh 0.9.3",
  "mpl-token-auth-rules",
  "mpl-token-metadata-context-derive 0.3.0",
- "mpl-utils 0.3.1",
+ "mpl-utils 0.2.0",
  "num-derive",
  "num-traits",
  "rmp-serde",

--- a/programs/token-metadata/program/Cargo.toml
+++ b/programs/token-metadata/program/Cargo.toml
@@ -18,7 +18,7 @@ arrayref = "0.3.6"
 borsh = "0.9.3"
 mpl-token-auth-rules = { version = "=1.4.3-beta.1", features = ["no-entrypoint"] }
 mpl-token-metadata-context-derive = { version = "0.3.0", path = "../macro" }
-mpl-utils = { version = "0.3.1" }
+mpl-utils = { version = "0.2" }
 num-derive = "0.3"
 num-traits = "0.2"
 serde = { version = "1.0.149", optional = true }


### PR DESCRIPTION
This PR downgrades `mpl-utils` version from the `0.3.x` to `0.2.x`, since Token Metadata `1.13.x` does not depend on `spl-token-2022`.