### PR TITLE
Move trait implementation to correct location for Rust client

### DIFF
--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -26,5 +26,3 @@ pub const MAX_EDITION_MARKER_SIZE: usize = 32;
 
 /// Number of bits used by a edition marker.
 pub const EDITION_MARKER_BIT_SIZE: u64 = 248;
-
-impl Copy for types::Key {}

--- a/clients/rust/src/traits.rs
+++ b/clients/rust/src/traits.rs
@@ -296,3 +296,7 @@ impl UpdateArgs {
         }
     }
 }
+
+// Key
+
+impl Copy for Key {}


### PR DESCRIPTION
Very minor cleanup after I realize its in the wrong file