### PR TITLE
chore(kinobi): migrate to Kinobi 0.17.0

### DIFF
--- a/clients/js/src/generated/instructions/createV1.ts
+++ b/clients/js/src/generated/instructions/createV1.ts
@@ -121,13 +121,13 @@ export type CreateV1InstructionDataArgs = {
   creators: OptionOrNullable<Array<CreatorArgs>>;
   primarySaleHappened?: boolean;
   isMutable?: boolean;
-  tokenStandard: TokenStandardArgs;
+  tokenStandard?: TokenStandardArgs;
   collection?: OptionOrNullable<CollectionArgs>;
   uses?: OptionOrNullable<UsesArgs>;
-  collectionDetails?: OptionOrNullable<CollectionDetailsArgs>;
+  collectionDetails: OptionOrNullable<CollectionDetailsArgs>;
   ruleSet?: OptionOrNullable<PublicKey>;
-  decimals?: OptionOrNullable<number>;
-  printSupply?: OptionOrNullable<PrintSupplyArgs>;
+  decimals: OptionOrNullable<number>;
+  printSupply: OptionOrNullable<PrintSupplyArgs>;
 };
 
 export function getCreateV1InstructionDataSerializer(): Serializer<
@@ -167,28 +167,26 @@ export function getCreateV1InstructionDataSerializer(): Serializer<
       symbol: value.symbol ?? '',
       primarySaleHappened: value.primarySaleHappened ?? false,
       isMutable: value.isMutable ?? true,
+      tokenStandard: value.tokenStandard ?? TokenStandard.NonFungible,
       collection: value.collection ?? none(),
       uses: value.uses ?? none(),
-      collectionDetails: value.collectionDetails ?? none(),
       ruleSet: value.ruleSet ?? none(),
-      decimals: value.decimals ?? none(),
-      printSupply: value.printSupply ?? none(),
     })
   ) as Serializer<CreateV1InstructionDataArgs, CreateV1InstructionData>;
 }
 
 // Extra Args.
-export type CreateV1InstructionExtraArgs = { isCollection: boolean };
+export type CreateV1InstructionExtraArgs = { isCollection?: boolean };
 
 // Args.
 export type CreateV1InstructionArgs = PickPartial<
   CreateV1InstructionDataArgs & CreateV1InstructionExtraArgs,
   | 'tokenStandard'
+  | 'creators'
   | 'isCollection'
   | 'collectionDetails'
   | 'decimals'
   | 'printSupply'
-  | 'creators'
 >;
 
 // Instruction.
@@ -314,6 +312,15 @@ export function createV1(
       resolvedAccounts.splTokenProgram.isWritable = false;
     }
   }
+  if (!resolvedArgs.creators) {
+    resolvedArgs.creators = resolveCreators(
+      context,
+      resolvedAccounts,
+      resolvedArgs,
+      programId,
+      false
+    );
+  }
   if (!resolvedArgs.isCollection) {
     resolvedArgs.isCollection = false;
   }
@@ -337,15 +344,6 @@ export function createV1(
   }
   if (!resolvedArgs.printSupply) {
     resolvedArgs.printSupply = resolvePrintSupply(
-      context,
-      resolvedAccounts,
-      resolvedArgs,
-      programId,
-      false
-    );
-  }
-  if (!resolvedArgs.creators) {
-    resolvedArgs.creators = resolveCreators(
       context,
       resolvedAccounts,
       resolvedArgs,

--- a/clients/js/src/generated/instructions/delegateAuthorityItemV1.ts
+++ b/clients/js/src/generated/instructions/delegateAuthorityItemV1.ts
@@ -230,9 +230,9 @@ export function delegateAuthorityItemV1(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.AuthorityItem,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegate: expectPublicKey(resolvedAccounts.delegate.value),
       }
     );

--- a/clients/js/src/generated/instructions/delegateCollectionItemV1.ts
+++ b/clients/js/src/generated/instructions/delegateCollectionItemV1.ts
@@ -230,9 +230,9 @@ export function delegateCollectionItemV1(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.CollectionItem,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegate: expectPublicKey(resolvedAccounts.delegate.value),
       }
     );

