### PR TITLE
Fix shank annotation

### DIFF
--- a/clients/js/src/generated/instructions/bubblegumSetCollectionSize.ts
+++ b/clients/js/src/generated/instructions/bubblegumSetCollectionSize.ts
@@ -103,7 +103,7 @@ export function bubblegumSetCollectionSize(
     },
     collectionAuthority: {
       index: 1,
-      isWritable: true as boolean,
+      isWritable: false as boolean,
       value: input.collectionAuthority ?? null,
     },
     collectionMint: {

--- a/clients/rust/src/generated/instructions/bubblegum_set_collection_size.rs
+++ b/clients/rust/src/generated/instructions/bubblegum_set_collection_size.rs
@@ -41,7 +41,7 @@ impl BubblegumSetCollectionSize {
             self.collection_metadata,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.collection_authority,
             true,
         ));
@@ -96,7 +96,7 @@ pub struct BubblegumSetCollectionSizeInstructionArgs {
 /// ### Accounts:
 ///
 ///   0. `[writable]` collection_metadata
-///   1. `[writable, signer]` collection_authority
+///   1. `[signer]` collection_authority
 ///   2. `[]` collection_mint
 ///   3. `[signer]` bubblegum_signer
 ///   4. `[optional]` collection_authority_record
@@ -297,7 +297,7 @@ impl<'a, 'b> BubblegumSetCollectionSizeCpi<'a, 'b> {
             *self.collection_metadata.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new(
+        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             *self.collection_authority.key,
             true,
         ));
@@ -359,7 +359,7 @@ impl<'a, 'b> BubblegumSetCollectionSizeCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[writable]` collection_metadata
-///   1. `[writable, signer]` collection_authority
+///   1. `[signer]` collection_authority
 ///   2. `[]` collection_mint
 ///   3. `[signer]` bubblegum_signer
 ///   4. `[optional]` collection_authority_record

--- a/idls/token_metadata.json
+++ b/idls/token_metadata.json
@@ -2495,7 +2495,7 @@
         },
         {
           "name": "collectionAuthority",
-          "isMut": true,
+          "isMut": false,
           "isSigner": true,
           "docs": [
             "Collection Update authority"

--- a/programs/token-metadata/program/src/instruction/mod.rs
+++ b/programs/token-metadata/program/src/instruction/mod.rs
@@ -466,7 +466,7 @@ pub enum MetadataInstruction {
     /// Set size of an existing collection using CPI from the Bubblegum program.  This is how
     /// collection size is incremented and decremented for compressed NFTs.
     #[account(0, writable, name="collection_metadata", desc="Collection Metadata account")]
-    #[account(1, signer, writable, name="collection_authority", desc="Collection Update authority")]
+    #[account(1, signer, name="collection_authority", desc="Collection Update authority")]
     #[account(2, name="collection_mint", desc="Mint of the Collection")]
     #[account(3, signer, name="bubblegum_signer", desc="Signing PDA of Bubblegum program")]
     #[account(4, optional, name="collection_authority_record", desc="Collection Authority Record PDA")]


### PR DESCRIPTION
This PR fixes the shank annotation on `BubblegumSetCollectionSize` instruction so the Rust client is correctly generated.