### PR TITLE
Set update authority as optional signer

### DIFF
--- a/clients/js/src/generated/instructions/createMetadataAccountV3.ts
+++ b/clients/js/src/generated/instructions/createMetadataAccountV3.ts
@@ -51,7 +51,7 @@ export type CreateMetadataAccountV3InstructionAccounts = {
   /** payer */
   payer?: Signer;
   /** update authority info */
-  updateAuthority?: PublicKey | Pda;
+  updateAuthority?: PublicKey | Pda | Signer;
   /** System program */
   systemProgram?: PublicKey | Pda;
   /** Rent info */
@@ -149,7 +149,7 @@ export function createMetadataAccountV3(
     resolvedAccounts.payer.value = context.payer;
   }
   if (!resolvedAccounts.updateAuthority.value) {
-    resolvedAccounts.updateAuthority.value = context.identity.publicKey;
+    resolvedAccounts.updateAuthority.value = context.identity;
   }
   if (!resolvedAccounts.systemProgram.value) {
     resolvedAccounts.systemProgram.value = context.programs.getPublicKey(

--- a/clients/rust/README.md
+++ b/clients/rust/README.md
@@ -119,7 +119,7 @@ let create_ix = CreateV1Builder::new()
     .seller_fee_basis_points(500)
     .token_standard(TokenStandard::ProgrammableNonFungible)
     .print_supply(PrintSupply::Zero)
-    .build();
+    .instruction();
 ```
 
 ### _CPI_ instruction builders

--- a/clients/rust/src/generated/instructions/create_metadata_account_v3.rs
+++ b/clients/rust/src/generated/instructions/create_metadata_account_v3.rs
@@ -21,7 +21,7 @@ pub struct CreateMetadataAccountV3 {
     /// payer
     pub payer: solana_program::pubkey::Pubkey,
     /// update authority info
-    pub update_authority: solana_program::pubkey::Pubkey,
+    pub update_authority: (solana_program::pubkey::Pubkey, bool),
     /// System program
     pub system_program: solana_program::pubkey::Pubkey,
     /// Rent info
@@ -57,8 +57,8 @@ impl CreateMetadataAccountV3 {
             self.payer, true,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            self.update_authority,
-            false,
+            self.update_authority.0,
+            self.update_authority.1,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.system_program,
@@ -112,7 +112,7 @@ pub struct CreateMetadataAccountV3Builder {
     mint: Option<solana_program::pubkey::Pubkey>,
     mint_authority: Option<solana_program::pubkey::Pubkey>,
     payer: Option<solana_program::pubkey::Pubkey>,
-    update_authority: Option<solana_program::pubkey::Pubkey>,
+    update_authority: Option<(solana_program::pubkey::Pubkey, bool)>,
     system_program: Option<solana_program::pubkey::Pubkey>,
     rent: Option<solana_program::pubkey::Pubkey>,
     data: Option<DataV2>,
@@ -154,8 +154,9 @@ impl CreateMetadataAccountV3Builder {
     pub fn update_authority(
         &mut self,
         update_authority: solana_program::pubkey::Pubkey,
+        as_signer: bool,
     ) -> &mut Self {
-        self.update_authority = Some(update_authority);
+        self.update_authority = Some((update_authority, as_signer));
         self
     }
     /// `[optional account, default to '11111111111111111111111111111111']`
@@ -232,7 +233,7 @@ pub struct CreateMetadataAccountV3CpiAccounts<'a, 'b> {
     /// payer
     pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info
-    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: (&'b solana_program::account_info::AccountInfo<'a>, bool),
     /// System program
     pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
@@ -252,7 +253,7 @@ pub struct CreateMetadataAccountV3Cpi<'a, 'b> {
     /// payer
     pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info
-    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: (&'b solana_program::account_info::AccountInfo<'a>, bool),
     /// System program
     pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
@@ -322,8 +323,8 @@ impl<'a, 'b> CreateMetadataAccountV3Cpi<'a, 'b> {
             true,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            *self.update_authority.key,
-            false,
+            *self.update_authority.0.key,
+            self.update_authority.1,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             *self.system_program.key,
@@ -354,7 +355,7 @@ impl<'a, 'b> CreateMetadataAccountV3Cpi<'a, 'b> {
         account_infos.push(self.mint.clone());
         account_infos.push(self.mint_authority.clone());
         account_infos.push(self.payer.clone());
-        account_infos.push(self.update_authority.clone());
+        account_infos.push(self.update_authority.0.clone());
         account_infos.push(self.system_program.clone());
         if let Some(rent) = self.rent {
             account_infos.push(rent.clone());
@@ -429,8 +430,9 @@ impl<'a, 'b> CreateMetadataAccountV3CpiBuilder<'a, 'b> {
     pub fn update_authority(
         &mut self,
         update_authority: &'b solana_program::account_info::AccountInfo<'a>,
+        as_signer: bool,
     ) -> &mut Self {
-        self.instruction.update_authority = Some(update_authority);
+        self.instruction.update_authority = Some((update_authority, as_signer));
         self
     }
     /// System program
@@ -545,7 +547,7 @@ struct CreateMetadataAccountV3CpiBuilderInstruction<'a, 'b> {
     mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<(&'b solana_program::account_info::AccountInfo<'a>, bool)>,
     system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     data: Option<DataV2>,

--- a/clients/rust/tests/mint.rs
+++ b/clients/rust/tests/mint.rs
@@ -1,0 +1,59 @@
+#[cfg(feature = "test-sbf")]
+pub mod setup;
+use setup::*;
+
+use solana_program_test::*;
+use solana_sdk::signature::{Keypair, Signer};
+
+use mpl_token_metadata::{
+    accounts::{MasterEdition, Metadata},
+    types::{Key, TokenStandard},
+};
+
+mod mint {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn mint_nonfungible() {
+        let mut context = program_test().start_with_context().await;
+
+        // when we mint a non-fungible asset
+
+        let update_authority = Keypair::new();
+        let token_owner = Keypair::new();
+        let payer = context.payer.dirty_clone();
+
+        let mut asset = DigitalAsset::default();
+        asset
+            .create_and_mint(
+                &mut context,
+                TokenStandard::NonFungible,
+                &update_authority,
+                &token_owner.pubkey(),
+                1,
+                &payer,
+            )
+            .await
+            .unwrap();
+
+        // then metadata account is created with correct information.
+
+        let metadata_account =
+            get_account(&mut context, &Metadata::find_pda(&asset.mint.pubkey()).0).await;
+        let metadata = Metadata::safe_deserialize(&metadata_account.data).unwrap();
+        assert_eq!(metadata.key, Key::MetadataV1);
+        assert_eq!(metadata.token_standard, Some(TokenStandard::NonFungible));
+
+        // and the master edition is created with correct information.
+
+        let master_edition_account = get_account(
+            &mut context,
+            &MasterEdition::find_pda(&asset.mint.pubkey()).0,
+        )
+        .await;
+        let master_edition = MasterEdition::safe_deserialize(&master_edition_account.data).unwrap();
+
+        assert_eq!(master_edition.key, Key::MasterEditionV2);
+    }
+}

--- a/idls/token_metadata.json
+++ b/idls/token_metadata.json
@@ -2350,6 +2350,7 @@
           "name": "updateAuthority",
           "isMut": false,
           "isSigner": false,
+          "isOptionalSigner": true,
           "docs": [
             "update authority info"
           ]

--- a/programs/token-metadata/program/src/instruction/mod.rs
+++ b/programs/token-metadata/program/src/instruction/mod.rs
@@ -441,7 +441,7 @@ pub enum MetadataInstruction {
     #[account(1, name="mint", desc="Mint of token asset")]
     #[account(2, signer, name="mint_authority", desc="Mint authority")]
     #[account(3, signer, writable, name="payer", desc="payer")]
-    #[account(4, name="update_authority", desc="update authority info")]
+    #[account(4, optional_signer, name="update_authority", desc="update authority info")]
     #[account(5, name="system_program", desc="System program")]
     #[account(6, optional, name="rent", desc="Rent info")]
     #[legacy_optional_accounts_strategy]


### PR DESCRIPTION
PR to set the `update_authority` as an optional signer on the `CreateMetadataAccountV3` instruction.