### PR TITLE
Fix misleading InstructionNotSupported error message

### DIFF
--- a/programs/token-metadata/program/src/error.rs
+++ b/programs/token-metadata/program/src/error.rs
@@ -601,7 +601,7 @@ pub enum MetadataError {
     InvalidTransferAuthority,
 
     /// 153
-    #[error("Instruction not supported for ProgrammableNonFungible assets")]
+    #[error("Instruction not supported for ProgrammableNonFungible or Token2022 assets")]
     InstructionNotSupported,
 
     /// 154


### PR DESCRIPTION
A simple fix for the misleading error message of InstructionNotSupported error which occurs when you call a legacy instruction that isn't supported by **pNFT OR Token2022**

Thanks to @samuelvanderwaal for pointing that out