### PR TITLE
Creating a 1.13.3 patch for backwards compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@
 
 ## Getting Started
 
-The packages below can be use to interact with Token Metadata program.
+The packages below can be used to interact with Token Metadata program.
 
 ### TypeScript
 ```sh
-npm install @metaplex-foundation/mpl-token-metadata@alpha
+npm install @metaplex-foundation/mpl-token-metadata
 ```
 
 [See typedoc documentation](https://mpl-token-metadata-js-docs.vercel.app/).
@@ -30,13 +30,13 @@ npm install @metaplex-foundation/mpl-token-metadata@alpha
 cargo add mpl-token-metadata
 ```
 
-[See crate documentation](https://docs.rs/mpl-token-metadata/1.13.1/mpl_token_metadata/).
+[See crate documentation](https://docs.rs/mpl-token-metadata/1.13.3/mpl_token_metadata/).
 
 ## Building
 
 From the root directory of the repository:
 
-- Install the required packges:
+- Install the required packages:
 ```sh
 pnpm install
 ```
@@ -50,7 +50,7 @@ This will create the program binary at `<ROOT>/programs/.bin`
 
 ## Testing
 
-Token Metadata includes two set of tests: BPF and TypeScript.
+Token Metadata includes two sets of tests: BPF and TypeScript.
 
 ### BPF
 
@@ -80,7 +80,7 @@ pnpm build && pnpm test
 
 ## Documentation
 
-Full documentation for Token Metadata can be found [here](https://docs.metaplex.com/programs/token-metadata/).
+Full documentation for Token Metadata can be found here [developers.metaplex.com/token-metadata](https://developers.metaplex.com/token-metadata). 
 
 ## Security
 

--- a/idls/token_metadata.json
+++ b/idls/token_metadata.json
@@ -7731,7 +7731,7 @@
   "metadata": {
     "origin": "shank",
     "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",
-    "binaryVersion": "0.2.0",
-    "libVersion": "0.2.0"
+    "binaryVersion": "0.4.2",
+    "libVersion": "0.4.2"
   }
 }

--- a/programs/token-metadata/Cargo.lock
+++ b/programs/token-metadata/Cargo.lock
@@ -3382,11 +3382,11 @@ dependencies = [
 
 [[package]]
 name = "shank"
-version = "0.2.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc647510fc0d94a936f7367a9e3e30edbefd410068747ce4d4084b19b5fdbab"
+checksum = "23d894855493d4ce613b25550fe1ed1c62d0af5486b984579ba55e3f8c9631d5"
 dependencies = [
- "shank_macro 0.2.1",
+ "shank_macro 0.4.2",
 ]
 
 [[package]]
@@ -3415,13 +3415,13 @@ dependencies = [
 
 [[package]]
 name = "shank_macro"
-version = "0.2.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9ec31d18dcca23f2270ccf69766a99156792da3aed050dc5713af0e778b4f2"
+checksum = "a9bf2645f8eebde043da69200195058e7b59806705104f908a31d05ca82844ce"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
- "shank_macro_impl 0.2.1",
+ "shank_macro_impl 0.4.2",
  "shank_render",
  "syn 1.0.109",
 ]
@@ -3454,9 +3454,9 @@ dependencies = [
 
 [[package]]
 name = "shank_macro_impl"
-version = "0.2.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccaeb1359cf545507b5d18a637cc5cf192c7dcc8c737dff466013ca2d9e792c7"
+checksum = "93d0593f48acb0a722906416b1f6b8926f6571eb9af16d566a7c65427f269f50"
 dependencies = [
  "anyhow",
  "proc-macro2 1.0.66",
@@ -3467,13 +3467,13 @@ dependencies = [
 
 [[package]]
 name = "shank_render"
-version = "0.2.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63f0b763c4c767dfb462a884d5f5b9b99fdd0a214c910d95792eb02a13b3d69"
+checksum = "121175ba61809189f888dc5822ebfd30fa0d91e1e1f61d25a4d40b0847b3075e"
 dependencies = [
  "proc-macro2 1.0.66",
  "quote 1.0.32",
- "shank_macro_impl 0.2.1",
+ "shank_macro_impl 0.4.2",
 ]
 
 [[package]]
@@ -5081,12 +5081,12 @@ dependencies = [
  "rooster",
  "serde",
  "serde_with 1.14.0",
- "shank 0.2.1",
+ "shank 0.4.2",
  "solana-program",
  "solana-program-test",
  "solana-sdk",
- "spl-associated-token-account 1.1.3",
- "spl-token 3.5.0",
+ "spl-associated-token-account 2.0.0",
+ "spl-token 4.0.0",
  "thiserror",
 ]
 

--- a/programs/token-metadata/program/Cargo.toml
+++ b/programs/token-metadata/program/Cargo.toml
@@ -1,38 +1,44 @@
 [package]
-name = "token_metadata"
-version = "1.13.3"
-description = "Metaplex Metadata"
 authors = ["Metaplex Developers <dev@metaplex.com>"]
-repository = "https://github.com/metaplex-foundation/metaplex-program-library"
-license-file = "../../../LICENSE"
+description = "Metaplex Metadata"
 edition = "2021"
+license-file = "../../../LICENSE"
+name = "token_metadata"
 readme = "README.md"
+repository = "https://github.com/metaplex-foundation/metaplex-program-library"
+version = "1.13.3"
 
 [features]
 no-entrypoint = []
-test-bpf = []
 serde-feature = ["serde", "serde_with"]
+test-bpf = []
 
 [dependencies]
 arrayref = "0.3.6"
 borsh = "0.9.3"
-mpl-token-auth-rules = { version = "=1.4.3-beta.1", features = ["no-entrypoint"] }
+mpl-token-auth-rules = { version = "=1.4.3-beta.1", features = [
+  "no-entrypoint",
+] }
 mpl-token-metadata-context-derive = { version = "0.3.0", path = "../macro" }
 mpl-utils = { version = "0.3.1" }
 num-derive = "0.3"
 num-traits = "0.2"
 serde = { version = "1.0.149", optional = true }
 serde_with = { version = "1.14.0", optional = true }
-shank = "0.2.0"
+shank = "0.4.2"
 solana-program = ">= 1.14.13, < 1.17"
+spl-associated-token-account = { version = ">= 1.1.3, < 3.0", features = [
+  "no-entrypoint",
+] }
 spl-token = { version = ">= 3.5.0, < 5.0", features = ["no-entrypoint"] }
-spl-associated-token-account = { version = ">= 1.1.3, < 3.0", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [dev-dependencies]
 async-trait = "0.1.64"
 rmp-serde = "1.1.1"
-rooster = { git = "https://github.com/metaplex-foundation/rooster", features = ["no-entrypoint"] }
+rooster = { git = "https://github.com/metaplex-foundation/rooster", features = [
+  "no-entrypoint",
+] }
 serde = { version = "1.0.147", features = ["derive"] }
 solana-program-test = ">= 1.14.13, < 1.17"
 solana-sdk = ">= 1.14.13, < 1.17"

--- a/programs/token-metadata/program/src/state/edition.rs
+++ b/programs/token-metadata/program/src/state/edition.rs
@@ -41,7 +41,15 @@ impl TokenMetadataAccount for Edition {
     }
 
     fn size() -> usize {
-        MAX_EDITION_LEN
+        0
+    }
+
+    fn pad_length(buf: &mut Vec<u8>) -> Result<(), MetadataError> {
+        let padding_length = MAX_EDITION_LEN
+            .checked_sub(buf.len())
+            .ok_or(MetadataError::NumericalOverflowError)?;
+        buf.extend(vec![0; padding_length]);
+        Ok(())
     }
 }
 

--- a/programs/token-metadata/program/src/state/master_edition.rs
+++ b/programs/token-metadata/program/src/state/master_edition.rs
@@ -88,7 +88,15 @@ impl TokenMetadataAccount for MasterEditionV2 {
     }
 
     fn size() -> usize {
-        MAX_MASTER_EDITION_LEN
+        0
+    }
+
+    fn pad_length(buf: &mut Vec<u8>) -> Result<(), MetadataError> {
+        let padding_length = MAX_MASTER_EDITION_LEN
+            .checked_sub(buf.len())
+            .ok_or(MetadataError::NumericalOverflowError)?;
+        buf.extend(vec![0; padding_length]);
+        Ok(())
     }
 }
 
@@ -148,7 +156,15 @@ impl TokenMetadataAccount for MasterEditionV1 {
     }
 
     fn size() -> usize {
-        MAX_MASTER_EDITION_LEN
+        0
+    }
+
+    fn pad_length(buf: &mut Vec<u8>) -> Result<(), MetadataError> {
+        let padding_length = MAX_MASTER_EDITION_LEN
+            .checked_sub(buf.len())
+            .ok_or(MetadataError::NumericalOverflowError)?;
+        buf.extend(vec![0; padding_length]);
+        Ok(())
     }
 }
 

--- a/programs/token-metadata/program/src/utils/fee.rs
+++ b/programs/token-metadata/program/src/utils/fee.rs
@@ -3,7 +3,7 @@ use solana_program::{
     sysvar::Sysvar,
 };
 
-use crate::state::{fee::CREATE_FEE, Metadata, TokenMetadataAccount, METADATA_FEE_FLAG_INDEX};
+use crate::state::{fee::CREATE_FEE, MAX_METADATA_LEN, METADATA_FEE_FLAG_INDEX};
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -16,7 +16,7 @@ pub(crate) fn levy(args: LevyArgs) -> ProgramResult {
     // Fund metadata account with rent + Metaplex fee.
     let rent = Rent::get()?;
 
-    let fee = CREATE_FEE + rent.minimum_balance(Metadata::size());
+    let fee = CREATE_FEE + rent.minimum_balance(MAX_METADATA_LEN);
 
     invoke(
         &solana_program::system_instruction::transfer(

--- a/programs/token-metadata/program/src/utils/mod.rs
+++ b/programs/token-metadata/program/src/utils/mod.rs
@@ -38,7 +38,7 @@ use crate::{
     error::MetadataError,
     state::{
         Edition, Key, MasterEditionV2, Metadata, TokenMetadataAccount, TokenStandard,
-        MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH,
+        MAX_METADATA_LEN, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH,
     },
 };
 
@@ -199,7 +199,7 @@ pub(crate) fn close_program_account<'a>(
     let rent_lamports = match key {
         // Metadata accounts could have fees stored, so we only want to withdraw
         // the actual rent lamport amount.
-        Key::MetadataV1 => rent.minimum_balance(Metadata::size()),
+        Key::MetadataV1 => rent.minimum_balance(MAX_METADATA_LEN),
         // Other accounts the rent is just the current lamport balance.
         _ => account_info.lamports(),
     };
@@ -313,7 +313,7 @@ mod tests {
         let corrupted_data = pesky_data();
 
         let metadata: Metadata =
-            try_from_slice_checked(corrupted_data, Key::MetadataV1, MAX_METADATA_LEN).unwrap();
+            try_from_slice_checked(corrupted_data, Key::MetadataV1, 0).unwrap();
 
         assert_eq!(metadata, expected_metadata);
     }


### PR DESCRIPTION
In the TM SDK 1.13 we supported dynamic accounts by returning 0 from the size() trait function for TokenMetadataAccount. This indicated to the deserializer that the account was dynamically sized and size should not be used as a discriminator. This patch makes the TM accounts being resized qualify as "dynamically sized" to support people still using the old SDKs. This will allow older Anchor and SDK users to still function so long as they rebuild their programs while pulling in the latest 1.x version.

I do, however, keep the MAX_XXX_LEN fields the same to minimize breaking changes. Additionally, because size() now returns zero but it used elsewhere, I swapped its usage in the fee and burn calculations with MAX_METADATA_LEN to get the tests to pass. However this should have no effect on the actual program as we will never be deploying from this branch.