### PR TITLE
Add client helper for ProgrammableNonFungible master editions

### DIFF
--- a/clients/js/src/generated/instructions/setAndVerifySizedCollectionItem.ts
+++ b/clients/js/src/generated/instructions/setAndVerifySizedCollectionItem.ts
@@ -106,7 +106,7 @@ export function setAndVerifySizedCollectionItem(
     collection: { index: 5, isWritable: true, value: input.collection ?? null },
     collectionMasterEditionAccount: {
       index: 6,
-      isWritable: true,
+      isWritable: false,
       value: input.collectionMasterEditionAccount ?? null,
     },
     collectionAuthorityRecord: {

--- a/clients/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
+++ b/clients/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
@@ -61,7 +61,7 @@ impl SetAndVerifySizedCollectionItem {
             self.collection,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.collection_master_edition_account,
             false,
         ));
@@ -333,7 +333,7 @@ impl<'a, 'b> SetAndVerifySizedCollectionItemCpi<'a, 'b> {
             *self.collection.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             *self.collection_master_edition_account.key,
             false,
         ));

--- a/clients/rust/src/utils.rs
+++ b/clients/rust/src/utils.rs
@@ -16,7 +16,7 @@ pub fn clean(value: String) -> String {
 
 /// Checks that the `master_edition` is Programmable NFT master edition.
 pub fn assert_edition_is_programmable(edition_data: &[u8]) -> Result<(), MplTokenMetadataError> {
-    if !edition_data.is_empty() {
+    if edition_data.len() > TOKEN_STANDARD_OFFSET {
         // the first byte is the account key
         let key = Key::deserialize(&mut &edition_data[0..1])
             .map_err(|_error| MplTokenMetadataError::InvalidEditionKey)?;

--- a/clients/rust/src/utils.rs
+++ b/clients/rust/src/utils.rs
@@ -40,5 +40,5 @@ pub fn assert_edition_is_programmable(edition_data: &[u8]) -> Result<(), MplToke
         }
     }
 
-    Err(MplTokenMetadataError::InvalidTokenStandard)
+    Err(MplTokenMetadataError::InvalidMasterEditionAccountLength)
 }

--- a/clients/rust/src/utils.rs
+++ b/clients/rust/src/utils.rs
@@ -1,4 +1,9 @@
-use crate::{errors::MplTokenMetadataError, types::TokenStandard};
+use borsh::BorshDeserialize;
+
+use crate::{
+    errors::MplTokenMetadataError,
+    types::{Key, TokenStandard},
+};
 
 /// The offset of the token standard byte in the master edition
 /// from the end of the account data.
@@ -11,12 +16,29 @@ pub fn clean(value: String) -> String {
 
 /// Checks that the `master_edition` is Programmable NFT master edition.
 pub fn assert_edition_is_programmable(edition_data: &[u8]) -> Result<(), MplTokenMetadataError> {
-    if !edition_data.is_empty()
-        && edition_data[edition_data.len() - TOKEN_STANDARD_OFFSET]
-            == TokenStandard::ProgrammableNonFungible as u8
-    {
-        Ok(())
-    } else {
-        Err(MplTokenMetadataError::InvalidTokenStandard)
+    if !edition_data.is_empty() {
+        // the first byte is the account key
+        let key = Key::deserialize(&mut &edition_data[0..1])
+            .map_err(|_error| MplTokenMetadataError::InvalidEditionKey)?;
+
+        if matches!(key, Key::MasterEditionV1 | Key::MasterEditionV2) {
+            // the last byte is the token standard
+            let standard = TokenStandard::deserialize(
+                &mut &edition_data[edition_data.len() - TOKEN_STANDARD_OFFSET..],
+            )
+            .map_err(|_error| MplTokenMetadataError::InvalidTokenStandard)?;
+
+            return if matches!(
+                standard,
+                TokenStandard::ProgrammableNonFungible
+                    | TokenStandard::ProgrammableNonFungibleEdition
+            ) {
+                Ok(())
+            } else {
+                Err(MplTokenMetadataError::InvalidTokenStandard)
+            };
+        }
     }
+
+    Err(MplTokenMetadataError::DataIsEmptyOrZeroed)
 }

--- a/clients/rust/src/utils.rs
+++ b/clients/rust/src/utils.rs
@@ -1,4 +1,22 @@
+use crate::{errors::MplTokenMetadataError, types::TokenStandard};
+
+/// The offset of the token standard byte in the master edition
+/// from the end of the account data.
+const TOKEN_STANDARD_OFFSET: usize = 1;
+
 /// Removes all null bytes from a string.
 pub fn clean(value: String) -> String {
     value.replace('\0', "")
+}
+
+/// Checks that the `master_edition` is Programmable NFT master edition.
+pub fn assert_edition_is_programmable(edition_data: &[u8]) -> Result<(), MplTokenMetadataError> {
+    if !edition_data.is_empty()
+        && edition_data[edition_data.len() - TOKEN_STANDARD_OFFSET]
+            == TokenStandard::ProgrammableNonFungible as u8
+    {
+        Ok(())
+    } else {
+        Err(MplTokenMetadataError::InvalidTokenStandard)
+    }
 }

--- a/clients/rust/src/utils.rs
+++ b/clients/rust/src/utils.rs
@@ -40,5 +40,5 @@ pub fn assert_edition_is_programmable(edition_data: &[u8]) -> Result<(), MplToke
         }
     }
 
-    Err(MplTokenMetadataError::DataIsEmptyOrZeroed)
+    Err(MplTokenMetadataError::InvalidTokenStandard)
 }

