### PR TITLE
MET-126: Added new option: CollectionDetails::V2

### DIFF
--- a/clients/js/src/generated/types/collectionDetails.ts
+++ b/clients/js/src/generated/types/collectionDetails.ts
@@ -10,14 +10,20 @@ import {
   GetDataEnumKind,
   GetDataEnumKindContent,
   Serializer,
+  array,
   dataEnum,
   struct,
   u64,
+  u8,
 } from '@metaplex-foundation/umi/serializers';
 
-export type CollectionDetails = { __kind: 'V1'; size: bigint };
+export type CollectionDetails =
+  | { __kind: 'V1'; size: bigint }
+  | { __kind: 'V2'; padding: Array<number> };
 
-export type CollectionDetailsArgs = { __kind: 'V1'; size: number | bigint };
+export type CollectionDetailsArgs =
+  | { __kind: 'V1'; size: number | bigint }
+  | { __kind: 'V2'; padding: Array<number> };
 
 export function getCollectionDetailsSerializer(): Serializer<
   CollectionDetailsArgs,
@@ -31,6 +37,12 @@ export function getCollectionDetailsSerializer(): Serializer<
           ['size', u64()],
         ]),
       ],
+      [
+        'V2',
+        struct<GetDataEnumKindContent<CollectionDetails, 'V2'>>([
+          ['padding', array(u8(), { size: 8 })],
+        ]),
+      ],
     ],
     { description: 'CollectionDetails' }
   ) as Serializer<CollectionDetailsArgs, CollectionDetails>;
@@ -41,6 +53,10 @@ export function collectionDetails(
   kind: 'V1',
   data: GetDataEnumKindContent<CollectionDetailsArgs, 'V1'>
 ): GetDataEnumKind<CollectionDetailsArgs, 'V1'>;
+export function collectionDetails(
+  kind: 'V2',
+  data: GetDataEnumKindContent<CollectionDetailsArgs, 'V2'>
+): GetDataEnumKind<CollectionDetailsArgs, 'V2'>;
 export function collectionDetails<K extends CollectionDetailsArgs['__kind']>(
   kind: K,
   data?: any

--- a/clients/rust/src/generated/types/collection_details.rs
+++ b/clients/rust/src/generated/types/collection_details.rs
@@ -12,4 +12,5 @@ use borsh::BorshSerialize;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CollectionDetails {
     V1 { size: u64 },
+    V2 { padding: [u8; 8] },
 }

--- a/idls/token_metadata.json
+++ b/idls/token_metadata.json
@@ -6584,6 +6584,20 @@
                 "type": "u64"
               }
             ]
+          },
+          {
+            "name": "V2",
+            "fields": [
+              {
+                "name": "padding",
+                "type": {
+                  "array": [
+                    "u8",
+                    8
+                  ]
+                }
+              }
+            ]
           }
         ]
       }

--- a/programs/token-metadata/program/src/assertions/metadata.rs
+++ b/programs/token-metadata/program/src/assertions/metadata.rs
@@ -7,6 +7,7 @@ use solana_program::{
 };
 use spl_token_2022::state::Account;
 
+use super::assert_owner_in;
 use crate::{
     assertions::assert_owned_by,
     error::MetadataError,
@@ -17,8 +18,6 @@ use crate::{
     },
     utils::unpack_initialized,
 };