--- a/clients/js/src/generated/instructions/delegateCollectionV1.ts
+++ b/clients/js/src/generated/instructions/delegateCollectionV1.ts
@@ -230,9 +230,9 @@ export function delegateCollectionV1(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.Collection,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegate: expectPublicKey(resolvedAccounts.delegate.value),
       }
     );

--- a/clients/js/src/generated/instructions/delegateDataItemV1.ts
+++ b/clients/js/src/generated/instructions/delegateDataItemV1.ts
@@ -230,9 +230,9 @@ export function delegateDataItemV1(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.DataItem,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegate: expectPublicKey(resolvedAccounts.delegate.value),
       }
     );

--- a/clients/js/src/generated/instructions/delegateDataV1.ts
+++ b/clients/js/src/generated/instructions/delegateDataV1.ts
@@ -228,9 +228,9 @@ export function delegateDataV1(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.Data,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegate: expectPublicKey(resolvedAccounts.delegate.value),
       }
     );

--- a/clients/js/src/generated/instructions/delegateProgrammableConfigItemV1.ts
+++ b/clients/js/src/generated/instructions/delegateProgrammableConfigItemV1.ts
@@ -232,9 +232,9 @@ export function delegateProgrammableConfigItemV1(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.ProgrammableConfigItem,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegate: expectPublicKey(resolvedAccounts.delegate.value),
       }
     );

--- a/clients/js/src/generated/instructions/delegateProgrammableConfigV1.ts
+++ b/clients/js/src/generated/instructions/delegateProgrammableConfigV1.ts
@@ -232,9 +232,9 @@ export function delegateProgrammableConfigV1(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.ProgrammableConfig,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegate: expectPublicKey(resolvedAccounts.delegate.value),
       }
     );

--- a/clients/js/src/generated/instructions/revokeAuthorityItemV1.ts
+++ b/clients/js/src/generated/instructions/revokeAuthorityItemV1.ts
@@ -214,9 +214,9 @@ export function revokeAuthorityItemV1(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.AuthorityItem,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegate: expectPublicKey(resolvedAccounts.delegate.value),
       }
     );

--- a/clients/js/src/generated/instructions/revokeCollectionItemV1.ts
+++ b/clients/js/src/generated/instructions/revokeCollectionItemV1.ts
@@ -214,9 +214,9 @@ export function revokeCollectionItemV1(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.CollectionItem,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegate: expectPublicKey(resolvedAccounts.delegate.value),
       }
     );

--- a/clients/js/src/generated/instructions/revokeCollectionV1.ts
+++ b/clients/js/src/generated/instructions/revokeCollectionV1.ts
@@ -214,9 +214,9 @@ export function revokeCollectionV1(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.Collection,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegate: expectPublicKey(resolvedAccounts.delegate.value),
       }
     );

--- a/clients/js/src/generated/instructions/revokeDataItemV1.ts
+++ b/clients/js/src/generated/instructions/revokeDataItemV1.ts
@@ -213,9 +213,9 @@ export function revokeDataItemV1(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.DataItem,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegate: expectPublicKey(resolvedAccounts.delegate.value),
       }
     );

--- a/clients/js/src/generated/instructions/revokeDataV1.ts
+++ b/clients/js/src/generated/instructions/revokeDataV1.ts
@@ -206,9 +206,9 @@ export function revokeDataV1(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.Data,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegate: expectPublicKey(resolvedAccounts.delegate.value),
       }
     );

--- a/clients/js/src/generated/instructions/revokeProgrammableConfigItemV1.ts
+++ b/clients/js/src/generated/instructions/revokeProgrammableConfigItemV1.ts
@@ -216,9 +216,9 @@ export function revokeProgrammableConfigItemV1(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.ProgrammableConfigItem,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegate: expectPublicKey(resolvedAccounts.delegate.value),
       }
     );