--- a/clients/rust/src/utils.rs
+++ b/clients/rust/src/utils.rs
@@ -21,23 +21,22 @@ pub fn assert_edition_is_programmable(edition_data: &[u8]) -> Result<(), MplToke
         let key = Key::deserialize(&mut &edition_data[0..1])
             .map_err(|_error| MplTokenMetadataError::InvalidEditionKey)?;
 
-        if matches!(key, Key::MasterEditionV1 | Key::MasterEditionV2) {
-            // the last byte is the token standard
-            let standard = TokenStandard::deserialize(
-                &mut &edition_data[edition_data.len() - TOKEN_STANDARD_OFFSET..],
-            )
-            .map_err(|_error| MplTokenMetadataError::InvalidTokenStandard)?;
+        return match key {
+            Key::MasterEditionV1 | Key::MasterEditionV2 => {
+                // the last byte is the token standard
+                let standard = TokenStandard::deserialize(
+                    &mut &edition_data[edition_data.len() - TOKEN_STANDARD_OFFSET..],
+                )
+                .map_err(|_error| MplTokenMetadataError::InvalidTokenStandard)?;
 
-            return if matches!(
-                standard,
-                TokenStandard::ProgrammableNonFungible
-                    | TokenStandard::ProgrammableNonFungibleEdition
-            ) {
-                Ok(())
-            } else {
-                Err(MplTokenMetadataError::InvalidTokenStandard)
-            };
-        }
+                return match standard {
+                    TokenStandard::ProgrammableNonFungible
+                    | TokenStandard::ProgrammableNonFungibleEdition => Ok(()),
+                    _ => Err(MplTokenMetadataError::InvalidTokenStandard),
+                };
+            }
+            _ => Err(MplTokenMetadataError::InvalidEditionKey),
+        };
     }
 
     Err(MplTokenMetadataError::InvalidMasterEditionAccountLength)

--- a/idls/token_metadata.json
+++ b/idls/token_metadata.json
@@ -2288,7 +2288,7 @@
         },
         {
           "name": "collectionMasterEditionAccount",
-          "isMut": true,
+          "isMut": false,
           "isSigner": false,
           "docs": [
             "MasterEdition2 Account of the Collection Token"

--- a/programs/token-metadata/program/src/instruction/mod.rs
+++ b/programs/token-metadata/program/src/instruction/mod.rs
@@ -431,7 +431,7 @@ pub enum MetadataInstruction {
     #[account(3, name="update_authority", desc="Update Authority of Collection NFT and NFT")]
     #[account(4, name="collection_mint", desc="Mint of the Collection")]
     #[account(5, writable, name="collection", desc="Metadata Account of the Collection")]
-    #[account(6, writable, name="collection_master_edition_account", desc="MasterEdition2 Account of the Collection Token")]
+    #[account(6, name="collection_master_edition_account", desc="MasterEdition2 Account of the Collection Token")]
     #[account(7, optional, name="collection_authority_record", desc="Collection Authority Record PDA")]
     #[legacy_optional_accounts_strategy]
     SetAndVerifySizedCollectionItem,


### PR DESCRIPTION
This PR adds an `assert_edition_is_programmable` helper to determine if the master edition is a `ProgrammableNonFungible` or not. It also includes a fix on a Shank annotation – this does not require changes to the program.