-
-use super::assert_owner_in;
 
 pub fn assert_data_valid(
     data: &Data,

--- a/programs/token-metadata/program/src/instruction/fee.rs
+++ b/programs/token-metadata/program/src/instruction/fee.rs
@@ -3,9 +3,8 @@ use solana_program::{
     pubkey::Pubkey,
 };
 
-use crate::state::fee::FEE_AUTHORITY;
-
 use super::*;
+use crate::state::fee::FEE_AUTHORITY;
 
 pub fn collect_fees(recipient: Pubkey, fee_accounts: Vec<Pubkey>) -> Instruction {
     let mut accounts = vec![

--- a/programs/token-metadata/program/src/instruction/mod.rs
+++ b/programs/token-metadata/program/src/instruction/mod.rs
@@ -22,7 +22,6 @@ pub use fee::collect_fees;
 pub use freeze::*;
 pub use metadata::*;
 use mpl_token_metadata_context_derive::AccountContext;
-
 #[cfg(feature = "serde-feature")]
 use serde::{Deserialize, Serialize};
 use shank::ShankInstruction;

--- a/programs/token-metadata/program/src/processor/bubblegum/bubblegum_set_collection_size.rs
+++ b/programs/token-metadata/program/src/processor/bubblegum/bubblegum_set_collection_size.rs
@@ -56,6 +56,7 @@ pub fn bubblegum_set_collection_size(
         match details {
             #[allow(deprecated)]
             CollectionDetails::V1 { size } => size,
+            CollectionDetails::V2 { padding: _ } => 0,
         }
     } else {
         return Err(MetadataError::NotACollectionParent.into());

--- a/programs/token-metadata/program/src/processor/burn/burn_edition_nft.rs
+++ b/programs/token-metadata/program/src/processor/burn/burn_edition_nft.rs
@@ -2,6 +2,7 @@ use mpl_utils::assert_signer;
 use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 use spl_token_2022::state::Account as TokenAccount;
 
+use super::nonfungible_edition::burn_nonfungible_edition;
 use crate::{
     assertions::assert_owned_by,
     error::MetadataError,
@@ -10,8 +11,6 @@ use crate::{
     state::{Metadata, TokenMetadataAccount, TokenStandard},
     utils::{assert_initialized, SPL_TOKEN_ID},
 };
-
-use super::nonfungible_edition::burn_nonfungible_edition;
 
 pub fn process_burn_edition_nft<'a>(
     program_id: &Pubkey,

--- a/programs/token-metadata/program/src/processor/burn/burn_nft.rs
+++ b/programs/token-metadata/program/src/processor/burn/burn_nft.rs
@@ -7,15 +7,16 @@ use solana_program::{
 };
 use spl_token_2022::state::Account;
 
-use super::*;
+use super::{
+    nonfungible::{burn_nonfungible, BurnNonFungibleArgs},
+    *,
+};
 use crate::{
     assertions::assert_owned_by,
     instruction::{Burn, Context},
     state::{Metadata, TokenMetadataAccount},
     utils::{unpack_initialized, SPL_TOKEN_ID},
 };
-
-use super::nonfungible::{burn_nonfungible, BurnNonFungibleArgs};
 
 pub fn process_burn_nft<'a>(program_id: &Pubkey, accounts: &'a [AccountInfo<'a>]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();

--- a/programs/token-metadata/program/src/processor/burn/nonfungible_edition.rs
+++ b/programs/token-metadata/program/src/processor/burn/nonfungible_edition.rs
@@ -1,12 +1,11 @@
 use spl_token_2022::state::Account;
 
+use super::*;
 use crate::{
     pda::MARKER,
     state::{EditionMarkerV2, MasterEdition, MasterEditionV2, EDITION_MARKER_BIT_SIZE},
     utils::unpack_initialized,
 };
-
-use super::*;
 
 pub(crate) fn burn_nonfungible_edition(
     ctx: &Context<Burn>,

--- a/programs/token-metadata/program/src/processor/fee/mod.rs
+++ b/programs/token-metadata/program/src/processor/fee/mod.rs
@@ -2,12 +2,11 @@ use mpl_utils::assert_signer;
 use num_traits::FromPrimitive;
 use solana_program::{account_info::next_account_info, rent::Rent, system_program, sysvar::Sysvar};
 
+use super::*;
 use crate::{
     state::{fee::FEE_AUTHORITY, MAX_METADATA_LEN},
     utils::fee::clear_fee_flag,
 };
-
-use super::*;
 
 pub(crate) fn process_collect_fees(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();

--- a/programs/token-metadata/program/src/processor/verification/collection.rs
+++ b/programs/token-metadata/program/src/processor/verification/collection.rs
@@ -1,3 +1,6 @@
+use mpl_utils::{assert_signer, token::SPL_TOKEN_PROGRAM_IDS};
+use solana_program::{entrypoint::ProgramResult, pubkey::Pubkey};
+
 use crate::{
     assertions::{
         assert_owned_by, assert_owner_in, collection::assert_collection_verify_is_valid,
@@ -8,8 +11,6 @@ use crate::{
     state::{AuthorityRequest, AuthorityType, Metadata, TokenMetadataAccount},
     utils::{clean_write_metadata, decrement_collection_size, increment_collection_size},
 };
-use mpl_utils::{assert_signer, token::SPL_TOKEN_PROGRAM_IDS};
-use solana_program::{entrypoint::ProgramResult, pubkey::Pubkey};
 
 pub(crate) fn verify_collection_v1(program_id: &Pubkey, ctx: Context<Verify>) -> ProgramResult {
     // Assert program ownership/signers.

--- a/programs/token-metadata/program/src/processor/verification/creator.rs
+++ b/programs/token-metadata/program/src/processor/verification/creator.rs
@@ -1,3 +1,6 @@
+use mpl_utils::assert_signer;
+use solana_program::{entrypoint::ProgramResult, pubkey::Pubkey};
+
 use crate::{
     assertions::assert_owned_by,
     error::MetadataError,
@@ -5,8 +8,6 @@ use crate::{
     state::{Creator, Metadata, TokenMetadataAccount},
     utils::clean_write_metadata,
 };
-use mpl_utils::assert_signer;
-use solana_program::{entrypoint::ProgramResult, pubkey::Pubkey};
 
 pub(crate) fn verify_creator_v1(program_id: &Pubkey, ctx: Context<Verify>) -> ProgramResult {
     // Assert program ownership/signers.

--- a/programs/token-metadata/program/src/processor/verification/verify.rs
+++ b/programs/token-metadata/program/src/processor/verification/verify.rs
@@ -1,3 +1,5 @@
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
+
 use crate::{
     instruction::{Unverify, VerificationArgs, Verify},
     processor::verification::{
@@ -5,7 +7,6 @@ use crate::{
         creator::{unverify_creator_v1, verify_creator_v1},
     },
 };
-use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey};
 
 pub fn verify<'a>(
     program_id: &Pubkey,

--- a/programs/token-metadata/program/src/state/collection.rs
+++ b/programs/token-metadata/program/src/state/collection.rs
@@ -59,8 +59,12 @@ pub enum CollectionDetails {
         since = "1.13.1",
         note = "The collection size tracking feature is deprecated and will soon be removed."
     )]
-    V1 { size: u64 },
-    V2 { padding: [u8; 8] }
+    V1 {
+        size: u64,
+    },
+    V2 {
+        padding: [u8; 8],
+    },
 }
 
 #[cfg(test)]

--- a/programs/token-metadata/program/src/state/collection.rs
+++ b/programs/token-metadata/program/src/state/collection.rs
@@ -60,6 +60,7 @@ pub enum CollectionDetails {
         note = "The collection size tracking feature is deprecated and will soon be removed."
     )]
     V1 { size: u64 },
+    V2 { padding: [u8; 8] }
 }
 
 #[cfg(test)]

--- a/programs/token-metadata/program/src/utils/collection.rs
+++ b/programs/token-metadata/program/src/utils/collection.rs
@@ -20,7 +20,7 @@ pub fn increment_collection_size(
                 clean_write_metadata(metadata, metadata_info)?;
                 Ok(())
             }
-            CollectionDetails::V2 { padding: _ } => Ok(())
+            CollectionDetails::V2 { padding: _ } => Ok(()),
         }
     } else {
         msg!("No collection details. Can't increment.");
@@ -44,7 +44,7 @@ pub fn decrement_collection_size(
                 clean_write_metadata(metadata, metadata_info)?;
                 Ok(())
             }
-            CollectionDetails::V2 { padding: _ } => Ok(())
+            CollectionDetails::V2 { padding: _ } => Ok(()),
         }
     } else {
         msg!("No collection details. Can't decrement.");

--- a/programs/token-metadata/program/src/utils/collection.rs
+++ b/programs/token-metadata/program/src/utils/collection.rs
@@ -20,6 +20,7 @@ pub fn increment_collection_size(
                 clean_write_metadata(metadata, metadata_info)?;
                 Ok(())
             }
+            CollectionDetails::V2 { padding: _ } => Ok(())
         }
     } else {
         msg!("No collection details. Can't increment.");
@@ -43,6 +44,7 @@ pub fn decrement_collection_size(
                 clean_write_metadata(metadata, metadata_info)?;
                 Ok(())
             }
+            CollectionDetails::V2 { padding: _ } => Ok(())
         }
     } else {
         msg!("No collection details. Can't decrement.");

--- a/programs/token-metadata/program/src/utils/metadata.rs
+++ b/programs/token-metadata/program/src/utils/metadata.rs
@@ -164,8 +164,7 @@ pub fn process_create_metadata_accounts_logic(
             }
             CollectionDetails::V2 { padding: _ } => {
                 metadata.collection_details = None;
-
-            },
+            }
         }
     } else {
         metadata.collection_details = None;

--- a/programs/token-metadata/program/src/utils/metadata.rs
+++ b/programs/token-metadata/program/src/utils/metadata.rs
@@ -162,6 +162,10 @@ pub fn process_create_metadata_accounts_logic(
             CollectionDetails::V1 { size: _size } => {
                 metadata.collection_details = Some(CollectionDetails::V1 { size: 0 });
             }
+            CollectionDetails::V2 { padding: _ } => {
+                metadata.collection_details = None;
+
+            },
         }
     } else {
         metadata.collection_details = None;

--- a/programs/token-metadata/program/src/utils/mod.rs
+++ b/programs/token-metadata/program/src/utils/mod.rs
@@ -10,8 +10,6 @@ pub use collection::*;
 pub use compression::*;
 pub use master_edition::*;
 pub use metadata::*;
-pub(crate) use token::*;
-
 pub use mpl_utils::{
     assert_signer, close_account_raw, create_or_allocate_account_raw,
     resize_or_reallocate_account_raw,
@@ -29,6 +27,7 @@ use spl_token_2022::{
     extension::{BaseState, StateWithExtensions},
     instruction::{set_authority, AuthorityType},
 };
+pub(crate) use token::*;
 
 pub const SPL_TOKEN_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 

--- a/programs/token-metadata/program/tests/burn.rs
+++ b/programs/token-metadata/program/tests/burn.rs
@@ -2187,6 +2187,7 @@ mod nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 0);
                 }
+                CollectionDetails::V2 { padding: _ } => ()
             }
         } else {
             panic!("CollectionDetails is not set!");
@@ -2216,6 +2217,7 @@ mod nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 1);
                 }
