### PR TITLE
update docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ pnpm build && pnpm test
 
 ## Documentation
 
-Full documentation for Token Metadata can be found [here](https://docs.metaplex.com/programs/token-metadata/).
+Full documentation for Token Metadata can be found [here]([https://docs.metaplex.com/programs/token-metadata/](https://developers.metaplex.com/token-metadata). 
 
 ## Security
 


### PR DESCRIPTION
Readme pointed to docs.metaplex.com instead of the developer hub.