### PR TITLE
Update Rust version for Rust client crate publish CI

### DIFF
--- a/.github/workflows/deploy-rust-client.yml
+++ b/.github/workflows/deploy-rust-client.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install Rust
         uses: metaplex-foundation/actions/install-rust@v1
         with:
-          toolchain: "1.70.0"
+          toolchain: "1.72.0"
 
       - name: Install cargo-release
         uses: metaplex-foundation/actions/install-cargo-release@v1


### PR DESCRIPTION
Needed because publishing the crate does a build and pulls Solana 1.18 which requires Rust 1.72.0 or newer.