+                CollectionDetails::V2 { padding: _ } => ()
             }
         } else {
             panic!("CollectionDetails is not set!");
@@ -2247,6 +2249,7 @@ mod nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 0);
                 }
+                CollectionDetails::V2 { padding: _ } => ()
             }
         } else {
             panic!("CollectionDetails is not set!");
@@ -2602,6 +2605,7 @@ mod nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 0);
                 }
+                CollectionDetails::V2 { padding: _ } => ()
             }
         } else {
             panic!("CollectionDetails is not set!");
@@ -2630,6 +2634,7 @@ mod nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 1);
                 }
+                CollectionDetails::V2 { padding: _ } => ()
             }
         } else {
             panic!("CollectionDetails is not set");

--- a/programs/token-metadata/program/tests/burn.rs
+++ b/programs/token-metadata/program/tests/burn.rs
@@ -2187,7 +2187,7 @@ mod nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 0);
                 }
-                CollectionDetails::V2 { padding: _ } => ()
+                CollectionDetails::V2 { padding: _ } => (),
             }
         } else {
             panic!("CollectionDetails is not set!");
@@ -2217,7 +2217,7 @@ mod nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 1);
                 }
-                CollectionDetails::V2 { padding: _ } => ()
+                CollectionDetails::V2 { padding: _ } => (),
             }
         } else {
             panic!("CollectionDetails is not set!");
@@ -2249,7 +2249,7 @@ mod nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 0);
                 }
