### PR TITLE
Revert to optional token owner on mint

### DIFF
--- a/clients/js/src/generated/instructions/mintV1.ts
+++ b/clients/js/src/generated/instructions/mintV1.ts
@@ -27,7 +27,7 @@ import {
   u64,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { resolveIsNonFungible } from '../../hooked';
+import { resolveIsNonFungible, resolveOptionalTokenOwner } from '../../hooked';
 import {
   findMasterEditionPda,
   findMetadataPda,
@@ -52,7 +52,7 @@ export type MintV1InstructionAccounts = {
   /** Token or Associated Token account */
   token?: PublicKey | Pda;
   /** Owner of the token account */
-  tokenOwner: PublicKey | Pda;
+  tokenOwner?: PublicKey | Pda;
   /** Metadata account (pda of ['metadata', program id, mint id]) */
   metadata?: PublicKey | Pda;
   /** Master Edition account */
@@ -215,6 +215,18 @@ export function mintV1(
   const resolvedArgs: MintV1InstructionArgs = { ...input };
 
   // Default values.
+  if (!resolvedAccounts.tokenOwner.value) {
+    resolvedAccounts.tokenOwner = {
+      ...resolvedAccounts.tokenOwner,
+      ...resolveOptionalTokenOwner(
+        context,
+        resolvedAccounts,
+        resolvedArgs,
+        programId,
+        false
+      ),
+    };
+  }
   if (!resolvedAccounts.token.value) {
     resolvedAccounts.token.value = findAssociatedTokenPda(context, {
       mint: expectPublicKey(resolvedAccounts.mint.value),

--- a/clients/rust/src/generated/instructions/mint.rs
+++ b/clients/rust/src/generated/instructions/mint.rs
@@ -14,7 +14,7 @@ pub struct Mint {
     /// Token or Associated Token account
     pub token: solana_program::pubkey::Pubkey,
     /// Owner of the token account
-    pub token_owner: solana_program::pubkey::Pubkey,
+    pub token_owner: Option<solana_program::pubkey::Pubkey>,
     /// Metadata account (pda of ['metadata', program id, mint id])
     pub metadata: solana_program::pubkey::Pubkey,
     /// Master Edition account
@@ -60,10 +60,17 @@ impl Mint {
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.token, false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            self.token_owner,
-            false,
-        ));
+        if let Some(token_owner) = self.token_owner {
+            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+                token_owner,
+                false,
+            ));
+        } else {
+            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+                crate::MPL_TOKEN_METADATA_ID,
+                false,
+            ));
+        }
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.metadata,
             false,
@@ -184,7 +191,7 @@ pub struct MintInstructionArgs {
 /// ### Accounts:
 ///
 ///   0. `[writable]` token
-///   1. `[]` token_owner
+///   1. `[optional]` token_owner
 ///   2. `[]` metadata
 ///   3. `[writable, optional]` master_edition
 ///   4. `[writable, optional]` token_record
@@ -229,10 +236,14 @@ impl MintBuilder {
         self.token = Some(token);
         self
     }
+    /// `[optional account]`
     /// Owner of the token account
     #[inline(always)]
-    pub fn token_owner(&mut self, token_owner: solana_program::pubkey::Pubkey) -> &mut Self {
-        self.token_owner = Some(token_owner);
+    pub fn token_owner(
+        &mut self,
+        token_owner: Option<solana_program::pubkey::Pubkey>,
+    ) -> &mut Self {
+        self.token_owner = token_owner;
         self
     }
     /// Metadata account (pda of ['metadata', program id, mint id])
@@ -373,7 +384,7 @@ impl MintBuilder {
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
         let accounts = Mint {
             token: self.token.expect("token is not set"),
-            token_owner: self.token_owner.expect("token_owner is not set"),
+            token_owner: self.token_owner,
             metadata: self.metadata.expect("metadata is not set"),
             master_edition: self.master_edition,
             token_record: self.token_record,
@@ -409,7 +420,7 @@ pub struct MintCpiAccounts<'a, 'b> {
     /// Token or Associated Token account
     pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner of the token account
-    pub token_owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata account (pda of ['metadata', program id, mint id])
     pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
@@ -445,7 +456,7 @@ pub struct MintCpi<'a, 'b> {
     /// Token or Associated Token account
     pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner of the token account
-    pub token_owner: &'b solana_program::account_info::AccountInfo<'a>,
+    pub token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Metadata account (pda of ['metadata', program id, mint id])
     pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
@@ -540,10 +551,17 @@ impl<'a, 'b> MintCpi<'a, 'b> {
             *self.token.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
-            *self.token_owner.key,
-            false,
-        ));
+        if let Some(token_owner) = self.token_owner {
+            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+                *token_owner.key,
+                false,
+            ));
+        } else {
+            accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+                crate::MPL_TOKEN_METADATA_ID,
+                false,
+            ));
+        }
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             *self.metadata.key,
             false,
@@ -650,7 +668,9 @@ impl<'a, 'b> MintCpi<'a, 'b> {
         let mut account_infos = Vec::with_capacity(15 + 1 + remaining_accounts.len());
         account_infos.push(self.__program.clone());
         account_infos.push(self.token.clone());
-        account_infos.push(self.token_owner.clone());
+        if let Some(token_owner) = self.token_owner {
+            account_infos.push(token_owner.clone());
+        }
         account_infos.push(self.metadata.clone());
         if let Some(master_edition) = self.master_edition {
             account_infos.push(master_edition.clone());
@@ -691,7 +711,7 @@ impl<'a, 'b> MintCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[writable]` token
-///   1. `[]` token_owner
+///   1. `[optional]` token_owner
 ///   2. `[]` metadata
 ///   3. `[writable, optional]` master_edition
 ///   4. `[writable, optional]` token_record
@@ -739,13 +759,14 @@ impl<'a, 'b> MintCpiBuilder<'a, 'b> {
         self.instruction.token = Some(token);
         self
     }
+    /// `[optional account]`
     /// Owner of the token account
     #[inline(always)]
     pub fn token_owner(
         &mut self,
-        token_owner: &'b solana_program::account_info::AccountInfo<'a>,
+        token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
-        self.instruction.token_owner = Some(token_owner);
+        self.instruction.token_owner = token_owner;
         self
     }
     /// Metadata account (pda of ['metadata', program id, mint id])
@@ -922,10 +943,7 @@ impl<'a, 'b> MintCpiBuilder<'a, 'b> {
 
             token: self.instruction.token.expect("token is not set"),
 
-            token_owner: self
-                .instruction
-                .token_owner
-                .expect("token_owner is not set"),
+            token_owner: self.instruction.token_owner,
 
             metadata: self.instruction.metadata.expect("metadata is not set"),
 

--- a/configs/kinobi.cjs
+++ b/configs/kinobi.cjs
@@ -194,6 +194,9 @@ kinobi.update(
             }
           ),
         },
+        tokenOwner: {
+          defaultsTo: k.resolverDefault("resolveOptionalTokenOwner", []),
+        },
         token: {
           defaultsTo: ataPdaDefault("mint", "tokenOwner"),
         },

--- a/idls/token_metadata.json
+++ b/idls/token_metadata.json
@@ -3154,6 +3154,7 @@
           "name": "tokenOwner",
           "isMut": false,
           "isSigner": false,
+          "isOptional": true,
           "docs": [
             "Owner of the token account"
           ]

--- a/programs/token-metadata/program/src/instruction/metadata.rs
+++ b/programs/token-metadata/program/src/instruction/metadata.rs
@@ -685,7 +685,7 @@ impl InstructionBuilder for super::builders::Mint {
     fn instruction(&self) -> solana_program::instruction::Instruction {
         let mut accounts = vec![
             AccountMeta::new(self.token, false),
-            AccountMeta::new_readonly(self.token_owner, false),
+            AccountMeta::new_readonly(self.token_owner.unwrap_or(crate::ID), false),
             AccountMeta::new_readonly(self.metadata, false),
             if let Some(master_edition) = self.master_edition {
                 AccountMeta::new(master_edition, false)

--- a/programs/token-metadata/program/src/instruction/mod.rs
+++ b/programs/token-metadata/program/src/instruction/mod.rs
@@ -597,7 +597,7 @@ pub enum MetadataInstruction {
     /// must be the update authority; in all other cases, it must be the mint authority from the mint
     /// account.
     #[account(0, writable, name="token", desc="Token or Associated Token account")]
-    #[account(1, name="token_owner", desc="Owner of the token account")]
+    #[account(1, optional, name="token_owner", desc="Owner of the token account")]
     #[account(2, name="metadata", desc="Metadata account (pda of ['metadata', program id, mint id])")]
     #[account(3, optional, writable, name="master_edition", desc="Master Edition account")]
     #[account(4, optional, writable, name="token_record", desc="Token record account")]

--- a/programs/token-metadata/program/src/processor/metadata/mint.rs
+++ b/programs/token-metadata/program/src/processor/metadata/mint.rs
@@ -113,17 +113,24 @@ pub fn mint_v1(program_id: &Pubkey, ctx: Context<Mint>, args: MintArgs) -> Progr
     // validates the token account
 
     if ctx.accounts.token_info.data_is_empty() {
+        // if we are initializing a new account, we need the token_owner
+        let token_owner_info = if let Some(token_owner_info) = ctx.accounts.token_owner_info {
+            token_owner_info
+        } else {
+            return Err(MetadataError::MissingTokenOwnerAccount.into());
+        };
+
         // creating the associated token account
         invoke(
             &spl_associated_token_account::instruction::create_associated_token_account(
                 ctx.accounts.payer_info.key,
-                ctx.accounts.token_owner_info.key,
+                token_owner_info.key,
                 ctx.accounts.mint_info.key,
                 ctx.accounts.spl_token_program_info.key,
             ),
             &[
                 ctx.accounts.payer_info.clone(),
-                ctx.accounts.token_owner_info.clone(),
+                token_owner_info.clone(),
                 ctx.accounts.mint_info.clone(),
                 ctx.accounts.token_info.clone(),
             ],

--- a/programs/token-metadata/program/src/processor/metadata/print.rs
+++ b/programs/token-metadata/program/src/processor/metadata/print.rs
@@ -151,7 +151,7 @@ fn print_v1(_program_id: &Pubkey, ctx: Context<Print>, args: PrintArgs) -> Progr
         let token = validate_token(
             edition_mint_info,
             edition_token_account_info,
-            edition_token_account_owner_info,
+            Some(edition_token_account_owner_info),
             token_program,
             Some(token_standard),
             Some(1), // we must have a token already

--- a/programs/token-metadata/program/src/processor/metadata/transfer.rs
+++ b/programs/token-metadata/program/src/processor/metadata/transfer.rs
@@ -143,7 +143,7 @@ fn transfer_v1(program_id: &Pubkey, ctx: Context<Transfer>, args: TransferArgs) 
         let token = validate_token(
             ctx.accounts.mint_info,
             ctx.accounts.destination_info,
-            ctx.accounts.destination_owner_info,
+            Some(ctx.accounts.destination_owner_info),
             ctx.accounts.spl_token_program_info,
             metadata.token_standard,
             None, // we already checked the supply of the mint account

--- a/programs/token-metadata/program/src/utils/token.rs
+++ b/programs/token-metadata/program/src/utils/token.rs
@@ -208,7 +208,7 @@ pub(crate) fn validate_mint(
 pub(crate) fn validate_token(
     mint: &AccountInfo,
     token: &AccountInfo,
-    token_owner: &AccountInfo,
+    token_owner: Option<&AccountInfo>,
     spl_token_program: &AccountInfo,
     token_standard: Option<TokenStandard>,
     required_amount: Option<u64>,
@@ -224,8 +224,10 @@ pub(crate) fn validate_token(
         return Err(MetadataError::MintMismatch.into());
     }
 
-    if token.base.owner != *token_owner.key {
-        return Err(MetadataError::IncorrectOwner.into());
+    if let Some(token_owner) = token_owner {
+        if token.base.owner != *token_owner.key {
+            return Err(MetadataError::IncorrectOwner.into());
+        }
     }
 
     if let Some(amount) = required_amount {


### PR DESCRIPTION
This PR reverts to optional token owner on mint to avoid a breaking change.