--- a/clients/js/src/generated/instructions/revokeProgrammableConfigV1.ts
+++ b/clients/js/src/generated/instructions/revokeProgrammableConfigV1.ts
@@ -214,9 +214,9 @@ export function revokeProgrammableConfigV1(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.ProgrammableConfig,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegate: expectPublicKey(resolvedAccounts.delegate.value),
       }
     );

--- a/clients/js/src/generated/instructions/transferV1.ts
+++ b/clients/js/src/generated/instructions/transferV1.ts
@@ -274,8 +274,8 @@ export function transferV1(
       resolvedAccounts.destinationTokenRecord.value = findTokenRecordPda(
         context,
         {
-          mint: expectPublicKey(resolvedAccounts.mint.value),
           token: expectPublicKey(resolvedAccounts.destinationToken.value),
+          mint: expectPublicKey(resolvedAccounts.mint.value),
         }
       );
     }

--- a/clients/js/src/generated/instructions/updateAsAuthorityItemDelegateV2.ts
+++ b/clients/js/src/generated/instructions/updateAsAuthorityItemDelegateV2.ts
@@ -223,10 +223,10 @@ export function updateAsAuthorityItemDelegateV2(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.AuthorityItem,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
         delegate: expectPublicKey(resolvedAccounts.authority.value),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
       }
     );
   }

--- a/clients/js/src/generated/instructions/updateAsCollectionItemDelegateV2.ts
+++ b/clients/js/src/generated/instructions/updateAsCollectionItemDelegateV2.ts
@@ -210,10 +210,10 @@ export function updateAsCollectionItemDelegateV2(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.CollectionItem,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
         delegate: expectPublicKey(resolvedAccounts.authority.value),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
       }
     );
   }

--- a/clients/js/src/generated/instructions/updateAsDataItemDelegateV2.ts
+++ b/clients/js/src/generated/instructions/updateAsDataItemDelegateV2.ts
@@ -207,10 +207,10 @@ export function updateAsDataItemDelegateV2(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.DataItem,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
         delegate: expectPublicKey(resolvedAccounts.authority.value),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
       }
     );
   }

--- a/clients/js/src/generated/instructions/updateAsProgrammableConfigItemDelegateV2.ts
+++ b/clients/js/src/generated/instructions/updateAsProgrammableConfigItemDelegateV2.ts
@@ -210,10 +210,10 @@ export function updateAsProgrammableConfigItemDelegateV2(
     resolvedAccounts.delegateRecord.value = findMetadataDelegateRecordPda(
       context,
       {
-        mint: expectPublicKey(resolvedAccounts.mint.value),
         delegateRole: MetadataDelegateRole.ProgrammableConfigItem,
         updateAuthority: expectSome(resolvedArgs.updateAuthority),
         delegate: expectPublicKey(resolvedAccounts.authority.value),
+        mint: expectPublicKey(resolvedAccounts.mint.value),
       }
     );
   }