-                CollectionDetails::V2 { padding: _ } => ()
+                CollectionDetails::V2 { padding: _ } => (),
             }
         } else {
             panic!("CollectionDetails is not set!");
@@ -2605,7 +2605,7 @@ mod nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 0);
                 }
-                CollectionDetails::V2 { padding: _ } => ()
+                CollectionDetails::V2 { padding: _ } => (),
             }
         } else {
             panic!("CollectionDetails is not set!");
@@ -2634,7 +2634,7 @@ mod nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 1);
                 }
-                CollectionDetails::V2 { padding: _ } => ()
+                CollectionDetails::V2 { padding: _ } => (),
             }
         } else {
             panic!("CollectionDetails is not set");

--- a/programs/token-metadata/program/tests/burn_nft.rs
+++ b/programs/token-metadata/program/tests/burn_nft.rs
@@ -275,7 +275,7 @@ mod burn_nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 0);
                 }
-                CollectionDetails::V2 { padding: _ } => ()
+                CollectionDetails::V2 { padding: _ } => (),
             }
         } else {
             panic!("CollectionDetails is not set!");
@@ -304,7 +304,7 @@ mod burn_nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 1);
                 }
-                CollectionDetails::V2 { padding: _ } => ()
+                CollectionDetails::V2 { padding: _ } => (),
             }
         } else {
             panic!("CollectionDetails is not set");
@@ -395,7 +395,7 @@ mod burn_nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 0);
                 }
