### PR TITLE
Use `DelegateScenario` to combine Metadata and Holder delegate functionality

### DIFF
--- a/programs/token-metadata/program/src/processor/delegate/delegate.rs
+++ b/programs/token-metadata/program/src/processor/delegate/delegate.rs
@@ -155,7 +155,7 @@ pub fn delegate<'a>(
     };
 
     if let Some((role, _authorization_data)) = delegate_args {
-        return create_metadata_delegate_v1(program_id, context, args, role);
+        return create_delegate_v1(program_id, context, DelegateScenario::Metadata(role));
     }
 
     // checks if it is a HolderDelegate creation
@@ -169,7 +169,7 @@ pub fn delegate<'a>(
     };
 
     if let Some((role, _authorization_data)) = delegate_args {
-        return create_holder_delegate_v1(program_id, context, args, role);
+        return create_delegate_v1(program_id, context, DelegateScenario::Holder(role));
     }
 
     // this only happens if we did not find a match
@@ -179,24 +179,20 @@ pub fn delegate<'a>(
 /// Creates a `DelegateRole::Collection` delegate.
 ///
 /// There can be multiple collections delegates set at any time.
-fn create_metadata_delegate_v1(
+fn create_delegate_v1(
     program_id: &Pubkey,
     ctx: Context<Delegate>,
-    _args: DelegateArgs,
-    role: MetadataDelegateRole,
+    delegate_scenario: DelegateScenario,
 ) -> ProgramResult {
     // signers
-
     assert_signer(ctx.accounts.payer_info)?;
     assert_signer(ctx.accounts.authority_info)?;
 
     // ownership
-
     assert_owned_by(ctx.accounts.metadata_info, program_id)?;
     assert_owner_in(ctx.accounts.mint_info, &SPL_TOKEN_PROGRAM_IDS)?;
 
     // key match
-
     assert_keys_equal(ctx.accounts.system_program_info.key, &system_program::ID)?;
     assert_keys_equal(
         ctx.accounts.sysvar_instructions_info.key,
@@ -204,13 +200,35 @@ fn create_metadata_delegate_v1(
     )?;
 
     // account relationships
-
     let metadata = Metadata::from_account_info(ctx.accounts.metadata_info)?;
-    // authority must match update authority
-    assert_update_authority_is_correct(&metadata, ctx.accounts.authority_info)?;
-
     if metadata.mint != *ctx.accounts.mint_info.key {
         return Err(MetadataError::MintMismatch.into());
+    }
+
+    match delegate_scenario {
+        DelegateScenario::Metadata(_) => {
+            // authority must match update authority
+            assert_update_authority_is_correct(&metadata, ctx.accounts.authority_info)?;
+        }
+        DelegateScenario::Holder(_) => {
+            // ownership for token
+            let token_info = match ctx.accounts.token_info {
+                Some(token_info) => token_info,
+                None => {
+                    return Err(MetadataError::MissingTokenAccount.into());
+                }
+            };
+
+            assert_owner_in(token_info, &SPL_TOKEN_PROGRAM_IDS)?;
+
+            // authority must be the owner of the token account: spl-token required the
+            // token owner to set a delegate
+            let token = unpack::<Account>(&token_info.try_borrow_data()?)?;
+            if token.owner != *ctx.accounts.authority_info.key {
+                return Err(MetadataError::IncorrectOwner.into());
+            }
+        }
+        _ => return Err(MetadataError::InvalidDelegateRole.into()),
     }
 
     let delegate_record_info = match ctx.accounts.delegate_record_info {
@@ -231,79 +249,7 @@ fn create_metadata_delegate_v1(
         ctx.accounts.authority_info,
         ctx.accounts.payer_info,
         ctx.accounts.system_program_info,
-        &Some(role),
-        &None,
-    )
-}
-
-fn create_holder_delegate_v1(
-    program_id: &Pubkey,
-    ctx: Context<Delegate>,
-    _args: DelegateArgs,
-    role: HolderDelegateRole,
-) -> ProgramResult {
-    // retrieving required optional accounts
-
-    let token_info = match ctx.accounts.token_info {
-        Some(token_info) => token_info,
-        None => {
-            return Err(MetadataError::MissingTokenAccount.into());
-        }
-    };
-
-    // signers
-
-    assert_signer(ctx.accounts.payer_info)?;
-    assert_signer(ctx.accounts.authority_info)?;
-
-    // ownership
-
-    assert_owned_by(ctx.accounts.metadata_info, program_id)?;
-    assert_owner_in(ctx.accounts.mint_info, &SPL_TOKEN_PROGRAM_IDS)?;
-    assert_owner_in(token_info, &SPL_TOKEN_PROGRAM_IDS)?;
-
-    // key match
-
-    assert_keys_equal(ctx.accounts.system_program_info.key, &system_program::ID)?;
-    assert_keys_equal(
-        ctx.accounts.sysvar_instructions_info.key,
-        &sysvar::instructions::ID,
-    )?;
-
-    // account relationships
-
-    let metadata = Metadata::from_account_info(ctx.accounts.metadata_info)?;
-    if metadata.mint != *ctx.accounts.mint_info.key {
-        return Err(MetadataError::MintMismatch.into());
-    }
-
-    // authority must be the owner of the token account: spl-token required the
-    // token owner to set a delegate
-    let token = unpack::<Account>(&token_info.try_borrow_data()?)?;
-    if token.owner != *ctx.accounts.authority_info.key {
-        return Err(MetadataError::IncorrectOwner.into());
-    }
-
-    let delegate_record_info = match ctx.accounts.delegate_record_info {
-        Some(delegate_record_info) => delegate_record_info,
-        None => {
-            return Err(MetadataError::MissingDelegateRecord.into());
-        }
-    };
-
-    // process the delegation creation (the derivation is checked
-    // by the create helper)
-
-    create_pda_account(
-        program_id,
-        delegate_record_info,
-        ctx.accounts.delegate_info,
-        ctx.accounts.mint_info,
-        ctx.accounts.authority_info,
-        ctx.accounts.payer_info,
-        ctx.accounts.system_program_info,
-        &None,
-        &Some(role),
+        delegate_scenario,
     )
 }
 
@@ -579,14 +525,13 @@ fn create_pda_account<'a>(
     authority_info: &'a AccountInfo<'a>,
     payer_info: &'a AccountInfo<'a>,
     system_program_info: &'a AccountInfo<'a>,
-    metadata_delegate_role: &Option<MetadataDelegateRole>,
-    holder_delegate_role: &Option<HolderDelegateRole>,
+    delegate_scenario: DelegateScenario,
 ) -> ProgramResult {
     // validates the delegate derivation
 
-    let delegate_role = match (metadata_delegate_role, holder_delegate_role) {
-        (Some(role), None) => role.to_string(),
-        (None, Some(role)) => role.to_string(),
+    let delegate_role = match delegate_scenario {
+        DelegateScenario::Metadata(role) => role.to_string(),
+        DelegateScenario::Holder(role) => role.to_string(),
         _ => return Err(MetadataError::InvalidDelegateRole.into()),
     };
 
@@ -620,8 +565,8 @@ fn create_pda_account<'a>(
         &signer_seeds,
     )?;
 
-    match (metadata_delegate_role, holder_delegate_role) {
-        (Some(_), None) => {
+    match delegate_scenario {
+        DelegateScenario::Metadata(_) => {
             let pda = MetadataDelegateRecord {
                 bump: bump[0],
                 mint: *mint_info.key,
@@ -631,7 +576,7 @@ fn create_pda_account<'a>(
             };
             borsh::to_writer(&mut delegate_record_info.try_borrow_mut_data()?[..], &pda)?;
         }
-        (None, Some(_)) => {
+        DelegateScenario::Holder(_) => {
             let pda = HolderDelegateRecord {
                 bump: bump[0],
                 mint: *mint_info.key,

--- a/programs/token-metadata/program/src/processor/delegate/revoke.rs
+++ b/programs/token-metadata/program/src/processor/delegate/revoke.rs
@@ -1,7 +1,7 @@
 use mpl_utils::{assert_signer, close_account_raw, cmp_pubkeys, token::SPL_TOKEN_PROGRAM_IDS};
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, program::invoke, program_option::COption,
-    pubkey::Pubkey, system_program, sysvar,
+    account_info::AccountInfo, entrypoint::ProgramResult, program::invoke,
+    program_error::ProgramError, program_option::COption, pubkey::Pubkey, system_program, sysvar,
 };
 use spl_token_2022::state::Account;
 
@@ -16,6 +16,7 @@ use crate::{
         find_holder_delegate_record_account, find_metadata_delegate_record_account,
         find_token_record_account,
     },
+    processor::DelegateScenario,
     state::{
         HolderDelegateRecord, Metadata, MetadataDelegateRecord, Resizable, TokenDelegateRole,
         TokenMetadataAccount, TokenRecord, TokenStandard,
@@ -73,7 +74,7 @@ pub fn revoke<'a>(
     };
 
     if let Some(role) = metadata_delegate {
-        return revoke_metadata_delegate_v1(program_id, context, role);
+        return revoke_other_delegate_v1(program_id, context, DelegateScenario::Metadata(role));
     }
 
     // checks if it is a HolderDelegate creation
@@ -84,17 +85,17 @@ pub fn revoke<'a>(
     };
 
     if let Some(role) = holder_delegate {
-        return revoke_holder_delegate_v1(program_id, context, role);
+        return revoke_other_delegate_v1(program_id, context, DelegateScenario::Holder(role));
     }
 
     // this only happens if we did not find a match
     Err(MetadataError::InvalidDelegateArgs.into())
 }
 
-fn revoke_metadata_delegate_v1(
+fn revoke_other_delegate_v1(
     program_id: &Pubkey,
     ctx: Context<Revoke>,
-    role: MetadataDelegateRole,
+    delegate_scenario: DelegateScenario,
 ) -> ProgramResult {
     // signers
 
@@ -116,6 +117,13 @@ fn revoke_metadata_delegate_v1(
 
     // account relationships
 
+    let metadata = Metadata::from_account_info(ctx.accounts.metadata_info)?;
+    if metadata.mint != *ctx.accounts.mint_info.key {
+        return Err(MetadataError::MintMismatch.into());
+    }
+
+    // retrieving required optional account
+
     let delegate_record_info = match ctx.accounts.delegate_record_info {
         Some(delegate_record_info) => delegate_record_info,
         None => {
@@ -123,39 +131,57 @@ fn revoke_metadata_delegate_v1(
         }
     };
 
-    let metadata = Metadata::from_account_info(ctx.accounts.metadata_info)?;
     // there are two scenarios here:
     //   1. authority is equal to delegate: delegate as a signer is self-revoking
-    //   2. otherwise we need the update authority as a signer
-    let approver = if cmp_pubkeys(
+    //   2. otherwise for Metadata delegate we need the update authority as a signer or for
+    //      Holder delegate we need the holder as a signer.
+    let self_revoking = cmp_pubkeys(
         ctx.accounts.delegate_info.key,
         ctx.accounts.authority_info.key,
-    ) {
-        match MetadataDelegateRecord::from_account_info(delegate_record_info) {
-            Ok(delegate_record) => {
-                if cmp_pubkeys(&delegate_record.delegate, ctx.accounts.authority_info.key) {
-                    delegate_record.update_authority
-                } else {
-                    return Err(MetadataError::InvalidDelegate.into());
-                }
-            }
-            Err(_) => {
-                return Err(MetadataError::DelegateNotFound.into());
-            }
-        }
+    );
+
+    let approver = if self_revoking {
+        get_delegate_record_update_authority(
+            &delegate_scenario,
+            delegate_record_info,
+            ctx.accounts.authority_info.key,
+        )?
     } else {
-        assert_update_authority_is_correct(&metadata, ctx.accounts.authority_info)?;
-        *ctx.accounts.authority_info.key
+        match delegate_scenario {
+            DelegateScenario::Metadata(_) => {
+                // authority must match update authority
+                assert_update_authority_is_correct(&metadata, ctx.accounts.authority_info)?;
+                *ctx.accounts.authority_info.key
+            }
+
+            DelegateScenario::Holder(_) => {
+                // retrieving required optional account
+                let token_info = match ctx.accounts.token_info {
+                    Some(token_info) => token_info,
+                    None => {
+                        return Err(MetadataError::MissingTokenAccount.into());
+                    }
+                };
+
+                // ownership for token
+                assert_owner_in(token_info, &SPL_TOKEN_PROGRAM_IDS)?;
+
+                // authority must be the owner of the token account: spl-token required the
+                // token owner to set a delegate
+                let token = unpack::<Account>(&token_info.try_borrow_data()?)?;
+                if token.owner != *ctx.accounts.authority_info.key {
+                    return Err(MetadataError::IncorrectOwner.into());
+                }
+                *ctx.accounts.authority_info.key
+            }
+
+            _ => return Err(MetadataError::InvalidDelegateRole.into()),
+        }
     };
 
-    if metadata.mint != *ctx.accounts.mint_info.key {
-        return Err(MetadataError::MintMismatch.into());
-    }
-
     // closes the delegate record
-
-    close_metadata_delegate_record(
-        role,
+    close_other_delegate_record(
+        delegate_scenario,
         delegate_record_info,
         ctx.accounts.delegate_info.key,
         ctx.accounts.mint_info.key,
@@ -164,97 +190,30 @@ fn revoke_metadata_delegate_v1(
     )
 }
 
-fn revoke_holder_delegate_v1(
-    program_id: &Pubkey,
-    ctx: Context<Revoke>,
-    role: HolderDelegateRole,
-) -> ProgramResult {
-    // retrieving required optional accounts
-
-    let token_info = match ctx.accounts.token_info {
-        Some(token_info) => token_info,
-        None => {
-            return Err(MetadataError::MissingTokenAccount.into());
+fn get_delegate_record_update_authority(
+    delegate_scenario: &DelegateScenario,
+    delegate_record_info: &AccountInfo,
+    authority: &Pubkey,
+) -> Result<Pubkey, ProgramError> {
+    let delegate_record_update_authority = match delegate_scenario {
+        DelegateScenario::Metadata(_) => {
+            MetadataDelegateRecord::from_account_info(delegate_record_info)
+                .map_err(|_| MetadataError::DelegateNotFound)?
+                .update_authority
         }
+        DelegateScenario::Holder(_) => {
+            HolderDelegateRecord::from_account_info(delegate_record_info)
+                .map_err(|_| MetadataError::DelegateNotFound)?
+                .update_authority
+        }
+        _ => return Err(MetadataError::InvalidDelegateRole.into()),
     };
 
-    // signers
-
-    assert_signer(ctx.accounts.payer_info)?;
-    assert_signer(ctx.accounts.authority_info)?;
-
-    // ownership
-
-    assert_owned_by(ctx.accounts.metadata_info, program_id)?;
-    assert_owner_in(ctx.accounts.mint_info, &SPL_TOKEN_PROGRAM_IDS)?;
-    assert_owner_in(ctx.accounts.mint_info, &SPL_TOKEN_PROGRAM_IDS)?;
-    // key match
-
-    assert_keys_equal(ctx.accounts.system_program_info.key, &system_program::ID)?;
-    assert_keys_equal(
-        ctx.accounts.sysvar_instructions_info.key,
-        &sysvar::instructions::ID,
-    )?;
-
-    // account relationships
-
-    let metadata = Metadata::from_account_info(ctx.accounts.metadata_info)?;
-    if metadata.mint != *ctx.accounts.mint_info.key {
-        return Err(MetadataError::MintMismatch.into());
-    }
-
-    let delegate_record_info = match ctx.accounts.delegate_record_info {
-        Some(delegate_record_info) => delegate_record_info,
-        None => {
-            return Err(MetadataError::MissingDelegateRecord.into());
-        }
-    };
-
-    // authority must be the owner of the token account: spl-token required the
-    // token owner to revoke a delegate
-    let token = unpack::<Account>(&token_info.try_borrow_data()?)?;
-    if token.owner != *ctx.accounts.authority_info.key {
-        return Err(MetadataError::IncorrectOwner.into());
-    }
-
-    // there are two scenarios here:
-    //   1. authority is equal to delegate: delegate as a signer is self-revoking
-    //   2. otherwise we need the original holder as a signer
-    let approver = if cmp_pubkeys(
-        ctx.accounts.delegate_info.key,
-        ctx.accounts.authority_info.key,
-    ) {
-        match HolderDelegateRecord::from_account_info(delegate_record_info) {
-            Ok(delegate_record) => {
-                if cmp_pubkeys(&delegate_record.delegate, ctx.accounts.authority_info.key) {
-                    delegate_record.update_authority
-                } else {
-                    return Err(MetadataError::InvalidDelegate.into());
-                }
-            }
-            Err(_) => {
-                return Err(MetadataError::DelegateNotFound.into());
-            }
-        }
+    if cmp_pubkeys(&delegate_record_update_authority, authority) {
+        Ok(delegate_record_update_authority)
     } else {
-        assert_update_authority_is_correct(&metadata, ctx.accounts.authority_info)?;
-        *ctx.accounts.authority_info.key
-    };
-
-    if metadata.mint != *ctx.accounts.mint_info.key {
-        return Err(MetadataError::MintMismatch.into());
+        Err(MetadataError::InvalidDelegate.into())
     }
-
-    // closes the delegate record
-
-    close_holder_delegate_record(
-        role,
-        delegate_record_info,
-        ctx.accounts.delegate_info.key,
-        ctx.accounts.mint_info.key,
-        &approver,
-        ctx.accounts.payer_info,
-    )
 }
 
 fn revoke_persistent_delegate_v1(
@@ -436,8 +395,8 @@ fn revoke_persistent_delegate_v1(
 ///
 /// It checks that the derivation is correct before closing
 /// the delegate record account.
-fn close_metadata_delegate_record<'a>(
-    role: MetadataDelegateRole,
+fn close_other_delegate_record<'a>(
+    delegate_scenario: DelegateScenario,
     delegate_record_info: &'a AccountInfo<'a>,
     delegate: &Pubkey,
     mint: &Pubkey,
@@ -448,33 +407,15 @@ fn close_metadata_delegate_record<'a>(
         return Err(MetadataError::Uninitialized.into());
     }
 
-    let (pda_key, _) = find_metadata_delegate_record_account(mint, role, approver, delegate);
-
-    if pda_key != *delegate_record_info.key {
-        Err(MetadataError::DerivedKeyInvalid.into())
-    } else {
-        // closes the delegate account
-        close_account_raw(payer_info, delegate_record_info)
-    }
-}
-
-/// Closes a delegate PDA.
-///
-/// It checks that the derivation is correct before closing
-/// the delegate record account.
-fn close_holder_delegate_record<'a>(
-    role: HolderDelegateRole,
-    delegate_record_info: &'a AccountInfo<'a>,
-    delegate: &Pubkey,
-    mint: &Pubkey,
-    approver: &Pubkey,
-    payer_info: &'a AccountInfo<'a>,
-) -> ProgramResult {
-    if delegate_record_info.data_is_empty() {
-        return Err(MetadataError::Uninitialized.into());
-    }
-
-    let (pda_key, _) = find_holder_delegate_record_account(mint, role, approver, delegate);
+    let (pda_key, _) = match delegate_scenario {
+        DelegateScenario::Metadata(role) => {
+            find_metadata_delegate_record_account(mint, role, approver, delegate)
+        }
+        DelegateScenario::Holder(role) => {
+            find_holder_delegate_record_account(mint, role, approver, delegate)
+        }
+        _ => return Err(MetadataError::InvalidDelegateRole.into()),
+    };
 
     if pda_key != *delegate_record_info.key {
         Err(MetadataError::DerivedKeyInvalid.into())


### PR DESCRIPTION
### Idea 
* See comment in https://github.com/metaplex-foundation/mpl-token-metadata/pull/84
* We could make use of the `DelegateScenario` enum to parameterize and thus combine `create_metadata_delegate_v1` and `create_holder_delegate_v1`, and then simplify the optional `role` arguments for `create_pda_account` into one.
* Similarly we could combine `revoke_metadata_delegate_v1` and `revoke_holder_delegate_v1`, as well as `close_metadata_delegate_record` and `close_holder_delegate_record`.
* The `revoke` changes refactor a bit to avoid some logic duplication.