--- a/clients/rust/src/generated/accounts/edition_marker.rs
+++ b/clients/rust/src/generated/accounts/edition_marker.rs
@@ -19,6 +19,7 @@ pub struct EditionMarker {
 
 impl EditionMarker {
     pub const LEN: usize = 32;
+
     /// Prefix values used to generate a PDA for this account.
     ///
     /// Values are positional and appear in the following order:

--- a/clients/rust/src/generated/accounts/holder_delegate_record.rs
+++ b/clients/rust/src/generated/accounts/holder_delegate_record.rs
@@ -35,6 +35,7 @@ pub struct HolderDelegateRecord {
 
 impl HolderDelegateRecord {
     pub const LEN: usize = 98;
+
     /// Prefix values used to generate a PDA for this account.
     ///
     /// Values are positional and appear in the following order:

--- a/clients/rust/src/generated/accounts/metadata_delegate_record.rs
+++ b/clients/rust/src/generated/accounts/metadata_delegate_record.rs
@@ -35,6 +35,7 @@ pub struct MetadataDelegateRecord {
 
 impl MetadataDelegateRecord {
     pub const LEN: usize = 98;
+
     /// Prefix values used to generate a PDA for this account.
     ///
     /// Values are positional and appear in the following order:

--- a/clients/rust/src/generated/accounts/token_record.rs
+++ b/clients/rust/src/generated/accounts/token_record.rs
@@ -26,6 +26,7 @@ pub struct TokenRecord {
 
 impl TokenRecord {
     pub const LEN: usize = 80;
+
     /// Prefix values used to generate a PDA for this account.
     ///
     /// Values are positional and appear in the following order:

--- a/clients/rust/src/generated/accounts/use_authority_record.rs
+++ b/clients/rust/src/generated/accounts/use_authority_record.rs
@@ -20,6 +20,7 @@ pub struct UseAuthorityRecord {
 
 impl UseAuthorityRecord {
     pub const LEN: usize = 10;
+
     /// Prefix values used to generate a PDA for this account.
     ///
     /// Values are positional and appear in the following order:

--- a/clients/rust/src/generated/instructions/create_v1.rs
+++ b/clients/rust/src/generated/instructions/create_v1.rs
@@ -302,6 +302,7 @@ impl CreateV1Builder {
         self.is_mutable = Some(is_mutable);
         self
     }
+    /// `[optional argument, defaults to 'TokenStandard::NonFungible']`
     #[inline(always)]
     pub fn token_standard(&mut self, token_standard: TokenStandard) -> &mut Self {
         self.token_standard = Some(token_standard);
@@ -392,7 +393,7 @@ impl CreateV1Builder {
             token_standard: self
                 .token_standard
                 .clone()
-                .expect("token_standard is not set"),
+                .unwrap_or(TokenStandard::NonFungible),
             collection: self.collection.clone(),
             uses: self.uses.clone(),
             collection_details: self.collection_details.clone(),
@@ -769,6 +770,7 @@ impl<'a, 'b> CreateV1CpiBuilder<'a, 'b> {
         self.instruction.is_mutable = Some(is_mutable);
         self
     }
+    /// `[optional argument, defaults to 'TokenStandard::NonFungible']`
     #[inline(always)]
     pub fn token_standard(&mut self, token_standard: TokenStandard) -> &mut Self {
         self.instruction.token_standard = Some(token_standard);
@@ -871,7 +873,7 @@ impl<'a, 'b> CreateV1CpiBuilder<'a, 'b> {
                 .instruction
                 .token_standard
                 .clone()
-                .expect("token_standard is not set"),
+                .unwrap_or(TokenStandard::NonFungible),
             collection: self.instruction.collection.clone(),
             uses: self.instruction.uses.clone(),
             collection_details: self.instruction.collection_details.clone(),

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@metaplex-foundation/amman": "^0.12.1",
-    "@metaplex-foundation/kinobi": "^0.16.15",
+    "@metaplex-foundation/kinobi": "^0.17.0",
     "@metaplex-foundation/shank-js": "^0.1.0",
     "typescript": "^4.9.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,12 +1,16 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 devDependencies:
   '@metaplex-foundation/amman':
     specifier: ^0.12.1
     version: 0.12.1(typescript@4.9.5)
   '@metaplex-foundation/kinobi':
-    specifier: ^0.16.15
-    version: 0.16.15
+    specifier: ^0.17.0
+    version: 0.17.0(fastestsmallesttextencoderdecoder@1.0.22)
   '@metaplex-foundation/shank-js':
     specifier: ^0.1.0
     version: 0.1.0
@@ -85,15 +89,18 @@ packages:
     resolution: {integrity: sha512-S9RulC2fFCFOQraz61bij+5YCHhSO9llJegK8c8Y6731fSi6snUSQJdCUqYS8AIgR0TKbQvdvgSyIIdbDFZbBA==}
     dev: true
 
-  /@metaplex-foundation/kinobi@0.16.15:
-    resolution: {integrity: sha512-D4uNSoue6+SCBVy4byqMt8O6yFitPTBP0AJC+37cMrtZjo22tGUAGfKklgcuTY3MoBbSh/xhndXXrckU32uExA==}
+  /@metaplex-foundation/kinobi@0.17.0(fastestsmallesttextencoderdecoder@1.0.22):
+    resolution: {integrity: sha512-tElCrV861b3sVjc0JnkfyyBOZPrqKpHYy+8aL1yUOBXYXRK92n5mZiTuZL8Klgr2bIzlzsDcd3dYWRUnzCyROg==}
     dependencies:
-      '@noble/hashes': 1.2.0
+      '@noble/hashes': 1.3.3
+      '@solana/codecs-strings': 2.0.0-experimental.a157265(fastestsmallesttextencoderdecoder@1.0.22)
       chalk: 4.1.2
+      json-stable-stringify: 1.1.1
       nunjucks: 3.2.4
       prettier: 2.8.8
     transitivePeerDependencies:
       - chokidar
+      - fastestsmallesttextencoderdecoder
     dev: true
 
   /@metaplex-foundation/rustbin@0.3.1:
@@ -121,8 +128,9 @@ packages:
     resolution: {integrity: sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==}
     dev: true
 
-  /@noble/hashes@1.2.0:
-    resolution: {integrity: sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==}
+  /@noble/hashes@1.3.3:
+    resolution: {integrity: sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==}
+    engines: {node: '>= 16'}
     dev: true
 
   /@noble/secp256k1@1.7.1:
@@ -169,6 +177,26 @@ packages:
       buffer: 6.0.3
     dev: true
 
+  /@solana/codecs-core@2.0.0-experimental.a157265:
+    resolution: {integrity: sha512-78SjZiLWWjAn5sVL92T5W+4LXYG01Vu28tVbtiCWi4QEX21794bW6lMcXbPmbivFPbD8Dje+EHAYADfxYj6RTA==}
+    dev: true
+
+  /@solana/codecs-numbers@2.0.0-experimental.a157265:
+    resolution: {integrity: sha512-Bkp7Y1KyhMsu8tHKxwHDXCnYxEawT0P4kEsIO1Fzs54pxOS1jtwJHo7e4FE8Kv8ZSajUQAnbmQqj5GaIU08h9A==}
+    dependencies:
+      '@solana/codecs-core': 2.0.0-experimental.a157265
+    dev: true
+
+  /@solana/codecs-strings@2.0.0-experimental.a157265(fastestsmallesttextencoderdecoder@1.0.22):
+    resolution: {integrity: sha512-1AypxqrFipI053/EOHZnDDcfKBduLjJdrpkbcqrgWJyciv/7+fMQjkgjbG+C8Vcqx5G8weUesXCcvAhqbdRwMw==}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+    dependencies:
+      '@solana/codecs-core': 2.0.0-experimental.a157265
+      '@solana/codecs-numbers': 2.0.0-experimental.a157265
+      fastestsmallesttextencoderdecoder: 1.0.22
+    dev: true
+
   /@solana/spl-token-registry@0.2.4574:
     resolution: {integrity: sha512-JzlfZmke8Rxug20VT/VpI2XsXlsqMlcORIUivF+Yucj7tFi7A0dXG7h+2UnD0WaZJw8BrUz2ABNkUnv89vbv1A==}
     engines: {node: '>=10'}
@@ -197,7 +225,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       '@noble/ed25519': 1.7.3
-      '@noble/hashes': 1.2.0
+      '@noble/hashes': 1.3.3
       '@noble/secp256k1': 1.7.1
       '@solana/buffer-layout': 4.0.1
       agentkeepalive: 4.2.1
@@ -398,12 +426,23 @@ packages:
       ieee754: 1.2.1
     dev: true
 
-  /bufferutil@4.0.7:
-    resolution: {integrity: sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==}
+  /bufferutil@4.0.8:
+    resolution: {integrity: sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==}
     engines: {node: '>=6.14.2'}
     requiresBuild: true
     dependencies:
       node-gyp-build: 4.6.0
+    dev: true
+
+  /call-bind@1.0.7:
+    resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.4
+      set-function-length: 1.2.1
     dev: true
 
   /chalk@4.1.2:
@@ -504,6 +543,15 @@ packages:
     resolution: {integrity: sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==}
     dev: true
 
+  /define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
+      gopd: 1.0.1
+    dev: true
+
   /delay@5.0.0:
     resolution: {integrity: sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==}
     engines: {node: '>=10'}
@@ -571,6 +619,18 @@ packages:
       - utf-8-validate
     dev: true
 
+  /es-define-property@1.0.0:
+    resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      get-intrinsic: 1.2.4
+    dev: true
+
+  /es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
   /es6-promise@4.2.8:
     resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
     dev: true
@@ -626,6 +686,10 @@ packages:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
     dev: true
 
+  /fastestsmallesttextencoderdecoder@1.0.22:
+    resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
+    dev: true
+
   /file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
     dev: true
@@ -655,9 +719,24 @@ packages:
     resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
     dev: true
 
+  /function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+    dev: true
+
   /get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+    dev: true
+
+  /get-intrinsic@1.2.4:
+    resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      has-proto: 1.0.1
+      has-symbols: 1.0.3
+      hasown: 2.0.1
     dev: true
 
   /get-stream@6.0.1:
@@ -665,9 +744,38 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /gopd@1.0.1:
+    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
+    dependencies:
+      get-intrinsic: 1.2.4
+    dev: true
+
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+    dev: true
+
+  /has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+    dependencies:
+      es-define-property: 1.0.0
+    dev: true
+
+  /has-proto@1.0.1:
+    resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /has-symbols@1.0.3:
+    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /hasown@2.0.1:
+    resolution: {integrity: sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      function-bind: 1.1.2
     dev: true
 
   /human-signals@2.1.0:
@@ -693,6 +801,10 @@ packages:
   /is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+    dev: true
+
+  /isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
     dev: true
 
   /isexe@2.0.0:
@@ -744,8 +856,22 @@ packages:
     resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
     dev: true
 
+  /json-stable-stringify@1.1.1:
+    resolution: {integrity: sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.7
+      isarray: 2.0.5
+      jsonify: 0.0.1
+      object-keys: 1.1.1
+    dev: true
+
   /json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+    dev: true
+
+  /jsonify@0.0.1:
+    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
     dev: true
 
   /jsonparse@1.3.1:
@@ -836,6 +962,7 @@ packages:
   /node-gyp-build@4.6.0:
     resolution: {integrity: sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==}
     hasBin: true
+    requiresBuild: true
     dev: true
 
   /npm-run-path@4.0.1:
@@ -867,6 +994,11 @@ packages:
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
     dev: true
 
   /onetime@5.1.2:
@@ -924,9 +1056,9 @@ packages:
       '@babel/runtime': 7.20.13
       eventemitter3: 4.0.7
       uuid: 8.3.2
-      ws: 8.12.1(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+      ws: 8.12.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     optionalDependencies:
-      bufferutil: 4.0.7
+      bufferutil: 4.0.8
       utf-8-validate: 5.0.10
     dev: true
 
@@ -952,6 +1084,18 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: true
+
+  /set-function-length@1.2.1:
+    resolution: {integrity: sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.4
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.2
     dev: true
 
   /shebang-command@2.0.0:
@@ -1230,7 +1374,7 @@ packages:
         optional: true
     dev: true
 
-  /ws@8.12.1(bufferutil@4.0.7)(utf-8-validate@5.0.10):
+  /ws@8.12.1(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     resolution: {integrity: sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -1242,7 +1386,7 @@ packages:
       utf-8-validate:
         optional: true
     dependencies:
-      bufferutil: 4.0.7
+      bufferutil: 4.0.8
       utf-8-validate: 5.0.10
     dev: true
 


### PR DESCRIPTION
# Description

Kinobi is updated to version 0.17.0. This PR was used as a reference to make the migration: https://github.com/metaplex-foundation/mpl-token-metadata/pull/77. It can be used to compare changes.