-                CollectionDetails::V2 { padding: _ } => ()
+                CollectionDetails::V2 { padding: _ } => (),
             }
         } else {
             panic!("CollectionDetails is not set!");
@@ -425,7 +425,7 @@ mod burn_nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 1);
                 }
-                CollectionDetails::V2 { padding: _ } => ()
+                CollectionDetails::V2 { padding: _ } => (),
             }
         } else {
             panic!("CollectionDetails is not set!");
@@ -454,7 +454,7 @@ mod burn_nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 0);
                 }
-                CollectionDetails::V2 { padding: _ } => ()
+                CollectionDetails::V2 { padding: _ } => (),
             }
         } else {
             panic!("CollectionDetails is not set!");

--- a/programs/token-metadata/program/tests/burn_nft.rs
+++ b/programs/token-metadata/program/tests/burn_nft.rs
@@ -275,6 +275,7 @@ mod burn_nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 0);
                 }
+                CollectionDetails::V2 { padding: _ } => ()
             }
         } else {
             panic!("CollectionDetails is not set!");
@@ -303,6 +304,7 @@ mod burn_nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 1);
                 }
+                CollectionDetails::V2 { padding: _ } => ()
             }
         } else {
             panic!("CollectionDetails is not set");
@@ -393,6 +395,7 @@ mod burn_nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 0);
                 }
+                CollectionDetails::V2 { padding: _ } => ()
             }
         } else {
             panic!("CollectionDetails is not set!");
@@ -422,6 +425,7 @@ mod burn_nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 1);
                 }
+                CollectionDetails::V2 { padding: _ } => ()
             }
         } else {
             panic!("CollectionDetails is not set!");
@@ -450,6 +454,7 @@ mod burn_nft {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 0);
                 }
+                CollectionDetails::V2 { padding: _ } => ()
             }
         } else {
             panic!("CollectionDetails is not set!");

--- a/programs/token-metadata/program/tests/collection_sizes.rs
+++ b/programs/token-metadata/program/tests/collection_sizes.rs
@@ -520,6 +520,7 @@ mod size_tracking {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 0);
                 }
+                CollectionDetails::V2 { padding: _ } => ()
             }
         } else {
             panic!("CollectionDetails is not populated!");
@@ -546,6 +547,7 @@ mod size_tracking {
             match details {
                 #[allow(deprecated)]
                 CollectionDetails::V1 { size } => assert_eq!(size, 1),
+                CollectionDetails::V2 { padding: _ } => ()
             }
         } else {
             panic!("CollectionDetails is not populated!");
@@ -572,6 +574,7 @@ mod size_tracking {
             match details {
                 #[allow(deprecated)]
                 CollectionDetails::V1 { size } => assert_eq!(size, 0),
+                CollectionDetails::V2 { padding: _ } => ()
             }
         } else {
             panic!("CollectionDetails is not populated!");
@@ -599,6 +602,7 @@ mod size_tracking {
             match details {
                 #[allow(deprecated)]
                 CollectionDetails::V1 { size } => assert_eq!(size, 1),
+                CollectionDetails::V2 { padding: _ } => ()
             }
         } else {
             panic!("CollectionDetails is not populated!");
@@ -625,6 +629,7 @@ mod size_tracking {
             match details {
                 #[allow(deprecated)]
                 CollectionDetails::V1 { size } => assert_eq!(size, 0),
+                CollectionDetails::V2 { padding: _ } => ()
             }
         } else {
             panic!("CollectionDetails is not populated!");

--- a/programs/token-metadata/program/tests/collection_sizes.rs
+++ b/programs/token-metadata/program/tests/collection_sizes.rs
@@ -520,7 +520,7 @@ mod size_tracking {
                 CollectionDetails::V1 { size } => {
                     assert_eq!(size, 0);
                 }
-                CollectionDetails::V2 { padding: _ } => ()
+                CollectionDetails::V2 { padding: _ } => (),
             }
         } else {
             panic!("CollectionDetails is not populated!");
@@ -547,7 +547,7 @@ mod size_tracking {
             match details {
                 #[allow(deprecated)]
                 CollectionDetails::V1 { size } => assert_eq!(size, 1),
-                CollectionDetails::V2 { padding: _ } => ()
+                CollectionDetails::V2 { padding: _ } => (),
             }
         } else {
             panic!("CollectionDetails is not populated!");
@@ -574,7 +574,7 @@ mod size_tracking {
             match details {
                 #[allow(deprecated)]
                 CollectionDetails::V1 { size } => assert_eq!(size, 0),
-                CollectionDetails::V2 { padding: _ } => ()
+                CollectionDetails::V2 { padding: _ } => (),
             }
         } else {
             panic!("CollectionDetails is not populated!");
@@ -602,7 +602,7 @@ mod size_tracking {
             match details {
                 #[allow(deprecated)]
                 CollectionDetails::V1 { size } => assert_eq!(size, 1),
-                CollectionDetails::V2 { padding: _ } => ()
+                CollectionDetails::V2 { padding: _ } => (),
             }
         } else {
             panic!("CollectionDetails is not populated!");
@@ -629,7 +629,7 @@ mod size_tracking {
             match details {
                 #[allow(deprecated)]
                 CollectionDetails::V1 { size } => assert_eq!(size, 0),
-                CollectionDetails::V2 { padding: _ } => ()
+                CollectionDetails::V2 { padding: _ } => (),
             }
         } else {
             panic!("CollectionDetails is not populated!");

--- a/programs/token-metadata/program/tests/set_collection_size.rs
+++ b/programs/token-metadata/program/tests/set_collection_size.rs
@@ -90,6 +90,7 @@ mod set_collection_size {
             match details {
                 #[allow(deprecated)]
                 CollectionDetails::V1 { size } => size,
+                CollectionDetails::V2 { padding: _ } => 0,
             }
         } else {
             panic!("Expected CollectionDetails::V1");
@@ -193,6 +194,7 @@ mod set_collection_size {
             match details {
                 #[allow(deprecated)]
                 CollectionDetails::V1 { size } => size,
+                CollectionDetails::V2 { padding: _ } => 0,
             }
         } else {
             panic!("Expected CollectionDetails::V1");
@@ -388,6 +390,7 @@ mod set_collection_size {
             match details {
                 #[allow(deprecated)]
                 CollectionDetails::V1 { size } => size,
+                CollectionDetails::V2 { padding: _ } => 0,
             }
         } else {
             panic!("Expected CollectionDetails::V1");
@@ -456,6 +459,7 @@ mod set_collection_size {
             match details {
                 #[allow(deprecated)]
                 CollectionDetails::V1 { size } => size,
+                CollectionDetails::V2 { padding: _ } => 0,
             }
         } else {
             panic!("Expected CollectionDetails::V1");

--- a/programs/token-metadata/program/tests/unverify.rs
+++ b/programs/token-metadata/program/tests/unverify.rs
@@ -898,6 +898,7 @@ mod unverify_collection {
         let verified_collection_details = DEFAULT_COLLECTION_DETAILS.map(|details| match details {
             #[allow(deprecated)]
             CollectionDetails::V1 { size } => CollectionDetails::V1 { size: size + 1 },
+            CollectionDetails::V2 { padding: _ } => CollectionDetails::V2 { padding: [0; 8] },
         });
 
         let collection_metadata = collection_parent_nft.get_data(&mut context).await;
@@ -1005,6 +1006,7 @@ mod unverify_collection {
         let verified_collection_details = DEFAULT_COLLECTION_DETAILS.map(|details| match details {
             #[allow(deprecated)]
             CollectionDetails::V1 { size } => CollectionDetails::V1 { size: size + 1 },
+            CollectionDetails::V2 { padding: _ } => CollectionDetails::V2 { padding: [0; 8] },
         });
 
         let collection_metadata = collection_parent_nft.get_data(&mut context).await;
@@ -1913,6 +1915,7 @@ mod unverify_collection {
         let verified_collection_details = DEFAULT_COLLECTION_DETAILS.map(|details| match details {
             #[allow(deprecated)]
             CollectionDetails::V1 { size } => CollectionDetails::V1 { size: size + 1 },
+            CollectionDetails::V2 { padding: _ } => CollectionDetails::V2 { padding: [0; 8] },
         });
 
         let collection_metadata = collection_parent_nft.get_data(&mut context).await;
@@ -2038,6 +2041,7 @@ mod unverify_collection {
         let verified_collection_details = DEFAULT_COLLECTION_DETAILS.map(|details| match details {
             #[allow(deprecated)]
             CollectionDetails::V1 { size } => CollectionDetails::V1 { size: size + 1 },
+            CollectionDetails::V2 { padding: _ } => CollectionDetails::V2 { padding: [0; 8] },
         });
 
         let collection_metadata = collection_parent_nft.get_data(&mut context).await;
@@ -2914,6 +2918,7 @@ mod unverify_collection {
         let verified_collection_details = collection_details.clone().map(|details| match details {
             #[allow(deprecated)]
             CollectionDetails::V1 { size } => CollectionDetails::V1 { size: size + 1 },
+            CollectionDetails::V2 { padding: _ } => CollectionDetails::V2 { padding: [0; 8] },
         });
 
         collection_parent_da

--- a/programs/token-metadata/program/tests/update.rs
+++ b/programs/token-metadata/program/tests/update.rs
@@ -6,8 +6,7 @@ use solana_program::pubkey::Pubkey;
 use solana_program_test::*;
 use solana_sdk::{
     instruction::InstructionError,
-    signature::Keypair,
-    signature::Signer,
+    signature::{Keypair, Signer},
     transaction::{Transaction, TransactionError},
 };
 use spl_token_2022::state::Account;
@@ -17,8 +16,10 @@ use token_metadata::{
         builders::UpdateBuilder, CollectionToggle, DelegateArgs, InstructionBuilder, RuleSetToggle,
         TransferArgs, UpdateArgs,
     },
-    state::{Collection, Creator, Data, ProgrammableConfig, TokenStandard},
-    state::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
+    state::{
+        Collection, Creator, Data, ProgrammableConfig, TokenStandard, MAX_NAME_LENGTH,
+        MAX_SYMBOL_LENGTH, MAX_URI_LENGTH,
+    },
     utils::puffed_out_string,
 };
 use utils::{DigitalAsset, *};

--- a/programs/token-metadata/program/tests/utils/metadata.rs
+++ b/programs/token-metadata/program/tests/utils/metadata.rs
@@ -715,6 +715,7 @@ pub async fn assert_collection_size(
         match details {
             #[allow(deprecated)]
             CollectionDetails::V1 { size } => size,
+            CollectionDetails::V2 { padding: _ } => 0
         }
     } else {
         panic!("Expected CollectionDetails::V1");

--- a/programs/token-metadata/program/tests/utils/metadata.rs
+++ b/programs/token-metadata/program/tests/utils/metadata.rs
@@ -715,7 +715,7 @@ pub async fn assert_collection_size(
         match details {
             #[allow(deprecated)]
             CollectionDetails::V1 { size } => size,
-            CollectionDetails::V2 { padding: _ } => 0
+            CollectionDetails::V2 { padding: _ } => 0,
         }
     } else {
         panic!("Expected CollectionDetails::V1");

--- a/programs/token-metadata/program/tests/verify.rs
+++ b/programs/token-metadata/program/tests/verify.rs
@@ -6,8 +6,10 @@ use num_traits::FromPrimitive;
 use solana_program::native_token::LAMPORTS_PER_SOL;
 use solana_program_test::*;
 use solana_sdk::{
-    instruction::InstructionError, signature::Keypair, signer::Signer, transaction::Transaction,
-    transaction::TransactionError,
+    instruction::InstructionError,
+    signature::Keypair,
+    signer::Signer,
+    transaction::{Transaction, TransactionError},
 };
 use token_metadata::{
     error::MetadataError,

--- a/programs/token-metadata/program/tests/verify.rs
+++ b/programs/token-metadata/program/tests/verify.rs
@@ -1468,6 +1468,7 @@ mod verify_collection {
         let verified_collection_details = collection_details.map(|details| match details {
             #[allow(deprecated)]
             CollectionDetails::V1 { size } => CollectionDetails::V1 { size: size + 1 },
+            CollectionDetails::V2 { padding } => CollectionDetails::V2 { padding },
         });
 
         let collection_metadata = collection_parent_nft.get_data(&mut context).await;
@@ -1769,6 +1770,7 @@ mod verify_collection {
         let verified_collection_details = collection_details.clone().map(|details| match details {
             #[allow(deprecated)]
             CollectionDetails::V1 { size } => CollectionDetails::V1 { size: size + 1 },
+            CollectionDetails::V2 { padding } => CollectionDetails::V2 { padding },
         });
 
         let collection_metadata = collection_parent_nft.get_data(context).await;
@@ -1975,6 +1977,7 @@ mod verify_collection {
         let verified_collection_details = collection_details.map(|details| match details {
             #[allow(deprecated)]
             CollectionDetails::V1 { size } => CollectionDetails::V1 { size: size + 1 },
+            CollectionDetails::V2 { padding } => CollectionDetails::V2 { padding },
         });
 
         collection_parent_da
@@ -2207,6 +2210,7 @@ mod verify_collection {
         let verified_collection_details = collection_details.map(|details| match details {
             #[allow(deprecated)]
             CollectionDetails::V1 { size } => CollectionDetails::V1 { size: size + 1 },
+            CollectionDetails::V2 { padding } => CollectionDetails::V2 { padding },
         });
 
         collection_parent_da

--- a/programs/token-metadata/program/tests/verify_sized_collection_item.rs
+++ b/programs/token-metadata/program/tests/verify_sized_collection_item.rs
@@ -1178,6 +1178,7 @@ async fn fail_verify_already_verified() {
         match details {
             #[allow(deprecated)]
             CollectionDetails::V1 { size } => size,
+            CollectionDetails::V2 { padding: _ } => 0,
         }
     } else {
         panic!("Expected CollectionDetails::V1");
@@ -1212,6 +1213,7 @@ async fn fail_verify_already_verified() {
         match details {
             #[allow(deprecated)]
             CollectionDetails::V1 { size } => size,
+            CollectionDetails::V2 { padding: _ } => 0,
         }
     } else {
         panic!("Expected CollectionDetails::V1");
@@ -1427,6 +1429,7 @@ async fn fail_set_and_verify_already_verified() {
         match details {
             #[allow(deprecated)]
             CollectionDetails::V1 { size } => size,
+            CollectionDetails::V2 { padding: _ } => 0,
         }
     } else {
         panic!("Expected CollectionDetails::V1");
@@ -1456,6 +1459,7 @@ async fn fail_set_and_verify_already_verified() {
         match details {
             #[allow(deprecated)]
             CollectionDetails::V1 { size } => size,
+            CollectionDetails::V2 { padding: _ } => 0,
         }
     } else {
         panic!("Expected CollectionDetails::V1");


### PR DESCRIPTION
Although the new `CollectionDetails` variant has been added with no additional logic on top, the changes happen to be relatively big. I'd rather completely remove the `V1` option with its related methods (or even whole files like `bubblegum_set_collection_size`), however, I'm worried that would destroy backward compatibility.