### PR TITLE
feat(js-kit): update token metadata plugin

### DIFF
--- a/clients/js-kit/package.json
+++ b/clients/js-kit/package.json
@@ -26,6 +26,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@ava/typescript": "^3.0.1",
+    "@solana-program/compute-budget": "^0.15.0",
     "@solana-program/system": "^0.12.0",
     "@solana-program/token": "^0.13.0",
     "@solana/kit": "^6.8.0",

--- a/clients/js-kit/package.json
+++ b/clients/js-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaplex-foundation/mpl-token-metadata-kit",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "JavaScript client for Token Metadata using @solana/kit",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -26,7 +26,11 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@ava/typescript": "^3.0.1",
-    "@solana-program/token": "^0.12.0",
+    "@solana-program/system": "^0.12.0",
+    "@solana-program/token": "^0.13.0",
+    "@solana/kit": "^6.8.0",
+    "@solana/kit-plugin-rpc": "^0.10.0",
+    "@solana/kit-plugin-signer": "^0.10.0",
     "@types/node": "^20.0.0",
     "ava": "^5.1.0",
     "eslint": "^8.0.1",
@@ -53,8 +57,10 @@
     "serial": true
   },
   "packageManager": "pnpm@8.9.0",
+  "peerDependencies": {
+    "@solana/kit": "^6.8.0"
+  },
   "dependencies": {
-    "@solana/kit": "^6.5.0",
-    "@solana/program-client-core": "^6.1.0"
+    "@solana/program-client-core": "^6.8.0"
   }
 }

--- a/clients/js-kit/pnpm-lock.yaml
+++ b/clients/js-kit/pnpm-lock.yaml
@@ -5,20 +5,29 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  '@solana/kit':
-    specifier: ^6.5.0
-    version: 6.5.0(typescript@5.9.3)
   '@solana/program-client-core':
-    specifier: ^6.1.0
-    version: 6.5.0(typescript@5.9.3)
+    specifier: ^6.8.0
+    version: 6.8.0(typescript@5.9.3)
 
 devDependencies:
   '@ava/typescript':
     specifier: ^3.0.1
     version: 3.0.1
-  '@solana-program/token':
+  '@solana-program/system':
     specifier: ^0.12.0
-    version: 0.12.0(@solana/kit@6.5.0)
+    version: 0.12.0(@solana/kit@6.8.0)
+  '@solana-program/token':
+    specifier: ^0.13.0
+    version: 0.13.0(@solana/kit@6.8.0)
+  '@solana/kit':
+    specifier: ^6.8.0
+    version: 6.8.0(typescript@5.9.3)
+  '@solana/kit-plugin-rpc':
+    specifier: ^0.10.0
+    version: 0.10.0(@solana/kit@6.8.0)
+  '@solana/kit-plugin-signer':
+    specifier: ^0.10.0
+    version: 0.10.0(@solana/kit@6.8.0)
   '@types/node':
     specifier: ^20.0.0
     version: 20.19.27
@@ -2288,152 +2297,153 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /@solana-program/system@0.12.0(@solana/kit@6.5.0):
+  /@solana-program/system@0.12.0(@solana/kit@6.8.0):
     resolution: {integrity: sha512-ZnAAWeGVMWNtJhw3GdifI2HnhZ0A0H0qs8tBkcFvxp/8wIavvO+GOM4Jd0N22u2+Lni2zcwvcrxrsxj6Mjphng==}
     peerDependencies:
       '@solana/kit': ^6.1.0
     dependencies:
-      '@solana/kit': 6.5.0(typescript@5.9.3)
+      '@solana/kit': 6.8.0(typescript@5.9.3)
     dev: true
 
-  /@solana-program/token@0.12.0(@solana/kit@6.5.0):
-    resolution: {integrity: sha512-hnidRNuFhmqUdW5aWkKTJ+cdzuotVMNwLsTyAk0Nd8VjLDld+vQC0fugHWqm5GPrvYe0hCNAhtpJcZVnNp7rOA==}
+  /@solana-program/token@0.13.0(@solana/kit@6.8.0):
+    resolution: {integrity: sha512-/Apjrd5lwOJGrPB0J5Rv7EBeclvyEBQPAGA85Scm7wBH+GpkbdLDM9uK3TNg8jjFKyWQYai/JtPHbrx7VgFLSg==}
     peerDependencies:
-      '@solana/kit': ^6.1.0
+      '@solana/kit': ^6.5.0
     dependencies:
-      '@solana-program/system': 0.12.0(@solana/kit@6.5.0)
-      '@solana/kit': 6.5.0(typescript@5.9.3)
+      '@solana-program/system': 0.12.0(@solana/kit@6.8.0)
+      '@solana/kit': 6.8.0(typescript@5.9.3)
     dev: true
 
-  /@solana/accounts@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-h3zQFjwZjmy+YxgTGOEna6g74Tsn4hTBaBCslwPT4QjqWhywe2JrM2Ab0ANfJcj7g/xrHF5QJ/FnUIcyUTeVfQ==}
+  /@solana/accounts@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-rXjFYVopaEw1H2PTBQbRjKr+0i4EFuBEhRT5E0dI4cMaabSb4KKypC2gaf47+6cjU3hMlM1AcsyIs72/MqAVBw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/addresses': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-spec': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.5.0(typescript@5.9.3)
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  /@solana/addresses@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-iD4/u3CWchQcPofbwzteaE9RnFJSoi654Rnhru5fOu6U2XOte3+7t50d6OxdxQ109ho2LqZyVtyCo2Wb7u1aJQ==}
+  /@solana/addresses@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-xVlA0DNX1LVfTueVsbhxDDoqr1VxeXvgJEh2GcIN/vcJPhY3GE3AYtjTbJJmTDgPrzOccI0t6ElVb1gelJH/PQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/assertions': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.5.0(typescript@5.9.3)
+      '@solana/assertions': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  /@solana/assertions@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-rEAf40TtC9r6EtJFLe39WID4xnTNT6hdOVRfD1xDzmIQdVOyGgIbJGt2FAuB/uQDKLWneWMnvGDBim+K61Bljw==}
+  /@solana/assertions@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-OU6prCq39fSvGL8xY1C/9vhghasvAkMiRlituzJxzJpZRfpVRrwhzLd6P5NPAPoQ28qKcenA50kFdw9+ZyneJQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/errors': 6.5.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
 
-  /@solana/codecs-core@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-Wb+YUj7vUKz5CxqZkrkugtQjxOP2fkMKnffySRlAmVAkpRnQvBY/2eP3VJAKTgDD4ru9xHSIQSpDu09hC/cQZg==}
+  /@solana/codecs-core@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/errors': 6.5.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
 
-  /@solana/codecs-data-structures@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-Rxi5zVJ1YA+E6FoSQ7RHP+3DF4U7ski0mJ3H5CsYQP24QLRlBqWB3X6m2n9GHT5O3s49UR0sqeF4oyq0lF8bKw==}
+  /@solana/codecs-data-structures@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-lHr0F+nNwgm9c+tWQX398yzYh1qDi7QSCJpY9MQ2azW4FfY2IyPSo7bqzTaWNnJh9pmJx3ZI6jHfXBnLD5k/SQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
 
-  /@solana/codecs-numbers@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-gU/7eYqD+zl2Kwzo7ctt7YHaxF+c3RX164F+iU4X02dwq8DGVcypp+kmEF1QaO6OiShtdryTxhL+JJmEBjhdfA==}
+  /@solana/codecs-numbers@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
 
-  /@solana/codecs-strings@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-9TuQQxumA9gWJeJzbv1GUg0+o0nZp204EijX3efR+lgBOKbkU7W0UWp33ygAZ+RvWE+kTs48ePoYoJ7UHpyxkQ==}
+  /@solana/codecs-strings@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-Rpk5NVhbKYcPnE7wz3IpTp0GVNVs0IYKdmyzByiimgPTiII8eb8ay4wQiYHGHrpYh62hD14Qy3GiGDFgipRKqA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       fastestsmallesttextencoderdecoder:
         optional: true
       typescript:
         optional: true
     dependencies:
-      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
 
-  /@solana/codecs@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-WfqMqUXk4jcCJQ9nfKqjDcCJN2Pt8/AKe/E78z8OcblFGVJnTzcu2yZpE2gsqM+DJyCVKdQmOY+NS8Uckk5e5w==}
+  /@solana/codecs@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-qCSAaw1qszeQflavkIM7c21qJ3BHReP/qgDelZbhsEXpZc852CCZM00FOIWuxePr6X+JjSNqJquxwdDSoZe7Bw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.5.0(typescript@5.9.3)
-      '@solana/options': 6.5.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/options': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+    dev: true
 
-  /@solana/errors@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-XPc0I8Ck6vgx8Uu+LVLewx/1RWDkXkY3lU+1aN1kmbrPAQWbX4Txk7GPmuIIFpyys8o5aKocYfNxJOPKvfaQhg==}
+  /@solana/errors@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -2442,580 +2452,619 @@ packages:
       commander: 14.0.3
       typescript: 5.9.3
 
-  /@solana/fast-stable-stringify@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-5ATQDwBVZMoenX5KS23uFswtaAGoaZB9TthzUXle3tkU3tOfgQTuEWEoqEBYc7ct0sK6LtyE1XXT/NP5YvAkkQ==}
+  /@solana/fast-stable-stringify@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-lZa3Qnsn+9ew6rHTXkPc+uqSa3i+AWqSBhV6oYxxBc+smvuxovItU4TPIs30cTfA7lAP+j+oYAQtUDu2dLy0hA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.9.3
+    dev: true
+
+  /@solana/functional@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-oMSAD/8w9ujx7OplvwRWwHHFnaaxi/Xrji1XH3xAB+gzxupUpBbOmgxQ+e84x+9VN8QWk5aU3L7gmCqdTAR6OA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
       typescript: 5.9.3
 
-  /@solana/functional@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-/KYgY7ZpBJfkN8+qlIvxuBpxv32U9jHXIOOJh3U5xk8Ncsa9Ex5VwbU9NkOf43MJjoIamsP0vARCHjcqJwe5JQ==}
+  /@solana/instruction-plans@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-osAsY8ozqohrcTcHlG1EmO3i9flc0eESMIy9akTHyVvqk915gZgkaTmt4IjcYSwBGt7i+Rh8TmLj27RrTpCKvg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      typescript: 5.9.3
-
-  /@solana/instruction-plans@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-zp2asevpyMwvhajHYM1aruYpO+xf3LSwHEI2FK6E2hddYZaEhuBy+bz+NZ1ixCyfx3iXcq7MamlFQc2ySHDyUQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/instructions': 6.5.0(typescript@5.9.3)
-      '@solana/keys': 6.5.0(typescript@5.9.3)
-      '@solana/promises': 6.5.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.5.0(typescript@5.9.3)
-      '@solana/transactions': 6.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  /@solana/instructions@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-2mQP/1qqr5PCfaVMzs9KofBjpyS7J1sBV6PidGoX9Dg5/4UgwJJ+7yfCVQPn37l1nKCShm4I+pQAy5vbmrxJmA==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-
-  /@solana/keys@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-CN5jmodX9j5CZKrWLM5XGaRlrLl/Ebl4vgqDXrnwC2NiSfUslLsthuORMuVUTDqkzBX/jd/tgVXFRH2NYNzREQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@solana/assertions': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.5.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/instructions': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/promises': 6.8.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.8.0(typescript@5.9.3)
+      '@solana/transactions': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  /@solana/kit@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-4ysrtqMRd7CTYRv179gQq4kbw9zMsJCLhWjiyOmLZ4co4ld3L654D8ykW7yqWE5PJwF0hzEfheE7oBscO37nvw==}
+  /@solana/instructions@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-dTtykhS9IeN3npCfnd7wSS6KmKAh54+g90JRtLYy5/31L2Zvunf3AJz2QUk58vgsAGZ5fuoiMyhCxRJm4rHUBQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/accounts': 6.5.0(typescript@5.9.3)
-      '@solana/addresses': 6.5.0(typescript@5.9.3)
-      '@solana/codecs': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/functional': 6.5.0(typescript@5.9.3)
-      '@solana/instruction-plans': 6.5.0(typescript@5.9.3)
-      '@solana/instructions': 6.5.0(typescript@5.9.3)
-      '@solana/keys': 6.5.0(typescript@5.9.3)
-      '@solana/offchain-messages': 6.5.0(typescript@5.9.3)
-      '@solana/plugin-core': 6.5.0(typescript@5.9.3)
-      '@solana/plugin-interfaces': 6.5.0(typescript@5.9.3)
-      '@solana/program-client-core': 6.5.0(typescript@5.9.3)
-      '@solana/programs': 6.5.0(typescript@5.9.3)
-      '@solana/rpc': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-api': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-parsed-types': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.5.0(typescript@5.9.3)
-      '@solana/signers': 6.5.0(typescript@5.9.3)
-      '@solana/sysvars': 6.5.0(typescript@5.9.3)
-      '@solana/transaction-confirmation': 6.5.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.5.0(typescript@5.9.3)
-      '@solana/transactions': 6.5.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  /@solana/keys@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-Wo8CnbrVfCP1Jbsb3ElMej/3dmMrl4ArPhI1mDcqIIz/O4j4HmxZYbn2BCWtnV9V/LPM638EMO2r1x6GzDNrPA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@solana/assertions': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.8.0(typescript@5.9.3)
+      '@solana/promises': 6.8.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  /@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.8.0):
+    resolution: {integrity: sha512-h99B+1Vp5QWU/M/q0UXlTxKJt781vWw5aAopnbgVCy0F3hNaSDZ/gio126Oz0/cipGOnyaJf3NnV79GvxaEqZA==}
+    peerDependencies:
+      '@solana/kit': ^6.8.0
+    dependencies:
+      '@solana/kit': 6.8.0(typescript@5.9.3)
+    dev: true
+
+  /@solana/kit-plugin-rpc@0.10.0(@solana/kit@6.8.0):
+    resolution: {integrity: sha512-UWKCcardpRHbj1G1S5UVPbZCP6LCqEwVX784C0JSeaWSKfeK6G81guiW2oEt8ETcryQFiZLBpwypqgfBdYGliQ==}
+    peerDependencies:
+      '@solana/kit': ^6.8.0
+    dependencies:
+      '@solana/kit': 6.8.0(typescript@5.9.3)
+      '@solana/kit-plugin-instruction-plan': 0.10.0(@solana/kit@6.8.0)
+    dev: true
+
+  /@solana/kit-plugin-signer@0.10.0(@solana/kit@6.8.0):
+    resolution: {integrity: sha512-3Gw3R6nQg/2r2+4cSaUZHj5zdbtb0SuA1mkDMd6uH7B+fdH1Ouxnulv1/sN8J0VxBo7tS+YDQA5t0arxX5gj+w==}
+    peerDependencies:
+      '@solana/kit': ^6.8.0
+    dependencies:
+      '@solana/kit': 6.8.0(typescript@5.9.3)
+    dev: true
+
+  /@solana/kit@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-+McC1aCgcUBdM7Cd7U6k2ZHJ9OKCy5mzpb0XWrhkrgsFxT0QoRr0AcWJc85o6tIDfG6Jz7vVhbS3l8ugYz2Vzw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@solana/accounts': 6.8.0(typescript@5.9.3)
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/functional': 6.8.0(typescript@5.9.3)
+      '@solana/instruction-plans': 6.8.0(typescript@5.9.3)
+      '@solana/instructions': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/offchain-messages': 6.8.0(typescript@5.9.3)
+      '@solana/plugin-core': 6.8.0(typescript@5.9.3)
+      '@solana/plugin-interfaces': 6.8.0(typescript@5.9.3)
+      '@solana/program-client-core': 6.8.0(typescript@5.9.3)
+      '@solana/programs': 6.8.0(typescript@5.9.3)
+      '@solana/rpc': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-api': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+      '@solana/signers': 6.8.0(typescript@5.9.3)
+      '@solana/subscribable': 6.8.0(typescript@5.9.3)
+      '@solana/sysvars': 6.8.0(typescript@5.9.3)
+      '@solana/transaction-confirmation': 6.8.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.8.0(typescript@5.9.3)
+      '@solana/transactions': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - bufferutil
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
+    dev: true
 
-  /@solana/nominal-types@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-HngIM2nlaDPXk0EDX0PklFqpjGDKuOFnlEKS0bfr2F9CorFwiNhNjhb9lPH+FdgsogD1wJ8wgLMMk1LZWn5kgQ==}
+  /@solana/nominal-types@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-mLmHr92pM4mEfe49GUmZ5Ry0RMqtMuFQqZYnxQqhDKMcl+Wtt820ezxYgwPhqcMxRzfqaQSO3ZxpSB0RlLBa/Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
       typescript: 5.9.3
 
-  /@solana/offchain-messages@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-IYuidJCwfXg5xlh3rkflkA1fbTKWTsip8MdI+znvXm87grfqOYCTd6t/SKiV4BhLl/65Tn0wB/zvZ1cmzJqa1w==}
+  /@solana/offchain-messages@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-HoniTs2uoCHGicD0dTTJ3YBhLZC9URxdXXUf0CHalLFwAidF9iNuB8dsuKk16Euu68L4/ERKKGfyC0QobBvahw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/addresses': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/keys': 6.5.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  /@solana/options@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-jdZjSKGCQpsMFK+3CiUEI7W9iGsndi46R4Abk66ULNLDoMsjvfqNy8kqktm0TN0++EX8dKEecpFwxFaA4VlY5g==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  /@solana/plugin-core@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-L6N69oNQOAqljH4GnLTaxpwJB0nibW9DrybHZxpGWshyv6b/EvwvkDVRKj5bNqtCG+HRZUHnEhLi1UgZVNkjpQ==}
+  /@solana/options@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-T5441HHeucFaLtaMAJQJl79T7mX007oAFPunpPebBphRvCXGv+qQwQvqa4HkYct6Jf2O0aKLBL9GSe/kfdCk9A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    dev: true
+
+  /@solana/plugin-core@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-kdqFIhQvJP2BDUsMOIbor35esj8u78SO33Xv0Wmo+uTRg6yKONKVK53ghw235pWrinOT4f0VnVe6MN6ciYiQVA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
       typescript: 5.9.3
+    dev: true
 
-  /@solana/plugin-interfaces@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-/ZlybbMaR7P4ySersOe1huioMADWze0AzsHbzgkpt5dJUv2tz5cpaKdu7TEVQkUZAFhLdqXQULNGqAU5neOgzg==}
+  /@solana/plugin-interfaces@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-4olaMKGUVA7wG6BBWM5A31bQsUWBlfcL1pjhq6ZTqVEJ7vshHXGwHVlWYXYyYn9ixozGDpGSl553yaRY9jQwWw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/addresses': 6.5.0(typescript@5.9.3)
-      '@solana/instruction-plans': 6.5.0(typescript@5.9.3)
-      '@solana/keys': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-spec': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-spec': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.5.0(typescript@5.9.3)
-      '@solana/signers': 6.5.0(typescript@5.9.3)
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/instruction-plans': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+      '@solana/signers': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  /@solana/program-client-core@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-eUz1xSeDKySGIjToAryPmlESdj8KX0Np7R+Pjt+kSFGw5Jgmn/Inh4o8luoeEnf5XwbvSPVb4aHpIsDyoUVbIg==}
+  /@solana/program-client-core@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-eOZtEnwl+vdiy9x/rFF89NDtnvt+Q3H04A/0u4GoHnt+fFkQG3JS+ChWG9c77izmpmRuz5C1GptOPDGNDnIUgQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/accounts': 6.5.0(typescript@5.9.3)
-      '@solana/addresses': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/instruction-plans': 6.5.0(typescript@5.9.3)
-      '@solana/instructions': 6.5.0(typescript@5.9.3)
-      '@solana/plugin-interfaces': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-api': 6.5.0(typescript@5.9.3)
-      '@solana/signers': 6.5.0(typescript@5.9.3)
+      '@solana/accounts': 6.8.0(typescript@5.9.3)
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/instruction-plans': 6.8.0(typescript@5.9.3)
+      '@solana/instructions': 6.8.0(typescript@5.9.3)
+      '@solana/plugin-interfaces': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-api': 6.8.0(typescript@5.9.3)
+      '@solana/signers': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  /@solana/programs@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-srn3nEROBxCnBpVz/bvLkVln1BZtk3bS3nuReu3yaeOLkKl8b0h1Zp0YmXVyXHzdMcYahsTvKKLR1ZtLZEyEPA==}
+  /@solana/programs@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-8hSKGfPTLX9Sm7KGV/UtiGCeSzptT/9vcjbodE+ZGHKFefo5vES4UAW+qD01LjL7IumGtMJvnfhCWt81qT/jbQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/addresses': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    dev: true
+
+  /@solana/promises@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-kIypZG83ZbADbrAq9/LS7LuWlVxlgJSzIpic75+9IuAfC3k5/KSus8LrvggBkCzfAyIslrUh70iz4JcnzUZrOw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.9.3
+
+  /@solana/rpc-api@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-v8ZKWgPtKbF6HeJcfC4ciwI8mwDCizBtRLYYjjHOu+9S9IJYyefQzsQxL5P8OjJPpI4gFauT6gsjQLo76BoojA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.8.0(typescript@5.9.3)
+      '@solana/transactions': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  /@solana/promises@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-n5rsA3YwOO2nUst6ghuVw6RSnuZQYqevqBKqVYbw11Z4XezsoQ6hb78opW3J9YNYapw9wLWy6tEfUsJjY+xtGw==}
+  /@solana/rpc-parsed-types@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-jYddZviBSUYbuUKqvNthet7KbJVI7me6xfRH2znv1SjIpmvhSPJcGN5QrlHVOasHdzEWSpvZa5VYDfnqH3aYvA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
       typescript: 5.9.3
 
-  /@solana/rpc-api@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-b+kftroO8vZFzLHj7Nk/uATS3HOlBUsUqdGg3eTQrW1pFgkyq5yIoEYHeFF7ApUN/SJLTK86U8ofCaXabd2SXA==}
+  /@solana/rpc-spec-types@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-ebCWgiQbIgFOehU7PdRFmYCzda3Azc/qa2Y3P8gexSHSsDAO27VwS4E05XSY+a7cIL5MYmvUa1vpDynl1Rkakw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@solana/addresses': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/keys': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-parsed-types': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-spec': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-transformers': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.5.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.5.0(typescript@5.9.3)
-      '@solana/transactions': 6.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  /@solana/rpc-parsed-types@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-129c8meL6CxRg56/HfhkFOpwYteQH9Rt0wyXOXZQx3a3FNpcJLd4JdPvxDsLBE3EupEkXLGVku/1bGKz+F2J+g==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
       typescript: 5.9.3
 
-  /@solana/rpc-spec-types@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-XasJp+sOW6PLfNoalzoLnm+j3LEZF8XOQmSrOqv9AGrGxQckkuOf6iXZucWTqeNKdstsOpU28BN2B6qOavfRzQ==}
+  /@solana/rpc-spec@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-kE5uOspxCVFJKNUu73hlebGiAFosjfYXbbTXAbGKfksPzy84u1oJFC2IVIobLRnqUCw1x7oJcvfnX00Zs0Itpg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
 
-  /@solana/rpc-spec@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-k4O7Kg0QfVyjUqQovL+WZJ1iuPzq0jiUDcWYgvzFjYVxQDVOIZmAol7yTvLEL4maVmf0tNFDsrDaB6t75MKRZA==}
+  /@solana/rpc-subscriptions-api@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-cPJOsydyoqkztW3msEH09wPDYqxJcMvO6DBlvrboq6wGu1UjeP66w2eApzQ8POoQHxhyw+CfEXl1Gbu6kKwuMQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-
-  /@solana/rpc-subscriptions-api@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-smqNjT2C5Vf9nWGIwiYOLOP744gRWKi2i2g0i3ZVdsfoouvB0d/WTQ2bbWq47MrdV8FSuGnjAOM3dRIwYmYOWw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@solana/addresses': 6.5.0(typescript@5.9.3)
-      '@solana/keys': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-spec': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-transformers': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.5.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.5.0(typescript@5.9.3)
-      '@solana/transactions': 6.5.0(typescript@5.9.3)
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.8.0(typescript@5.9.3)
+      '@solana/transactions': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+    dev: true
 
-  /@solana/rpc-subscriptions-channel-websocket@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-xRKH3ZwIoV9Zua9Gp0RR0eL8lXNgx+iNIkE3F0ROlOzI48lt4lRJ7jLrHQCN3raVtkatFVuEyZ7e9eLHK9zhAw==}
+  /@solana/rpc-subscriptions-channel-websocket@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-c3PpkorYwhAz1iuUfM5sLpZQi8xtZFGbaPbaPRELVeDjFSRzoa12KFnuQs4i9fbVbLy5Cnt1t23tf0bL2snZCQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/functional': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-spec': 6.5.0(typescript@5.9.3)
-      '@solana/subscribable': 6.5.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/functional': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.8.0(typescript@5.9.3)
+      '@solana/subscribable': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    dev: true
 
-  /@solana/rpc-subscriptions-spec@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-Mi8g9rNS2lG7lyNkDhOVfQVfDC7hXKgH+BlI5qKGk+8cfyU7VDq6tVjDysu6kBWGOPHZxyCvcL6+xW/EkdVoAg==}
+  /@solana/rpc-subscriptions-spec@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-+t4L5q9qE6IVfunW3n1amA/3EswJr64pVqRF7234vCUuVUz4PgYfbqtEBV3KkA1o0NwEHHM3pXuofT63nBb8Bg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/promises': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.5.0(typescript@5.9.3)
-      '@solana/subscribable': 6.5.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/promises': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.8.0(typescript@5.9.3)
+      '@solana/subscribable': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
 
-  /@solana/rpc-subscriptions@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-EenogPQw9Iy8VUj8anu7xoBnPk7gu1J6sAi4MTVlNVz02sNjdUBJoSS0PRJZuhSM1ktPTtHrNwqlXP8TxPR7jg==}
+  /@solana/rpc-subscriptions@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-9CotreNZmKAP2z07FY1I7TPPvylKLFF5p4mujB5ZFMHQPp5JVQFVCmMIhSj5voZHAeYx7jdwJ2Kf0RDeClqJzA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/fast-stable-stringify': 6.5.0(typescript@5.9.3)
-      '@solana/functional': 6.5.0(typescript@5.9.3)
-      '@solana/promises': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-api': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-channel-websocket': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-spec': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-transformers': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.5.0(typescript@5.9.3)
-      '@solana/subscribable': 6.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - bufferutil
-      - fastestsmallesttextencoderdecoder
-      - utf-8-validate
-
-  /@solana/rpc-transformers@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-kS0d+LuuSLfsod2cm2xp0mNj65PL1aomwu6VKtubmsdESwPXHIaI9XrpkPCBuhNSz1SwVp4OkfK5O/VOOHYHSw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/functional': 6.5.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  /@solana/rpc-transport-http@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-A3qgDGiUIHdtAfc2OyazlQa7IvRh+xyl0dmzaZlz4rY7Oc7Xk8jmXtaKGkgXihLyAK3oVSqSz5gn9yEfx55eXA==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-spec': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-      undici-types: 7.24.5
-
-  /@solana/rpc-types@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-hxts27+Z2VNv4IjXGcXkqbj/MgrN9Xtw/4iE1qZk68T2OAb5vA4b8LHchsOHmHvrzZfo8XDvB9mModCdM3JPsQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@solana/addresses': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  /@solana/rpc@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-lGj7ZMVOR3Rf16aByXD6ghrMqw3G8rAMuWCHU4uMKES5M5VLqNv6o71bSyoTxVMGrmYdbALOvCbFMFINAxtoBg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/fast-stable-stringify': 6.5.0(typescript@5.9.3)
-      '@solana/functional': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-api': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-spec': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-transformers': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-transport-http': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  /@solana/signers@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-AL75/DyDUhc+QQ+VGZT7aRwJNzIUTWvmLNXQRlCVhLRuyroXzZEL2WJBs8xOwbZXjY8weacfYT7UNM8qK6ucDg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@solana/addresses': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/instructions': 6.5.0(typescript@5.9.3)
-      '@solana/keys': 6.5.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.5.0(typescript@5.9.3)
-      '@solana/offchain-messages': 6.5.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.5.0(typescript@5.9.3)
-      '@solana/transactions': 6.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  /@solana/subscribable@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-Jmy2NYmQN68FsQzKJ5CY3qrxXBJdb5qtJKp8B4byPPO5liKNIsC59HpT0Tq8MCNSfBMmOkWF2rrVot2/g1iB1A==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-
-  /@solana/sysvars@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-iLSS5qj0MWNiGH1LN1E4jhGsXH9D3tWSjwaB6zK9LjhLdVYcPfkosBkj7s0EHHrH03QlwiuFdU0Y2kH8Jcp8kw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@solana/accounts': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  /@solana/transaction-confirmation@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-hfdRBq4toZj7DRMgBN3F0VtJpmTAEtcVTTDZoiszoSpSVa2cAvFth6KypIqASVFZyi9t4FKolLP8ASd3/39UQg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@solana/addresses': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/keys': 6.5.0(typescript@5.9.3)
-      '@solana/promises': 6.5.0(typescript@5.9.3)
-      '@solana/rpc': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.5.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.5.0(typescript@5.9.3)
-      '@solana/transactions': 6.5.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 6.8.0(typescript@5.9.3)
+      '@solana/functional': 6.8.0(typescript@5.9.3)
+      '@solana/promises': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-api': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-channel-websocket': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+      '@solana/subscribable': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - bufferutil
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
+    dev: true
 
-  /@solana/transaction-messages@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-ueXkm5xaRlqYBFAlABhaCKK/DuzIYSot0FybwSDeOQCDy2hvU9Zda16Iwa1n56M0fG+XUvFJz2woG3u9DhQh1g==}
+  /@solana/rpc-transformers@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-GzcFkllym7eXbw7grdE41MCb15CjkibrXtr7EFsf4d6LD9DRvzFj2ZRYywS2FB2ibVP0LUXXGk3vmtkZJjfajA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/addresses': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/functional': 6.5.0(typescript@5.9.3)
-      '@solana/instructions': 6.5.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.5.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/functional': 6.8.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  /@solana/transactions@6.5.0(typescript@5.9.3):
-    resolution: {integrity: sha512-b3eJrrGmwpk64VLHjOrmXKAahPpba42WX/FqSUn4WRXPoQjga7Mb57yp+EaRVeQfjszKCkF+13yu+ni6iv2NFQ==}
+  /@solana/rpc-transport-http@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-jw/L0q2motGcx7yo6KvkKJd2HGVg9gvViXatFloLl1XmHbkwE7+97YYmG17WRuM5xauzI/UGYOXNW7cEB+Uaxw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@solana/addresses': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.5.0(typescript@5.9.3)
-      '@solana/errors': 6.5.0(typescript@5.9.3)
-      '@solana/functional': 6.5.0(typescript@5.9.3)
-      '@solana/instructions': 6.5.0(typescript@5.9.3)
-      '@solana/keys': 6.5.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.5.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.5.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.8.0(typescript@5.9.3)
+      typescript: 5.9.3
+      undici-types: 8.1.0
+    dev: true
+
+  /@solana/rpc-types@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-vACMV9VR2JsZGDcgaMOFN/dwLK57CsE+erassxxtF12sSPXJooz+Vu1vyY2Yp2EkCc7mDf7BNkTKvSXajbt+Qw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.8.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  /@solana/rpc@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-+jW4n9TDmBttY3bO3PdUo54GAnwFrd7UJsyfXoMgl/lWGQq5uddYDgnzQLtHOBP5zKslkR8h0RKkic0GZhMZrQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 6.8.0(typescript@5.9.3)
+      '@solana/functional': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-api': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-transport-http': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    dev: true
+
+  /@solana/signers@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-7E1cAXBLOcz9kmHhzWdu5m3UJlJzxfwOl8irOMLJI6NnKB2EmU0B0h4I+Mlfs9w8Bfj0WQpUei21ammbNBq39g==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/instructions': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.8.0(typescript@5.9.3)
+      '@solana/offchain-messages': 6.8.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.8.0(typescript@5.9.3)
+      '@solana/transactions': 6.8.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  /@solana/subscribable@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-yj41Q97MiWrOmLj1iRFobvTdtU6H5wz5BlH5FHJg9lyapy1YQyaYF37MZx4LiUj4Ww0V3ReluIZTWWDBOJ53Jg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  /@solana/sysvars@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-pwfMpMNL6MSmm07eHQYdTdRdzmPOd+EuVCCaNLSYdWGpYcocVJiaLiNWRV3cXA5wPj/ZFkoUGtc1bo0v7H50lw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@solana/accounts': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    dev: true
+
+  /@solana/transaction-confirmation@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-R6rj8y/+kZqYJr8FR/fWxgi3Pw3eCiacUyjCPTVtdVe6i+hIiBApTGLzXrSRJmAMdpZrjYBZU1cG8C6oAb+B2A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/promises': 6.8.0(typescript@5.9.3)
+      '@solana/rpc': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.8.0(typescript@5.9.3)
+      '@solana/transactions': 6.8.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+    dev: true
+
+  /@solana/transaction-messages@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-jsJu9mAcN1x7onKOeC4WEvYP04UVcnkOYu/9bMe+S9jqjL+3DMy9kFZpV5FBl+TPuTNJrtOqc6Gc28hUWyyp1A==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/functional': 6.8.0(typescript@5.9.3)
+      '@solana/instructions': 6.8.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  /@solana/transactions@6.8.0(typescript@5.9.3):
+    resolution: {integrity: sha512-Q46m+o3C1yL2EIZBAP5B8ou2VZwHN9wTi+muIS6/giCKO3jwUtnTEbWcZEDMj2vxUb7P2WfwTluZb/VAWxlx7Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/functional': 6.8.0(typescript@5.9.3)
+      '@solana/instructions': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.8.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -6115,7 +6164,7 @@ packages:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
     dependencies:
-      semver: 6.1.1
+      semver: 6.3.1
     dev: true
 
   /make-error@1.3.6:
@@ -8068,6 +8117,7 @@ packages:
   /tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     dependencies:
       chownr: 2.0.0
       fs-minipass: 2.1.0
@@ -8271,8 +8321,9 @@ packages:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
     dev: true
 
-  /undici-types@7.24.5:
-    resolution: {integrity: sha512-kNh333UBSbgK35OIW7FwJTr9tTfVIG51Fm1tSVT7m8foPHfDVjsb7OIee/q/rs3bB2aV/3qOPgG5mHNWl1odiA==}
+  /undici-types@8.1.0:
+    resolution: {integrity: sha512-JlLXdMmH4kxyn2JPtGK/cajzKY7F15OKYG8sO5HfkIC1AC09sLUeptGFKjnMWnprDQ2EwzYDO3kgzkK3aaoHCA==}
+    dev: true
 
   /unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -8660,6 +8711,7 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: true
 
   /xdm@2.1.0:
     resolution: {integrity: sha512-3LxxbxKcRogYY7cQSMy1tUuU1zKNK9YPqMT7/S0r7Cz2QpyF8O9yFySGD7caOZt+LWUOQioOIX+6ZzCoBCpcAA==}

--- a/clients/js-kit/pnpm-lock.yaml
+++ b/clients/js-kit/pnpm-lock.yaml
@@ -13,6 +13,9 @@ devDependencies:
   '@ava/typescript':
     specifier: ^3.0.1
     version: 3.0.1
+  '@solana-program/compute-budget':
+    specifier: ^0.15.0
+    version: 0.15.0(@solana/kit@6.8.0)
   '@solana-program/system':
     specifier: ^0.12.0
     version: 0.12.0(@solana/kit@6.8.0)
@@ -2295,6 +2298,14 @@ packages:
   /@sindresorhus/is@4.6.0:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
+    dev: true
+
+  /@solana-program/compute-budget@0.15.0(@solana/kit@6.8.0):
+    resolution: {integrity: sha512-toejNdIkzpUTqLSIzP0Nofr/EFel8QpPWuTtIKzfCcjn+mXpkThHxPJaNesk251rSTiWaxDZ3WxG7RxYwTWTqA==}
+    peerDependencies:
+      '@solana/kit': ^6.3.0
+    dependencies:
+      '@solana/kit': 6.8.0(typescript@5.9.3)
     dev: true
 
   /@solana-program/system@0.12.0(@solana/kit@6.8.0):

--- a/clients/js-kit/src/generated/accounts/collectionAuthorityRecord.ts
+++ b/clients/js-kit/src/generated/accounts/collectionAuthorityRecord.ts
@@ -34,6 +34,7 @@ import {
   type MaybeEncodedAccount,
   type Option,
   type OptionOrNullable,
+  type ReadonlyUint8Array,
 } from '@solana/kit';
 import {
   CollectionAuthorityRecordSeeds,
@@ -41,9 +42,10 @@ import {
 } from '../pdas';
 import { getKeyDecoder, getKeyEncoder, Key } from '../types';
 
-export const COLLECTION_AUTHORITY_RECORD_KEY = Key.CollectionAuthorityRecord;
+export const COLLECTION_AUTHORITY_RECORD_KEY: Key =
+  Key.CollectionAuthorityRecord;
 
-export function getCollectionAuthorityRecordKeyBytes() {
+export function getCollectionAuthorityRecordKeyBytes(): ReadonlyUint8Array {
   return getKeyEncoder().encode(COLLECTION_AUTHORITY_RECORD_KEY);
 }
 

--- a/clients/js-kit/src/generated/accounts/deprecatedMasterEditionV1.ts
+++ b/clients/js-kit/src/generated/accounts/deprecatedMasterEditionV1.ts
@@ -34,6 +34,7 @@ import {
   type MaybeEncodedAccount,
   type Option,
   type OptionOrNullable,
+  type ReadonlyUint8Array,
 } from '@solana/kit';
 import {
   DeprecatedMasterEditionV1Seeds,
@@ -41,9 +42,9 @@ import {
 } from '../pdas';
 import { getKeyDecoder, getKeyEncoder, Key } from '../types';
 
-export const DEPRECATED_MASTER_EDITION_V1_KEY = Key.MasterEditionV1;
+export const DEPRECATED_MASTER_EDITION_V1_KEY: Key = Key.MasterEditionV1;
 
-export function getDeprecatedMasterEditionV1KeyBytes() {
+export function getDeprecatedMasterEditionV1KeyBytes(): ReadonlyUint8Array {
   return getKeyEncoder().encode(DEPRECATED_MASTER_EDITION_V1_KEY);
 }
 

--- a/clients/js-kit/src/generated/accounts/edition.ts
+++ b/clients/js-kit/src/generated/accounts/edition.ts
@@ -30,12 +30,13 @@ import {
   type FixedSizeEncoder,
   type MaybeAccount,
   type MaybeEncodedAccount,
+  type ReadonlyUint8Array,
 } from '@solana/kit';
 import { getKeyDecoder, getKeyEncoder, Key } from '../types';
 
-export const EDITION_KEY = Key.EditionV1;
+export const EDITION_KEY: Key = Key.EditionV1;
 
-export function getEditionKeyBytes() {
+export function getEditionKeyBytes(): ReadonlyUint8Array {
   return getKeyEncoder().encode(EDITION_KEY);
 }
 

--- a/clients/js-kit/src/generated/accounts/editionMarker.ts
+++ b/clients/js-kit/src/generated/accounts/editionMarker.ts
@@ -35,9 +35,9 @@ import {
 import { EditionMarkerSeeds, findEditionMarkerPda } from '../pdas';
 import { getKeyDecoder, getKeyEncoder, Key } from '../types';
 
-export const EDITION_MARKER_KEY = Key.EditionMarker;
+export const EDITION_MARKER_KEY: Key = Key.EditionMarker;
 
-export function getEditionMarkerKeyBytes() {
+export function getEditionMarkerKeyBytes(): ReadonlyUint8Array {
   return getKeyEncoder().encode(EDITION_MARKER_KEY);
 }
 

--- a/clients/js-kit/src/generated/accounts/masterEdition.ts
+++ b/clients/js-kit/src/generated/accounts/masterEdition.ts
@@ -32,13 +32,14 @@ import {
   type MaybeEncodedAccount,
   type Option,
   type OptionOrNullable,
+  type ReadonlyUint8Array,
 } from '@solana/kit';
 import { findMasterEditionPda, MasterEditionSeeds } from '../pdas';
 import { getKeyDecoder, getKeyEncoder, Key } from '../types';
 
-export const MASTER_EDITION_KEY = Key.MasterEditionV2;
+export const MASTER_EDITION_KEY: Key = Key.MasterEditionV2;
 
-export function getMasterEditionKeyBytes() {
+export function getMasterEditionKeyBytes(): ReadonlyUint8Array {
   return getKeyEncoder().encode(MASTER_EDITION_KEY);
 }
 

--- a/clients/js-kit/src/generated/accounts/metadata.ts
+++ b/clients/js-kit/src/generated/accounts/metadata.ts
@@ -46,6 +46,7 @@ import {
   type MaybeEncodedAccount,
   type Option,
   type OptionOrNullable,
+  type ReadonlyUint8Array,
 } from '@solana/kit';
 import { findMetadataPda, MetadataSeeds } from '../pdas';
 import {
@@ -78,9 +79,9 @@ import {
   type UsesArgs,
 } from '../types';
 
-export const METADATA_KEY = Key.MetadataV1;
+export const METADATA_KEY: Key = Key.MetadataV1;
 
-export function getMetadataKeyBytes() {
+export function getMetadataKeyBytes(): ReadonlyUint8Array {
   return getKeyEncoder().encode(METADATA_KEY);
 }
 

--- a/clients/js-kit/src/generated/accounts/tokenOwnedEscrow.ts
+++ b/clients/js-kit/src/generated/accounts/tokenOwnedEscrow.ts
@@ -30,6 +30,7 @@ import {
   type FetchAccountsConfig,
   type MaybeAccount,
   type MaybeEncodedAccount,
+  type ReadonlyUint8Array,
 } from '@solana/kit';
 import {
   getEscrowAuthorityDecoder,
@@ -41,9 +42,9 @@ import {
   type EscrowAuthorityArgs,
 } from '../types';
 
-export const TOKEN_OWNED_ESCROW_KEY = Key.TokenOwnedEscrow;
+export const TOKEN_OWNED_ESCROW_KEY: Key = Key.TokenOwnedEscrow;
 
-export function getTokenOwnedEscrowKeyBytes() {
+export function getTokenOwnedEscrowKeyBytes(): ReadonlyUint8Array {
   return getKeyEncoder().encode(TOKEN_OWNED_ESCROW_KEY);
 }
 

--- a/clients/js-kit/src/generated/accounts/tokenRecord.ts
+++ b/clients/js-kit/src/generated/accounts/tokenRecord.ts
@@ -36,6 +36,7 @@ import {
   type MaybeEncodedAccount,
   type Option,
   type OptionOrNullable,
+  type ReadonlyUint8Array,
 } from '@solana/kit';
 import { findTokenRecordPda, TokenRecordSeeds } from '../pdas';
 import {
@@ -52,9 +53,9 @@ import {
   type TokenStateArgs,
 } from '../types';
 
-export const TOKEN_RECORD_KEY = Key.TokenRecord;
+export const TOKEN_RECORD_KEY: Key = Key.TokenRecord;
 
-export function getTokenRecordKeyBytes() {
+export function getTokenRecordKeyBytes(): ReadonlyUint8Array {
   return getKeyEncoder().encode(TOKEN_RECORD_KEY);
 }
 

--- a/clients/js-kit/src/generated/accounts/useAuthorityRecord.ts
+++ b/clients/js-kit/src/generated/accounts/useAuthorityRecord.ts
@@ -30,13 +30,14 @@ import {
   type FixedSizeEncoder,
   type MaybeAccount,
   type MaybeEncodedAccount,
+  type ReadonlyUint8Array,
 } from '@solana/kit';
 import { findUseAuthorityRecordPda, UseAuthorityRecordSeeds } from '../pdas';
 import { getKeyDecoder, getKeyEncoder, Key } from '../types';
 
-export const USE_AUTHORITY_RECORD_KEY = Key.UseAuthorityRecord;
+export const USE_AUTHORITY_RECORD_KEY: Key = Key.UseAuthorityRecord;
 
-export function getUseAuthorityRecordKeyBytes() {
+export function getUseAuthorityRecordKeyBytes(): ReadonlyUint8Array {
   return getKeyEncoder().encode(USE_AUTHORITY_RECORD_KEY);
 }
 

--- a/clients/js-kit/src/generated/errors/mplTokenMetadata.ts
+++ b/clients/js-kit/src/generated/errors/mplTokenMetadata.ts
@@ -629,7 +629,7 @@ export type MplTokenMetadataError =
 let mplTokenMetadataErrorMessages:
   | Record<MplTokenMetadataError, string>
   | undefined;
-if (process.env.NODE_ENV !== 'production') {
+if (process.env['NODE_ENV'] !== 'production') {
   mplTokenMetadataErrorMessages = {
     [MPL_TOKEN_METADATA_ERROR__ACCOUNT_ALREADY_RESIZED]: `Account has already been resized`,
     [MPL_TOKEN_METADATA_ERROR__ADDRESS_NOT_IN_RESERVATION]: ``,
@@ -840,7 +840,7 @@ if (process.env.NODE_ENV !== 'production') {
 export function getMplTokenMetadataErrorMessage(
   code: MplTokenMetadataError
 ): string {
-  if (process.env.NODE_ENV !== 'production') {
+  if (process.env['NODE_ENV'] !== 'production') {
     return (
       mplTokenMetadataErrorMessages as Record<MplTokenMetadataError, string>
     )[code];

--- a/clients/js-kit/src/generated/instructions/approveCollectionAuthority.ts
+++ b/clients/js-kit/src/generated/instructions/approveCollectionAuthority.ts
@@ -40,7 +40,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const APPROVE_COLLECTION_AUTHORITY_DISCRIMINATOR = 23;
 
-export function getApproveCollectionAuthorityDiscriminatorBytes() {
+export function getApproveCollectionAuthorityDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(APPROVE_COLLECTION_AUTHORITY_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/approveUseAuthority.ts
+++ b/clients/js-kit/src/generated/instructions/approveUseAuthority.ts
@@ -42,7 +42,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const APPROVE_USE_AUTHORITY_DISCRIMINATOR = 20;
 
-export function getApproveUseAuthorityDiscriminatorBytes() {
+export function getApproveUseAuthorityDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(APPROVE_USE_AUTHORITY_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/bubblegumSetCollectionSize.ts
+++ b/clients/js-kit/src/generated/instructions/bubblegumSetCollectionSize.ts
@@ -44,7 +44,7 @@ import {
 
 export const BUBBLEGUM_SET_COLLECTION_SIZE_DISCRIMINATOR = 36;
 
-export function getBubblegumSetCollectionSizeDiscriminatorBytes() {
+export function getBubblegumSetCollectionSizeDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(BUBBLEGUM_SET_COLLECTION_SIZE_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/burn.ts
+++ b/clients/js-kit/src/generated/instructions/burn.ts
@@ -54,7 +54,7 @@ import {
 
 export const BURN_DISCRIMINATOR = 41;
 
-export function getBurnDiscriminatorBytes() {
+export function getBurnDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(BURN_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/burnEditionNft.ts
+++ b/clients/js-kit/src/generated/instructions/burnEditionNft.ts
@@ -38,7 +38,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const BURN_EDITION_NFT_DISCRIMINATOR = 37;
 
-export function getBurnEditionNftDiscriminatorBytes() {
+export function getBurnEditionNftDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(BURN_EDITION_NFT_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/burnNft.ts
+++ b/clients/js-kit/src/generated/instructions/burnNft.ts
@@ -40,7 +40,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const BURN_NFT_DISCRIMINATOR = 29;
 
-export function getBurnNftDiscriminatorBytes() {
+export function getBurnNftDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(BURN_NFT_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/burnV1.ts
+++ b/clients/js-kit/src/generated/instructions/burnV1.ts
@@ -49,7 +49,7 @@ import { TokenStandard, type TokenStandardArgs } from '../types';
 
 export const BURN_V1_DISCRIMINATOR = 41;
 
-export function getBurnV1DiscriminatorBytes() {
+export function getBurnV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(BURN_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/closeAccounts.ts
+++ b/clients/js-kit/src/generated/instructions/closeAccounts.ts
@@ -39,7 +39,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const CLOSE_ACCOUNTS_DISCRIMINATOR = 57;
 
-export function getCloseAccountsDiscriminatorBytes() {
+export function getCloseAccountsDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(CLOSE_ACCOUNTS_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/closeEscrowAccount.ts
+++ b/clients/js-kit/src/generated/instructions/closeEscrowAccount.ts
@@ -40,7 +40,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const CLOSE_ESCROW_ACCOUNT_DISCRIMINATOR = 39;
 
-export function getCloseEscrowAccountDiscriminatorBytes() {
+export function getCloseEscrowAccountDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(CLOSE_ESCROW_ACCOUNT_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/collect.ts
+++ b/clients/js-kit/src/generated/instructions/collect.ts
@@ -37,7 +37,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const COLLECT_DISCRIMINATOR = 54;
 
-export function getCollectDiscriminatorBytes() {
+export function getCollectDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(COLLECT_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/convertMasterEditionV1ToV2.ts
+++ b/clients/js-kit/src/generated/instructions/convertMasterEditionV1ToV2.ts
@@ -34,7 +34,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const CONVERT_MASTER_EDITION_V1_TO_V2_DISCRIMINATOR = 12;
 
-export function getConvertMasterEditionV1ToV2DiscriminatorBytes() {
+export function getConvertMasterEditionV1ToV2DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(CONVERT_MASTER_EDITION_V1_TO_V2_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/create.ts
+++ b/clients/js-kit/src/generated/instructions/create.ts
@@ -49,7 +49,7 @@ import {
 
 export const CREATE_DISCRIMINATOR = 42;
 
-export function getCreateDiscriminatorBytes() {
+export function getCreateDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(CREATE_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/createEscrowAccount.ts
+++ b/clients/js-kit/src/generated/instructions/createEscrowAccount.ts
@@ -41,7 +41,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const CREATE_ESCROW_ACCOUNT_DISCRIMINATOR = 38;
 
-export function getCreateEscrowAccountDiscriminatorBytes() {
+export function getCreateEscrowAccountDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(CREATE_ESCROW_ACCOUNT_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/createMasterEditionV3.ts
+++ b/clients/js-kit/src/generated/instructions/createMasterEditionV3.ts
@@ -47,7 +47,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const CREATE_MASTER_EDITION_V3_DISCRIMINATOR = 17;
 
-export function getCreateMasterEditionV3DiscriminatorBytes() {
+export function getCreateMasterEditionV3DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(CREATE_MASTER_EDITION_V3_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/createMetadataAccountV3.ts
+++ b/clients/js-kit/src/generated/instructions/createMetadataAccountV3.ts
@@ -57,7 +57,7 @@ import {
 
 export const CREATE_METADATA_ACCOUNT_V3_DISCRIMINATOR = 33;
 
-export function getCreateMetadataAccountV3DiscriminatorBytes() {
+export function getCreateMetadataAccountV3DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(CREATE_METADATA_ACCOUNT_V3_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/createV1.ts
+++ b/clients/js-kit/src/generated/instructions/createV1.ts
@@ -97,7 +97,7 @@ import {
 
 export const CREATE_V1_DISCRIMINATOR = 42;
 
-export function getCreateV1DiscriminatorBytes() {
+export function getCreateV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(CREATE_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/delegate.ts
+++ b/clients/js-kit/src/generated/instructions/delegate.ts
@@ -50,7 +50,7 @@ import {
 
 export const DELEGATE_DISCRIMINATOR = 44;
 
-export function getDelegateDiscriminatorBytes() {
+export function getDelegateDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(DELEGATE_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/delegateAuthorityItemV1.ts
+++ b/clients/js-kit/src/generated/instructions/delegateAuthorityItemV1.ts
@@ -60,7 +60,7 @@ import {
 
 export const DELEGATE_AUTHORITY_ITEM_V1_DISCRIMINATOR = 44;
 
-export function getDelegateAuthorityItemV1DiscriminatorBytes() {
+export function getDelegateAuthorityItemV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(DELEGATE_AUTHORITY_ITEM_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/delegateCollectionItemV1.ts
+++ b/clients/js-kit/src/generated/instructions/delegateCollectionItemV1.ts
@@ -60,7 +60,7 @@ import {
 
 export const DELEGATE_COLLECTION_ITEM_V1_DISCRIMINATOR = 44;
 
-export function getDelegateCollectionItemV1DiscriminatorBytes() {
+export function getDelegateCollectionItemV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(DELEGATE_COLLECTION_ITEM_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/delegateCollectionV1.ts
+++ b/clients/js-kit/src/generated/instructions/delegateCollectionV1.ts
@@ -60,7 +60,7 @@ import {
 
 export const DELEGATE_COLLECTION_V1_DISCRIMINATOR = 44;
 
-export function getDelegateCollectionV1DiscriminatorBytes() {
+export function getDelegateCollectionV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(DELEGATE_COLLECTION_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/delegateDataItemV1.ts
+++ b/clients/js-kit/src/generated/instructions/delegateDataItemV1.ts
@@ -60,7 +60,7 @@ import {
 
 export const DELEGATE_DATA_ITEM_V1_DISCRIMINATOR = 44;
 
-export function getDelegateDataItemV1DiscriminatorBytes() {
+export function getDelegateDataItemV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(DELEGATE_DATA_ITEM_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/delegateDataV1.ts
+++ b/clients/js-kit/src/generated/instructions/delegateDataV1.ts
@@ -60,7 +60,7 @@ import {
 
 export const DELEGATE_DATA_V1_DISCRIMINATOR = 44;
 
-export function getDelegateDataV1DiscriminatorBytes() {
+export function getDelegateDataV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(DELEGATE_DATA_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/delegateLockedTransferV1.ts
+++ b/clients/js-kit/src/generated/instructions/delegateLockedTransferV1.ts
@@ -64,7 +64,7 @@ import {
 
 export const DELEGATE_LOCKED_TRANSFER_V1_DISCRIMINATOR = 44;
 
-export function getDelegateLockedTransferV1DiscriminatorBytes() {
+export function getDelegateLockedTransferV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(DELEGATE_LOCKED_TRANSFER_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/delegatePrintDelegateV1.ts
+++ b/clients/js-kit/src/generated/instructions/delegatePrintDelegateV1.ts
@@ -55,7 +55,7 @@ import {
 
 export const DELEGATE_PRINT_DELEGATE_V1_DISCRIMINATOR = 44;
 
-export function getDelegatePrintDelegateV1DiscriminatorBytes() {
+export function getDelegatePrintDelegateV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(DELEGATE_PRINT_DELEGATE_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/delegateProgrammableConfigItemV1.ts
+++ b/clients/js-kit/src/generated/instructions/delegateProgrammableConfigItemV1.ts
@@ -60,7 +60,7 @@ import {
 
 export const DELEGATE_PROGRAMMABLE_CONFIG_ITEM_V1_DISCRIMINATOR = 44;
 
-export function getDelegateProgrammableConfigItemV1DiscriminatorBytes() {
+export function getDelegateProgrammableConfigItemV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(
     DELEGATE_PROGRAMMABLE_CONFIG_ITEM_V1_DISCRIMINATOR
   );

--- a/clients/js-kit/src/generated/instructions/delegateProgrammableConfigV1.ts
+++ b/clients/js-kit/src/generated/instructions/delegateProgrammableConfigV1.ts
@@ -60,7 +60,7 @@ import {
 
 export const DELEGATE_PROGRAMMABLE_CONFIG_V1_DISCRIMINATOR = 44;
 
-export function getDelegateProgrammableConfigV1DiscriminatorBytes() {
+export function getDelegateProgrammableConfigV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(DELEGATE_PROGRAMMABLE_CONFIG_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/delegateSaleV1.ts
+++ b/clients/js-kit/src/generated/instructions/delegateSaleV1.ts
@@ -62,7 +62,7 @@ import {
 
 export const DELEGATE_SALE_V1_DISCRIMINATOR = 44;
 
-export function getDelegateSaleV1DiscriminatorBytes() {
+export function getDelegateSaleV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(DELEGATE_SALE_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/delegateStakingV1.ts
+++ b/clients/js-kit/src/generated/instructions/delegateStakingV1.ts
@@ -62,7 +62,7 @@ import {
 
 export const DELEGATE_STAKING_V1_DISCRIMINATOR = 44;
 
-export function getDelegateStakingV1DiscriminatorBytes() {
+export function getDelegateStakingV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(DELEGATE_STAKING_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/delegateStandardV1.ts
+++ b/clients/js-kit/src/generated/instructions/delegateStandardV1.ts
@@ -50,7 +50,7 @@ import { type TokenStandardArgs } from '../types';
 
 export const DELEGATE_STANDARD_V1_DISCRIMINATOR = 44;
 
-export function getDelegateStandardV1DiscriminatorBytes() {
+export function getDelegateStandardV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(DELEGATE_STANDARD_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/delegateTransferV1.ts
+++ b/clients/js-kit/src/generated/instructions/delegateTransferV1.ts
@@ -62,7 +62,7 @@ import {
 
 export const DELEGATE_TRANSFER_V1_DISCRIMINATOR = 44;
 
-export function getDelegateTransferV1DiscriminatorBytes() {
+export function getDelegateTransferV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(DELEGATE_TRANSFER_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/delegateUtilityV1.ts
+++ b/clients/js-kit/src/generated/instructions/delegateUtilityV1.ts
@@ -62,7 +62,7 @@ import {
 
 export const DELEGATE_UTILITY_V1_DISCRIMINATOR = 44;
 
-export function getDelegateUtilityV1DiscriminatorBytes() {
+export function getDelegateUtilityV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(DELEGATE_UTILITY_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/deprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
+++ b/clients/js-kit/src/generated/instructions/deprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
@@ -40,7 +40,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const DEPRECATED_MINT_NEW_EDITION_FROM_MASTER_EDITION_VIA_PRINTING_TOKEN_DISCRIMINATOR = 3;
 
-export function getDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenDiscriminatorBytes() {
+export function getDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(
     DEPRECATED_MINT_NEW_EDITION_FROM_MASTER_EDITION_VIA_PRINTING_TOKEN_DISCRIMINATOR
   );

--- a/clients/js-kit/src/generated/instructions/freezeDelegatedAccount.ts
+++ b/clients/js-kit/src/generated/instructions/freezeDelegatedAccount.ts
@@ -40,7 +40,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const FREEZE_DELEGATED_ACCOUNT_DISCRIMINATOR = 26;
 
-export function getFreezeDelegatedAccountDiscriminatorBytes() {
+export function getFreezeDelegatedAccountDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(FREEZE_DELEGATED_ACCOUNT_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/lock.ts
+++ b/clients/js-kit/src/generated/instructions/lock.ts
@@ -59,7 +59,7 @@ import {
 
 export const LOCK_DISCRIMINATOR = 46;
 
-export function getLockDiscriminatorBytes() {
+export function getLockDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(LOCK_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/lockV1.ts
+++ b/clients/js-kit/src/generated/instructions/lockV1.ts
@@ -64,7 +64,7 @@ import {
 
 export const LOCK_V1_DISCRIMINATOR = 46;
 
-export function getLockV1DiscriminatorBytes() {
+export function getLockV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(LOCK_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/migrate.ts
+++ b/clients/js-kit/src/generated/instructions/migrate.ts
@@ -45,7 +45,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const MIGRATE_DISCRIMINATOR = 48;
 
-export function getMigrateDiscriminatorBytes() {
+export function getMigrateDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(MIGRATE_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/mint.ts
+++ b/clients/js-kit/src/generated/instructions/mint.ts
@@ -60,7 +60,7 @@ import {
 
 export const MINT_DISCRIMINATOR = 43;
 
-export function getMintDiscriminatorBytes() {
+export function getMintDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(MINT_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/mintNewEditionFromMasterEditionViaToken.ts
+++ b/clients/js-kit/src/generated/instructions/mintNewEditionFromMasterEditionViaToken.ts
@@ -45,7 +45,7 @@ import {
 
 export const MINT_NEW_EDITION_FROM_MASTER_EDITION_VIA_TOKEN_DISCRIMINATOR = 11;
 
-export function getMintNewEditionFromMasterEditionViaTokenDiscriminatorBytes() {
+export function getMintNewEditionFromMasterEditionViaTokenDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(
     MINT_NEW_EDITION_FROM_MASTER_EDITION_VIA_TOKEN_DISCRIMINATOR
   );

--- a/clients/js-kit/src/generated/instructions/mintNewEditionFromMasterEditionViaVaultProxy.ts
+++ b/clients/js-kit/src/generated/instructions/mintNewEditionFromMasterEditionViaVaultProxy.ts
@@ -45,7 +45,7 @@ import {
 
 export const MINT_NEW_EDITION_FROM_MASTER_EDITION_VIA_VAULT_PROXY_DISCRIMINATOR = 13;
 
-export function getMintNewEditionFromMasterEditionViaVaultProxyDiscriminatorBytes() {
+export function getMintNewEditionFromMasterEditionViaVaultProxyDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(
     MINT_NEW_EDITION_FROM_MASTER_EDITION_VIA_VAULT_PROXY_DISCRIMINATOR
   );

--- a/clients/js-kit/src/generated/instructions/mintV1.ts
+++ b/clients/js-kit/src/generated/instructions/mintV1.ts
@@ -67,7 +67,7 @@ import {
 
 export const MINT_V1_DISCRIMINATOR = 43;
 
-export function getMintV1DiscriminatorBytes() {
+export function getMintV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(MINT_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/print.ts
+++ b/clients/js-kit/src/generated/instructions/print.ts
@@ -55,7 +55,7 @@ import {
 
 export const PRINT_DISCRIMINATOR = 55;
 
-export function getPrintDiscriminatorBytes() {
+export function getPrintDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(PRINT_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/printV1.ts
+++ b/clients/js-kit/src/generated/instructions/printV1.ts
@@ -54,7 +54,7 @@ import { TokenStandard, type TokenStandardArgs } from '../types';
 
 export const PRINT_V1_DISCRIMINATOR = 55;
 
-export function getPrintV1DiscriminatorBytes() {
+export function getPrintV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(PRINT_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/printV2.ts
+++ b/clients/js-kit/src/generated/instructions/printV2.ts
@@ -54,7 +54,7 @@ import { TokenStandard, type TokenStandardArgs } from '../types';
 
 export const PRINT_V2_DISCRIMINATOR = 55;
 
-export function getPrintV2DiscriminatorBytes() {
+export function getPrintV2DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(PRINT_V2_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/puffMetadata.ts
+++ b/clients/js-kit/src/generated/instructions/puffMetadata.ts
@@ -34,7 +34,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const PUFF_METADATA_DISCRIMINATOR = 14;
 
-export function getPuffMetadataDiscriminatorBytes() {
+export function getPuffMetadataDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(PUFF_METADATA_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/removeCreatorVerification.ts
+++ b/clients/js-kit/src/generated/instructions/removeCreatorVerification.ts
@@ -37,7 +37,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const REMOVE_CREATOR_VERIFICATION_DISCRIMINATOR = 28;
 
-export function getRemoveCreatorVerificationDiscriminatorBytes() {
+export function getRemoveCreatorVerificationDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REMOVE_CREATOR_VERIFICATION_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/resize.ts
+++ b/clients/js-kit/src/generated/instructions/resize.ts
@@ -41,7 +41,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const RESIZE_DISCRIMINATOR = 56;
 
-export function getResizeDiscriminatorBytes() {
+export function getResizeDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(RESIZE_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/revoke.ts
+++ b/clients/js-kit/src/generated/instructions/revoke.ts
@@ -50,7 +50,7 @@ import {
 
 export const REVOKE_DISCRIMINATOR = 45;
 
-export function getRevokeDiscriminatorBytes() {
+export function getRevokeDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REVOKE_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/revokeAuthorityItemV1.ts
+++ b/clients/js-kit/src/generated/instructions/revokeAuthorityItemV1.ts
@@ -48,7 +48,7 @@ import { MetadataDelegateRole, type TokenStandardArgs } from '../types';
 
 export const REVOKE_AUTHORITY_ITEM_V1_DISCRIMINATOR = 45;
 
-export function getRevokeAuthorityItemV1DiscriminatorBytes() {
+export function getRevokeAuthorityItemV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REVOKE_AUTHORITY_ITEM_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/revokeCollectionAuthority.ts
+++ b/clients/js-kit/src/generated/instructions/revokeCollectionAuthority.ts
@@ -40,7 +40,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const REVOKE_COLLECTION_AUTHORITY_DISCRIMINATOR = 24;
 
-export function getRevokeCollectionAuthorityDiscriminatorBytes() {
+export function getRevokeCollectionAuthorityDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REVOKE_COLLECTION_AUTHORITY_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/revokeCollectionItemV1.ts
+++ b/clients/js-kit/src/generated/instructions/revokeCollectionItemV1.ts
@@ -48,7 +48,7 @@ import { MetadataDelegateRole, type TokenStandardArgs } from '../types';
 
 export const REVOKE_COLLECTION_ITEM_V1_DISCRIMINATOR = 45;
 
-export function getRevokeCollectionItemV1DiscriminatorBytes() {
+export function getRevokeCollectionItemV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REVOKE_COLLECTION_ITEM_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/revokeCollectionV1.ts
+++ b/clients/js-kit/src/generated/instructions/revokeCollectionV1.ts
@@ -48,7 +48,7 @@ import { MetadataDelegateRole, type TokenStandardArgs } from '../types';
 
 export const REVOKE_COLLECTION_V1_DISCRIMINATOR = 45;
 
-export function getRevokeCollectionV1DiscriminatorBytes() {
+export function getRevokeCollectionV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REVOKE_COLLECTION_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/revokeDataItemV1.ts
+++ b/clients/js-kit/src/generated/instructions/revokeDataItemV1.ts
@@ -48,7 +48,7 @@ import { MetadataDelegateRole, type TokenStandardArgs } from '../types';
 
 export const REVOKE_DATA_ITEM_V1_DISCRIMINATOR = 45;
 
-export function getRevokeDataItemV1DiscriminatorBytes() {
+export function getRevokeDataItemV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REVOKE_DATA_ITEM_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/revokeDataV1.ts
+++ b/clients/js-kit/src/generated/instructions/revokeDataV1.ts
@@ -48,7 +48,7 @@ import { MetadataDelegateRole, type TokenStandardArgs } from '../types';
 
 export const REVOKE_DATA_V1_DISCRIMINATOR = 45;
 
-export function getRevokeDataV1DiscriminatorBytes() {
+export function getRevokeDataV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REVOKE_DATA_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/revokeLockedTransferV1.ts
+++ b/clients/js-kit/src/generated/instructions/revokeLockedTransferV1.ts
@@ -48,7 +48,7 @@ import { TokenStandard, type TokenStandardArgs } from '../types';
 
 export const REVOKE_LOCKED_TRANSFER_V1_DISCRIMINATOR = 45;
 
-export function getRevokeLockedTransferV1DiscriminatorBytes() {
+export function getRevokeLockedTransferV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REVOKE_LOCKED_TRANSFER_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/revokeMigrationV1.ts
+++ b/clients/js-kit/src/generated/instructions/revokeMigrationV1.ts
@@ -48,7 +48,7 @@ import { TokenStandard, type TokenStandardArgs } from '../types';
 
 export const REVOKE_MIGRATION_V1_DISCRIMINATOR = 45;
 
-export function getRevokeMigrationV1DiscriminatorBytes() {
+export function getRevokeMigrationV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REVOKE_MIGRATION_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/revokePrintDelegateV1.ts
+++ b/clients/js-kit/src/generated/instructions/revokePrintDelegateV1.ts
@@ -44,7 +44,7 @@ import { type TokenStandardArgs } from '../types';
 
 export const REVOKE_PRINT_DELEGATE_V1_DISCRIMINATOR = 45;
 
-export function getRevokePrintDelegateV1DiscriminatorBytes() {
+export function getRevokePrintDelegateV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REVOKE_PRINT_DELEGATE_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/revokeProgrammableConfigItemV1.ts
+++ b/clients/js-kit/src/generated/instructions/revokeProgrammableConfigItemV1.ts
@@ -48,7 +48,7 @@ import { MetadataDelegateRole, type TokenStandardArgs } from '../types';
 
 export const REVOKE_PROGRAMMABLE_CONFIG_ITEM_V1_DISCRIMINATOR = 45;
 
-export function getRevokeProgrammableConfigItemV1DiscriminatorBytes() {
+export function getRevokeProgrammableConfigItemV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(
     REVOKE_PROGRAMMABLE_CONFIG_ITEM_V1_DISCRIMINATOR
   );

--- a/clients/js-kit/src/generated/instructions/revokeProgrammableConfigV1.ts
+++ b/clients/js-kit/src/generated/instructions/revokeProgrammableConfigV1.ts
@@ -48,7 +48,7 @@ import { MetadataDelegateRole, type TokenStandardArgs } from '../types';
 
 export const REVOKE_PROGRAMMABLE_CONFIG_V1_DISCRIMINATOR = 45;
 
-export function getRevokeProgrammableConfigV1DiscriminatorBytes() {
+export function getRevokeProgrammableConfigV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REVOKE_PROGRAMMABLE_CONFIG_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/revokeSaleV1.ts
+++ b/clients/js-kit/src/generated/instructions/revokeSaleV1.ts
@@ -48,7 +48,7 @@ import { TokenStandard, type TokenStandardArgs } from '../types';
 
 export const REVOKE_SALE_V1_DISCRIMINATOR = 45;
 
-export function getRevokeSaleV1DiscriminatorBytes() {
+export function getRevokeSaleV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REVOKE_SALE_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/revokeStakingV1.ts
+++ b/clients/js-kit/src/generated/instructions/revokeStakingV1.ts
@@ -48,7 +48,7 @@ import { TokenStandard, type TokenStandardArgs } from '../types';
 
 export const REVOKE_STAKING_V1_DISCRIMINATOR = 45;
 
-export function getRevokeStakingV1DiscriminatorBytes() {
+export function getRevokeStakingV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REVOKE_STAKING_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/revokeStandardV1.ts
+++ b/clients/js-kit/src/generated/instructions/revokeStandardV1.ts
@@ -48,7 +48,7 @@ import { type TokenStandardArgs } from '../types';
 
 export const REVOKE_STANDARD_V1_DISCRIMINATOR = 45;
 
-export function getRevokeStandardV1DiscriminatorBytes() {
+export function getRevokeStandardV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REVOKE_STANDARD_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/revokeTransferV1.ts
+++ b/clients/js-kit/src/generated/instructions/revokeTransferV1.ts
@@ -48,7 +48,7 @@ import { TokenStandard, type TokenStandardArgs } from '../types';
 
 export const REVOKE_TRANSFER_V1_DISCRIMINATOR = 45;
 
-export function getRevokeTransferV1DiscriminatorBytes() {
+export function getRevokeTransferV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REVOKE_TRANSFER_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/revokeUseAuthority.ts
+++ b/clients/js-kit/src/generated/instructions/revokeUseAuthority.ts
@@ -40,7 +40,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const REVOKE_USE_AUTHORITY_DISCRIMINATOR = 21;
 
-export function getRevokeUseAuthorityDiscriminatorBytes() {
+export function getRevokeUseAuthorityDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REVOKE_USE_AUTHORITY_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/revokeUtilityV1.ts
+++ b/clients/js-kit/src/generated/instructions/revokeUtilityV1.ts
@@ -48,7 +48,7 @@ import { TokenStandard, type TokenStandardArgs } from '../types';
 
 export const REVOKE_UTILITY_V1_DISCRIMINATOR = 45;
 
-export function getRevokeUtilityV1DiscriminatorBytes() {
+export function getRevokeUtilityV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(REVOKE_UTILITY_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/setAndVerifyCollection.ts
+++ b/clients/js-kit/src/generated/instructions/setAndVerifyCollection.ts
@@ -38,7 +38,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const SET_AND_VERIFY_COLLECTION_DISCRIMINATOR = 25;
 
-export function getSetAndVerifyCollectionDiscriminatorBytes() {
+export function getSetAndVerifyCollectionDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(SET_AND_VERIFY_COLLECTION_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/setAndVerifySizedCollectionItem.ts
+++ b/clients/js-kit/src/generated/instructions/setAndVerifySizedCollectionItem.ts
@@ -39,7 +39,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const SET_AND_VERIFY_SIZED_COLLECTION_ITEM_DISCRIMINATOR = 32;
 
-export function getSetAndVerifySizedCollectionItemDiscriminatorBytes() {
+export function getSetAndVerifySizedCollectionItemDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(
     SET_AND_VERIFY_SIZED_COLLECTION_ITEM_DISCRIMINATOR
   );

--- a/clients/js-kit/src/generated/instructions/setCollectionSize.ts
+++ b/clients/js-kit/src/generated/instructions/setCollectionSize.ts
@@ -44,7 +44,7 @@ import {
 
 export const SET_COLLECTION_SIZE_DISCRIMINATOR = 34;
 
-export function getSetCollectionSizeDiscriminatorBytes() {
+export function getSetCollectionSizeDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(SET_COLLECTION_SIZE_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/setTokenStandard.ts
+++ b/clients/js-kit/src/generated/instructions/setTokenStandard.ts
@@ -40,7 +40,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const SET_TOKEN_STANDARD_DISCRIMINATOR = 35;
 
-export function getSetTokenStandardDiscriminatorBytes() {
+export function getSetTokenStandardDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(SET_TOKEN_STANDARD_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/signMetadata.ts
+++ b/clients/js-kit/src/generated/instructions/signMetadata.ts
@@ -37,7 +37,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const SIGN_METADATA_DISCRIMINATOR = 7;
 
-export function getSignMetadataDiscriminatorBytes() {
+export function getSignMetadataDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(SIGN_METADATA_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/thawDelegatedAccount.ts
+++ b/clients/js-kit/src/generated/instructions/thawDelegatedAccount.ts
@@ -40,7 +40,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const THAW_DELEGATED_ACCOUNT_DISCRIMINATOR = 27;
 
-export function getThawDelegatedAccountDiscriminatorBytes() {
+export function getThawDelegatedAccountDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(THAW_DELEGATED_ACCOUNT_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/transfer.ts
+++ b/clients/js-kit/src/generated/instructions/transfer.ts
@@ -55,7 +55,7 @@ import {
 
 export const TRANSFER_DISCRIMINATOR = 49;
 
-export function getTransferDiscriminatorBytes() {
+export function getTransferDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(TRANSFER_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/transferOutOfEscrow.ts
+++ b/clients/js-kit/src/generated/instructions/transferOutOfEscrow.ts
@@ -41,7 +41,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const TRANSFER_OUT_OF_ESCROW_DISCRIMINATOR = 40;
 
-export function getTransferOutOfEscrowDiscriminatorBytes() {
+export function getTransferOutOfEscrowDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(TRANSFER_OUT_OF_ESCROW_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/transferV1.ts
+++ b/clients/js-kit/src/generated/instructions/transferV1.ts
@@ -62,7 +62,7 @@ import {
 
 export const TRANSFER_V1_DISCRIMINATOR = 49;
 
-export function getTransferV1DiscriminatorBytes() {
+export function getTransferV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(TRANSFER_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/unlock.ts
+++ b/clients/js-kit/src/generated/instructions/unlock.ts
@@ -59,7 +59,7 @@ import {
 
 export const UNLOCK_DISCRIMINATOR = 47;
 
-export function getUnlockDiscriminatorBytes() {
+export function getUnlockDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(UNLOCK_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/unlockV1.ts
+++ b/clients/js-kit/src/generated/instructions/unlockV1.ts
@@ -64,7 +64,7 @@ import {
 
 export const UNLOCK_V1_DISCRIMINATOR = 47;
 
-export function getUnlockV1DiscriminatorBytes() {
+export function getUnlockV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(UNLOCK_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/unverify.ts
+++ b/clients/js-kit/src/generated/instructions/unverify.ts
@@ -44,7 +44,7 @@ import {
 
 export const UNVERIFY_DISCRIMINATOR = 53;
 
-export function getUnverifyDiscriminatorBytes() {
+export function getUnverifyDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(UNVERIFY_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/unverifyCollection.ts
+++ b/clients/js-kit/src/generated/instructions/unverifyCollection.ts
@@ -38,7 +38,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const UNVERIFY_COLLECTION_DISCRIMINATOR = 22;
 
-export function getUnverifyCollectionDiscriminatorBytes() {
+export function getUnverifyCollectionDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(UNVERIFY_COLLECTION_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/unverifyCollectionV1.ts
+++ b/clients/js-kit/src/generated/instructions/unverifyCollectionV1.ts
@@ -40,7 +40,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const UNVERIFY_COLLECTION_V1_DISCRIMINATOR = 53;
 
-export function getUnverifyCollectionV1DiscriminatorBytes() {
+export function getUnverifyCollectionV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(UNVERIFY_COLLECTION_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/unverifyCreatorV1.ts
+++ b/clients/js-kit/src/generated/instructions/unverifyCreatorV1.ts
@@ -38,7 +38,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const UNVERIFY_CREATOR_V1_DISCRIMINATOR = 53;
 
-export function getUnverifyCreatorV1DiscriminatorBytes() {
+export function getUnverifyCreatorV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(UNVERIFY_CREATOR_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/unverifySizedCollectionItem.ts
+++ b/clients/js-kit/src/generated/instructions/unverifySizedCollectionItem.ts
@@ -39,7 +39,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const UNVERIFY_SIZED_COLLECTION_ITEM_DISCRIMINATOR = 31;
 
-export function getUnverifySizedCollectionItemDiscriminatorBytes() {
+export function getUnverifySizedCollectionItemDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(UNVERIFY_SIZED_COLLECTION_ITEM_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/update.ts
+++ b/clients/js-kit/src/generated/instructions/update.ts
@@ -47,7 +47,7 @@ import {
 
 export const UPDATE_DISCRIMINATOR = 50;
 
-export function getUpdateDiscriminatorBytes() {
+export function getUpdateDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(UPDATE_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/updateAsAuthorityItemDelegateV2.ts
+++ b/clients/js-kit/src/generated/instructions/updateAsAuthorityItemDelegateV2.ts
@@ -62,7 +62,7 @@ import {
 
 export const UPDATE_AS_AUTHORITY_ITEM_DELEGATE_V2_DISCRIMINATOR = 50;
 
-export function getUpdateAsAuthorityItemDelegateV2DiscriminatorBytes() {
+export function getUpdateAsAuthorityItemDelegateV2DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(
     UPDATE_AS_AUTHORITY_ITEM_DELEGATE_V2_DISCRIMINATOR
   );

--- a/clients/js-kit/src/generated/instructions/updateAsCollectionDelegateV2.ts
+++ b/clients/js-kit/src/generated/instructions/updateAsCollectionDelegateV2.ts
@@ -59,7 +59,7 @@ import {
 
 export const UPDATE_AS_COLLECTION_DELEGATE_V2_DISCRIMINATOR = 50;
 
-export function getUpdateAsCollectionDelegateV2DiscriminatorBytes() {
+export function getUpdateAsCollectionDelegateV2DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(UPDATE_AS_COLLECTION_DELEGATE_V2_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/updateAsCollectionItemDelegateV2.ts
+++ b/clients/js-kit/src/generated/instructions/updateAsCollectionItemDelegateV2.ts
@@ -59,7 +59,7 @@ import {
 
 export const UPDATE_AS_COLLECTION_ITEM_DELEGATE_V2_DISCRIMINATOR = 50;
 
-export function getUpdateAsCollectionItemDelegateV2DiscriminatorBytes() {
+export function getUpdateAsCollectionItemDelegateV2DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(
     UPDATE_AS_COLLECTION_ITEM_DELEGATE_V2_DISCRIMINATOR
   );

--- a/clients/js-kit/src/generated/instructions/updateAsDataDelegateV2.ts
+++ b/clients/js-kit/src/generated/instructions/updateAsDataDelegateV2.ts
@@ -58,7 +58,7 @@ import {
 
 export const UPDATE_AS_DATA_DELEGATE_V2_DISCRIMINATOR = 50;
 
-export function getUpdateAsDataDelegateV2DiscriminatorBytes() {
+export function getUpdateAsDataDelegateV2DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(UPDATE_AS_DATA_DELEGATE_V2_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/updateAsDataItemDelegateV2.ts
+++ b/clients/js-kit/src/generated/instructions/updateAsDataItemDelegateV2.ts
@@ -58,7 +58,7 @@ import {
 
 export const UPDATE_AS_DATA_ITEM_DELEGATE_V2_DISCRIMINATOR = 50;
 
-export function getUpdateAsDataItemDelegateV2DiscriminatorBytes() {
+export function getUpdateAsDataItemDelegateV2DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(UPDATE_AS_DATA_ITEM_DELEGATE_V2_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/updateAsProgrammableConfigDelegateV2.ts
+++ b/clients/js-kit/src/generated/instructions/updateAsProgrammableConfigDelegateV2.ts
@@ -59,7 +59,7 @@ import {
 
 export const UPDATE_AS_PROGRAMMABLE_CONFIG_DELEGATE_V2_DISCRIMINATOR = 50;
 
-export function getUpdateAsProgrammableConfigDelegateV2DiscriminatorBytes() {
+export function getUpdateAsProgrammableConfigDelegateV2DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(
     UPDATE_AS_PROGRAMMABLE_CONFIG_DELEGATE_V2_DISCRIMINATOR
   );

--- a/clients/js-kit/src/generated/instructions/updateAsProgrammableConfigItemDelegateV2.ts
+++ b/clients/js-kit/src/generated/instructions/updateAsProgrammableConfigItemDelegateV2.ts
@@ -59,7 +59,7 @@ import {
 
 export const UPDATE_AS_PROGRAMMABLE_CONFIG_ITEM_DELEGATE_V2_DISCRIMINATOR = 50;
 
-export function getUpdateAsProgrammableConfigItemDelegateV2DiscriminatorBytes() {
+export function getUpdateAsProgrammableConfigItemDelegateV2DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(
     UPDATE_AS_PROGRAMMABLE_CONFIG_ITEM_DELEGATE_V2_DISCRIMINATOR
   );

--- a/clients/js-kit/src/generated/instructions/updateAsUpdateAuthorityV2.ts
+++ b/clients/js-kit/src/generated/instructions/updateAsUpdateAuthorityV2.ts
@@ -84,7 +84,7 @@ import {
 
 export const UPDATE_AS_UPDATE_AUTHORITY_V2_DISCRIMINATOR = 50;
 
-export function getUpdateAsUpdateAuthorityV2DiscriminatorBytes() {
+export function getUpdateAsUpdateAuthorityV2DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(UPDATE_AS_UPDATE_AUTHORITY_V2_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/updateMetadataAccountV2.ts
+++ b/clients/js-kit/src/generated/instructions/updateMetadataAccountV2.ts
@@ -52,7 +52,7 @@ import {
 
 export const UPDATE_METADATA_ACCOUNT_V2_DISCRIMINATOR = 15;
 
-export function getUpdateMetadataAccountV2DiscriminatorBytes() {
+export function getUpdateMetadataAccountV2DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(UPDATE_METADATA_ACCOUNT_V2_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/updatePrimarySaleHappenedViaToken.ts
+++ b/clients/js-kit/src/generated/instructions/updatePrimarySaleHappenedViaToken.ts
@@ -38,7 +38,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const UPDATE_PRIMARY_SALE_HAPPENED_VIA_TOKEN_DISCRIMINATOR = 4;
 
-export function getUpdatePrimarySaleHappenedViaTokenDiscriminatorBytes() {
+export function getUpdatePrimarySaleHappenedViaTokenDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(
     UPDATE_PRIMARY_SALE_HAPPENED_VIA_TOKEN_DISCRIMINATOR
   );

--- a/clients/js-kit/src/generated/instructions/updateV1.ts
+++ b/clients/js-kit/src/generated/instructions/updateV1.ts
@@ -80,7 +80,7 @@ import {
 
 export const UPDATE_V1_DISCRIMINATOR = 50;
 
-export function getUpdateV1DiscriminatorBytes() {
+export function getUpdateV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(UPDATE_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/use.ts
+++ b/clients/js-kit/src/generated/instructions/use.ts
@@ -46,7 +46,7 @@ import {
 
 export const USE_DISCRIMINATOR = 51;
 
-export function getUseDiscriminatorBytes() {
+export function getUseDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(USE_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/useV1.ts
+++ b/clients/js-kit/src/generated/instructions/useV1.ts
@@ -51,7 +51,7 @@ import {
 
 export const USE_V1_DISCRIMINATOR = 51;
 
-export function getUseV1DiscriminatorBytes() {
+export function getUseV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(USE_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/utilize.ts
+++ b/clients/js-kit/src/generated/instructions/utilize.ts
@@ -42,7 +42,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const UTILIZE_DISCRIMINATOR = 19;
 
-export function getUtilizeDiscriminatorBytes() {
+export function getUtilizeDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(UTILIZE_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/verify.ts
+++ b/clients/js-kit/src/generated/instructions/verify.ts
@@ -44,7 +44,7 @@ import {
 
 export const VERIFY_DISCRIMINATOR = 52;
 
-export function getVerifyDiscriminatorBytes() {
+export function getVerifyDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(VERIFY_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/verifyCollection.ts
+++ b/clients/js-kit/src/generated/instructions/verifyCollection.ts
@@ -38,7 +38,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const VERIFY_COLLECTION_DISCRIMINATOR = 18;
 
-export function getVerifyCollectionDiscriminatorBytes() {
+export function getVerifyCollectionDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(VERIFY_COLLECTION_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/verifyCollectionV1.ts
+++ b/clients/js-kit/src/generated/instructions/verifyCollectionV1.ts
@@ -40,7 +40,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const VERIFY_COLLECTION_V1_DISCRIMINATOR = 52;
 
-export function getVerifyCollectionV1DiscriminatorBytes() {
+export function getVerifyCollectionV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(VERIFY_COLLECTION_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/verifyCreatorV1.ts
+++ b/clients/js-kit/src/generated/instructions/verifyCreatorV1.ts
@@ -38,7 +38,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const VERIFY_CREATOR_V1_DISCRIMINATOR = 52;
 
-export function getVerifyCreatorV1DiscriminatorBytes() {
+export function getVerifyCreatorV1DiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(VERIFY_CREATOR_V1_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/instructions/verifySizedCollectionItem.ts
+++ b/clients/js-kit/src/generated/instructions/verifySizedCollectionItem.ts
@@ -39,7 +39,7 @@ import { MPL_TOKEN_METADATA_PROGRAM_ADDRESS } from '../programs';
 
 export const VERIFY_SIZED_COLLECTION_ITEM_DISCRIMINATOR = 30;
 
-export function getVerifySizedCollectionItemDiscriminatorBytes() {
+export function getVerifySizedCollectionItemDiscriminatorBytes(): ReadonlyUint8Array {
   return getU8Encoder().encode(VERIFY_SIZED_COLLECTION_ITEM_DISCRIMINATOR);
 }
 

--- a/clients/js-kit/src/generated/programs/mplTokenMetadata.ts
+++ b/clients/js-kit/src/generated/programs/mplTokenMetadata.ts
@@ -9,6 +9,7 @@
 import {
   assertIsInstructionWithAccounts,
   containsBytes,
+  extendClient,
   getU8Encoder,
   SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_ACCOUNT,
   SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION,
@@ -2154,9 +2155,12 @@ export type MplTokenMetadataPluginRequirements = ClientWithRpc<
   ClientWithTransactionSending;
 
 export function mplTokenMetadataProgram() {
-  return <T extends MplTokenMetadataPluginRequirements>(client: T) => {
-    return {
-      ...client,
+  return <T extends MplTokenMetadataPluginRequirements>(
+    client: T
+  ): Omit<T, 'mplTokenMetadata'> & {
+    mplTokenMetadata: MplTokenMetadataPlugin;
+  } => {
+    return extendClient(client, {
       mplTokenMetadata: <MplTokenMetadataPlugin>{
         accounts: {
           collectionAuthorityRecord: addSelfFetchFunctions(
@@ -2521,7 +2525,7 @@ export function mplTokenMetadataProgram() {
           useAuthorityRecord: findUseAuthorityRecordPda,
         },
       },
-    };
+    });
   };
 }
 

--- a/clients/js-kit/src/hooked/createHelpers.ts
+++ b/clients/js-kit/src/hooked/createHelpers.ts
@@ -18,8 +18,13 @@ import { TokenStandard } from '../generated/types';
  * Input for createAndMint helper
  * Combines createV1 and mintV1 parameters
  */
-export type CreateAndMintInput = CreateV1AsyncInput &
-  Omit<MintV1AsyncInput, 'mint' | 'metadata'>;
+export type CreateAndMintInput = CreateV1AsyncInput & Omit<MintV1AsyncInput, 'mint' | 'metadata'>;
+
+/** Input for `createNft` — `tokenStandard` and `amount` are filled in by the helper. */
+export type CreateNftInput = Omit<CreateAndMintInput, 'amount' | 'tokenStandard'>;
+
+/** Input for `createProgrammableNft` — `tokenStandard` and `amount` are filled in by the helper. */
+export type CreateProgrammableNftInput = Omit<CreateAndMintInput, 'amount' | 'tokenStandard'>;
 
 /**
  * Creates and mints a token in one step
@@ -88,9 +93,7 @@ export async function createAndMint(
  * });
  * ```
  */
-export async function createNft(
-  input: Omit<CreateAndMintInput, 'amount' | 'tokenStandard'>
-): Promise<[Instruction, Instruction]> {
+export async function createNft(input: CreateNftInput): Promise<[Instruction, Instruction]> {
   return createAndMint({
     ...input,
     tokenStandard: TokenStandard.NonFungible,
@@ -120,7 +123,7 @@ export async function createNft(
  * ```
  */
 export async function createProgrammableNft(
-  input: Omit<CreateAndMintInput, 'amount' | 'tokenStandard'>
+  input: CreateProgrammableNftInput
 ): Promise<[Instruction, Instruction]> {
   return createAndMint({
     ...input,

--- a/clients/js-kit/src/hooked/digitalAsset.ts
+++ b/clients/js-kit/src/hooked/digitalAsset.ts
@@ -13,26 +13,12 @@ import type {
   FetchAccountsConfig,
   Rpc,
 } from '@solana/kit';
-import {
-  assertAccountExists,
-  fetchEncodedAccounts,
-  decodeAccount,
-} from '@solana/kit';
+import { assertAccountExists, fetchEncodedAccounts, decodeAccount } from '@solana/kit';
 import type { Mint } from '@solana-program/token';
 import { getMintDecoder } from '@solana-program/token';
-import {
-  fetchMetadata,
-  decodeMetadata,
-  type Metadata,
-} from '../generated/accounts/metadata';
-import {
-  decodeMasterEdition,
-  type MasterEdition,
-} from '../generated/accounts/masterEdition';
-import {
-  decodeEdition,
-  type Edition,
-} from '../generated/accounts/edition';
+import { fetchMetadata, decodeMetadata, type Metadata } from '../generated/accounts/metadata';
+import { decodeMasterEdition, type MasterEdition } from '../generated/accounts/masterEdition';
+import { decodeEdition, type Edition } from '../generated/accounts/edition';
 import { findMetadataPda, findMasterEditionPda } from '../generated/pdas';
 import { Key, getKeyDecoder } from '../generated/types';
 
@@ -47,9 +33,7 @@ export type DigitalAsset<TMint extends string = string> = {
   /** The metadata account data */
   metadata: Metadata;
   /** The edition account data (if present) */
-  edition?:
-    | ({ isOriginal: true } & MasterEdition)
-    | ({ isOriginal: false } & Edition);
+  edition?: ({ isOriginal: true } & MasterEdition) | ({ isOriginal: false } & Edition);
 };
 
 /**
@@ -219,7 +203,7 @@ export function deserializeDigitalAsset<TMint extends string = string>(
 
   // Decode edition account based on its key
   const keyDecoder = getKeyDecoder();
-  const editionKey = keyDecoder.decode(editionAccount.data)[0];
+  const editionKey = keyDecoder.decode(editionAccount.data);
 
   let edition: DigitalAsset<TMint>['edition'];
 

--- a/clients/js-kit/src/hooked/resolvers.ts
+++ b/clients/js-kit/src/hooked/resolvers.ts
@@ -3,12 +3,7 @@
  * These are called by the generated instruction builders to compute default values
  */
 
-import type {
-  Address,
-  OptionOrNullable,
-  TransactionSigner,
-  ProgramDerivedAddress,
-} from '@solana/kit';
+import type { Address, OptionOrNullable, TransactionSigner, ProgramDerivedAddress } from '@solana/kit';
 import type { ResolvedInstructionAccount } from '@solana/program-client-core';
 import type { TokenStandard } from '../generated/types/tokenStandard';
 import type { CollectionDetailsArgs } from '../generated/types/collectionDetails';
@@ -40,7 +35,7 @@ export function isNonFungible(tokenStandard: TokenStandard): boolean {
   return (
     tokenStandard === 0 || // TokenStandard.NonFungible
     tokenStandard === 3 || // TokenStandard.NonFungibleEdition
-    tokenStandard === 4 // TokenStandard.ProgrammableNonFungible
+    tokenStandard === 4    // TokenStandard.ProgrammableNonFungible
   );
 }
 
@@ -97,7 +92,9 @@ export function resolveCollectionDetails(
 /**
  * Check if token standard is non-fungible
  */
-export function resolveIsNonFungible(scope: ResolverScope<TokenStandardArgs>): boolean {
+export function resolveIsNonFungible(
+  scope: ResolverScope<TokenStandardArgs>
+): boolean {
   if (scope.args.tokenStandard === undefined) {
     throw new Error('tokenStandard is required');
   }
@@ -107,7 +104,9 @@ export function resolveIsNonFungible(scope: ResolverScope<TokenStandardArgs>): b
 /**
  * Resolve decimals based on token standard
  */
-export function resolveDecimals(scope: ResolverScope<TokenStandardArgs>): OptionOrNullable<number> {
+export function resolveDecimals(
+  scope: ResolverScope<TokenStandardArgs>
+): OptionOrNullable<number> {
   if (scope.args.tokenStandard === undefined) {
     throw new Error('tokenStandard is required');
   }
@@ -123,13 +122,17 @@ export function resolvePrintSupply(
   if (scope.args.tokenStandard === undefined) {
     throw new Error('tokenStandard is required');
   }
-  return isNonFungible(scope.args.tokenStandard) ? { __kind: 'Zero' } : null;
+  return isNonFungible(scope.args.tokenStandard)
+    ? { __kind: 'Zero' }
+    : null;
 }
 
 /**
  * Resolve creators from authority account
  */
-export function resolveCreators(scope: ResolverScope<unknown>): OptionOrNullable<CreatorArgs[]> {
+export function resolveCreators(
+  scope: ResolverScope<unknown>
+): OptionOrNullable<CreatorArgs[]> {
   const authorityAddress = getAddressFromAccount(scope.accounts.authority?.value);
   if (!authorityAddress) {
     throw new Error('authority account is required');
@@ -146,7 +149,9 @@ export function resolveCreators(scope: ResolverScope<unknown>): OptionOrNullable
 /**
  * Calculate byte delta for CreateV1 instruction
  */
-export function resolveCreateV1Bytes(scope: ResolverScope<TokenStandardArgs>): number {
+export function resolveCreateV1Bytes(
+  scope: ResolverScope<TokenStandardArgs>
+): number {
   const base = MINT_SIZE + METADATA_SIZE + 2 * ACCOUNT_HEADER_SIZE;
   if (scope.args.tokenStandard !== undefined && isNonFungible(scope.args.tokenStandard)) {
     return base + MASTER_EDITION_SIZE + ACCOUNT_HEADER_SIZE;
@@ -158,9 +163,9 @@ export function resolveCreateV1Bytes(scope: ResolverScope<TokenStandardArgs>): n
  * Resolve optional token owner
  * Returns the authority's address as the default token owner
  */
-export function resolveOptionalTokenOwner(scope: ResolverScope<unknown>): {
-  value: Address | null;
-} {
+export function resolveOptionalTokenOwner(
+  scope: ResolverScope<unknown>
+): { value: Address | null } {
   // If token is provided, return null (owner will be derived from token account)
   // Otherwise, use the authority's address as the owner
   const authorityAddress = getAddressFromAccount(scope.accounts.authority?.value);

--- a/clients/js-kit/src/hooked/resolvers.ts
+++ b/clients/js-kit/src/hooked/resolvers.ts
@@ -3,7 +3,12 @@
  * These are called by the generated instruction builders to compute default values
  */
 
-import type { Address, OptionOrNullable, TransactionSigner, ProgramDerivedAddress } from '@solana/kit';
+import type {
+  Address,
+  OptionOrNullable,
+  TransactionSigner,
+  ProgramDerivedAddress,
+} from '@solana/kit';
 import type { ResolvedInstructionAccount } from '@solana/program-client-core';
 import type { TokenStandard } from '../generated/types/tokenStandard';
 import type { CollectionDetailsArgs } from '../generated/types/collectionDetails';
@@ -35,7 +40,7 @@ export function isNonFungible(tokenStandard: TokenStandard): boolean {
   return (
     tokenStandard === 0 || // TokenStandard.NonFungible
     tokenStandard === 3 || // TokenStandard.NonFungibleEdition
-    tokenStandard === 4    // TokenStandard.ProgrammableNonFungible
+    tokenStandard === 4 // TokenStandard.ProgrammableNonFungible
   );
 }
 
@@ -92,9 +97,7 @@ export function resolveCollectionDetails(
 /**
  * Check if token standard is non-fungible
  */
-export function resolveIsNonFungible(
-  scope: ResolverScope<TokenStandardArgs>
-): boolean {
+export function resolveIsNonFungible(scope: ResolverScope<TokenStandardArgs>): boolean {
   if (scope.args.tokenStandard === undefined) {
     throw new Error('tokenStandard is required');
   }
@@ -104,9 +107,7 @@ export function resolveIsNonFungible(
 /**
  * Resolve decimals based on token standard
  */
-export function resolveDecimals(
-  scope: ResolverScope<TokenStandardArgs>
-): OptionOrNullable<number> {
+export function resolveDecimals(scope: ResolverScope<TokenStandardArgs>): OptionOrNullable<number> {
   if (scope.args.tokenStandard === undefined) {
     throw new Error('tokenStandard is required');
   }
@@ -122,17 +123,13 @@ export function resolvePrintSupply(
   if (scope.args.tokenStandard === undefined) {
     throw new Error('tokenStandard is required');
   }
-  return isNonFungible(scope.args.tokenStandard)
-    ? { __kind: 'Zero' }
-    : null;
+  return isNonFungible(scope.args.tokenStandard) ? { __kind: 'Zero' } : null;
 }
 
 /**
  * Resolve creators from authority account
  */
-export function resolveCreators(
-  scope: ResolverScope<unknown>
-): OptionOrNullable<CreatorArgs[]> {
+export function resolveCreators(scope: ResolverScope<unknown>): OptionOrNullable<CreatorArgs[]> {
   const authorityAddress = getAddressFromAccount(scope.accounts.authority?.value);
   if (!authorityAddress) {
     throw new Error('authority account is required');
@@ -149,9 +146,7 @@ export function resolveCreators(
 /**
  * Calculate byte delta for CreateV1 instruction
  */
-export function resolveCreateV1Bytes(
-  scope: ResolverScope<TokenStandardArgs>
-): number {
+export function resolveCreateV1Bytes(scope: ResolverScope<TokenStandardArgs>): number {
   const base = MINT_SIZE + METADATA_SIZE + 2 * ACCOUNT_HEADER_SIZE;
   if (scope.args.tokenStandard !== undefined && isNonFungible(scope.args.tokenStandard)) {
     return base + MASTER_EDITION_SIZE + ACCOUNT_HEADER_SIZE;
@@ -163,9 +158,9 @@ export function resolveCreateV1Bytes(
  * Resolve optional token owner
  * Returns the authority's address as the default token owner
  */
-export function resolveOptionalTokenOwner(
-  scope: ResolverScope<unknown>
-): { value: Address | null } {
+export function resolveOptionalTokenOwner(scope: ResolverScope<unknown>): {
+  value: Address | null;
+} {
   // If token is provided, return null (owner will be derived from token account)
   // Otherwise, use the authority's address as the owner
   const authorityAddress = getAddressFromAccount(scope.accounts.authority?.value);

--- a/clients/js-kit/src/index.ts
+++ b/clients/js-kit/src/index.ts
@@ -1,9 +1,17 @@
 /**
  * Metaplex Token Metadata - Codama Client
  *
- * This is the @solana/kit (web3.js 2.0) client for mpl-token-metadata
- * Generated using Codama
+ * @solana/kit (web3.js 2.0) client for mpl-token-metadata, generated using Codama.
  */
 
 export * from './generated';
+
+// Plugin overlay (must be re-exported explicitly so it shadows the generated names).
+export {
+  mplTokenMetadataProgram,
+  type MplTokenMetadataPlugin,
+  type MplTokenMetadataPluginInstructions,
+  type MplTokenMetadataPluginRequirements,
+} from './plugin';
+
 export * from './hooked';

--- a/clients/js-kit/src/index.ts
+++ b/clients/js-kit/src/index.ts
@@ -6,12 +6,11 @@
 
 export * from './generated';
 
-// Plugin overlay (must be re-exported explicitly so it shadows the generated names).
+// Plugin overlay — explicit named re-exports shadow the generated names.
 export {
   mplTokenMetadataProgram,
   type MplTokenMetadataPlugin,
   type MplTokenMetadataPluginInstructions,
-  type MplTokenMetadataPluginRequirements,
 } from './plugin';
 
 export * from './hooked';

--- a/clients/js-kit/src/plugin.ts
+++ b/clients/js-kit/src/plugin.ts
@@ -1,0 +1,125 @@
+import {
+  pipe,
+  sequentialInstructionPlan,
+  type Address,
+  type ClientWithPayer,
+  type FetchAccountConfig,
+  type FetchAccountsConfig,
+  type InstructionPlan,
+} from '@solana/kit';
+import {
+  addSelfPlanAndSendFunctions,
+  type SelfPlanAndSendFunctions,
+} from '@solana/program-client-core';
+
+import {
+  mplTokenMetadataProgram as generatedMplTokenMetadataProgram,
+  type MplTokenMetadataPlugin as GeneratedMplTokenMetadataPlugin,
+  type MplTokenMetadataPluginInstructions as GeneratedMplTokenMetadataPluginInstructions,
+  type MplTokenMetadataPluginRequirements as GeneratedMplTokenMetadataPluginRequirements,
+} from './generated';
+import {
+  createAndMint,
+  createNft,
+  createProgrammableNft,
+  type CreateAndMintInput,
+} from './hooked/createHelpers';
+import {
+  fetchAllDigitalAsset,
+  fetchDigitalAsset,
+  fetchDigitalAssetByMetadata,
+  type DigitalAsset,
+} from './hooked/digitalAsset';
+import {
+  fetchDigitalAssetWithToken,
+  fetchDigitalAssetWithAssociatedToken,
+  type DigitalAssetWithToken,
+} from './hooked/digitalAssetWithToken';
+
+type MakeOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+type CreateNftInput = Parameters<typeof createNft>[0];
+type CreateProgrammableNftInput = Parameters<typeof createProgrammableNft>[0];
+type PlanResult = Promise<InstructionPlan> & SelfPlanAndSendFunctions;
+
+export type MplTokenMetadataPluginRequirements = GeneratedMplTokenMetadataPluginRequirements &
+  ClientWithPayer;
+
+export type MplTokenMetadataPluginInstructions = GeneratedMplTokenMetadataPluginInstructions & {
+  /** Create a new asset and mint it in one sequential plan. */
+  createAndMint: (input: MakeOptional<CreateAndMintInput, 'payer'>) => PlanResult;
+  /** Create and mint a NonFungible NFT (amount=1). */
+  createNft: (input: MakeOptional<CreateNftInput, 'payer'>) => PlanResult;
+  /** Create and mint a ProgrammableNonFungible NFT (amount=1). */
+  createProgrammableNft: (input: MakeOptional<CreateProgrammableNftInput, 'payer'>) => PlanResult;
+};
+
+export type MplTokenMetadataPlugin = Omit<GeneratedMplTokenMetadataPlugin, 'instructions'> & {
+  instructions: MplTokenMetadataPluginInstructions;
+  /** Fetch a digital asset (mint + metadata + edition) by mint address. */
+  fetchDigitalAsset: <TMint extends string = string>(
+    mint: Address<TMint>,
+    config?: FetchAccountConfig
+  ) => Promise<DigitalAsset<TMint>>;
+  /** Fetch a digital asset by metadata address. */
+  fetchDigitalAssetByMetadata: (
+    metadataAddress: Address,
+    config?: FetchAccountConfig
+  ) => Promise<DigitalAsset>;
+  /** Fetch multiple digital assets by mint addresses. */
+  fetchAllDigitalAsset: (mints: Address[], config?: FetchAccountsConfig) => Promise<DigitalAsset[]>;
+  /** Fetch a digital asset together with a specific token account. */
+  fetchDigitalAssetWithToken: (
+    mint: Address,
+    token: Address,
+    config?: FetchAccountConfig
+  ) => Promise<DigitalAssetWithToken>;
+  /** Fetch a digital asset together with the owner's ATA. */
+  fetchDigitalAssetWithAssociatedToken: (
+    mint: Address,
+    owner: Address,
+    config?: FetchAccountConfig
+  ) => Promise<DigitalAssetWithToken>;
+};
+
+export function mplTokenMetadataProgram() {
+  return <T extends MplTokenMetadataPluginRequirements>(client: T) => {
+    return pipe(client, generatedMplTokenMetadataProgram(), (c) => ({
+      ...c,
+      mplTokenMetadata: <MplTokenMetadataPlugin>{
+        ...c.mplTokenMetadata,
+        instructions: {
+          ...c.mplTokenMetadata.instructions,
+          createAndMint: (input) =>
+            addSelfPlanAndSendFunctions(
+              client,
+              createAndMint({ payer: client.payer, ...input }).then((ixs) =>
+                sequentialInstructionPlan(ixs)
+              )
+            ),
+          createNft: (input) =>
+            addSelfPlanAndSendFunctions(
+              client,
+              createNft({ payer: client.payer, ...input }).then((ixs) =>
+                sequentialInstructionPlan(ixs)
+              )
+            ),
+          createProgrammableNft: (input) =>
+            addSelfPlanAndSendFunctions(
+              client,
+              createProgrammableNft({ payer: client.payer, ...input }).then((ixs) =>
+                sequentialInstructionPlan(ixs)
+              )
+            ),
+        },
+        fetchDigitalAsset: (mint, config) => fetchDigitalAsset(client.rpc, mint, config),
+        fetchDigitalAssetByMetadata: (metadataAddress, config) =>
+          fetchDigitalAssetByMetadata(client.rpc, metadataAddress, config),
+        fetchAllDigitalAsset: (mints, config) => fetchAllDigitalAsset(client.rpc, mints, config),
+        fetchDigitalAssetWithToken: (mint, token, config) =>
+          fetchDigitalAssetWithToken(client.rpc, mint, token, config),
+        fetchDigitalAssetWithAssociatedToken: (mint, owner, config) =>
+          fetchDigitalAssetWithAssociatedToken(client.rpc, mint, owner, config),
+      },
+    }));
+  };
+}

--- a/clients/js-kit/src/plugin.ts
+++ b/clients/js-kit/src/plugin.ts
@@ -2,7 +2,6 @@ import {
   pipe,
   sequentialInstructionPlan,
   type Address,
-  type ClientWithPayer,
   type FetchAccountConfig,
   type FetchAccountsConfig,
   type InstructionPlan,
@@ -16,13 +15,15 @@ import {
   mplTokenMetadataProgram as generatedMplTokenMetadataProgram,
   type MplTokenMetadataPlugin as GeneratedMplTokenMetadataPlugin,
   type MplTokenMetadataPluginInstructions as GeneratedMplTokenMetadataPluginInstructions,
-  type MplTokenMetadataPluginRequirements as GeneratedMplTokenMetadataPluginRequirements,
+  type MplTokenMetadataPluginRequirements,
 } from './generated';
 import {
   createAndMint,
   createNft,
   createProgrammableNft,
   type CreateAndMintInput,
+  type CreateNftInput,
+  type CreateProgrammableNftInput,
 } from './hooked/createHelpers';
 import {
   fetchAllDigitalAsset,
@@ -37,43 +38,31 @@ import {
 } from './hooked/digitalAssetWithToken';
 
 type MakeOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
-type CreateNftInput = Parameters<typeof createNft>[0];
-type CreateProgrammableNftInput = Parameters<typeof createProgrammableNft>[0];
-type PlanResult = Promise<InstructionPlan> & SelfPlanAndSendFunctions;
-
-export type MplTokenMetadataPluginRequirements = GeneratedMplTokenMetadataPluginRequirements &
-  ClientWithPayer;
+type PlanResult = PromiseLike<InstructionPlan> & SelfPlanAndSendFunctions;
 
 export type MplTokenMetadataPluginInstructions = GeneratedMplTokenMetadataPluginInstructions & {
-  /** Create a new asset and mint it in one sequential plan. */
   createAndMint: (input: MakeOptional<CreateAndMintInput, 'payer'>) => PlanResult;
-  /** Create and mint a NonFungible NFT (amount=1). */
   createNft: (input: MakeOptional<CreateNftInput, 'payer'>) => PlanResult;
-  /** Create and mint a ProgrammableNonFungible NFT (amount=1). */
   createProgrammableNft: (input: MakeOptional<CreateProgrammableNftInput, 'payer'>) => PlanResult;
 };
 
 export type MplTokenMetadataPlugin = Omit<GeneratedMplTokenMetadataPlugin, 'instructions'> & {
   instructions: MplTokenMetadataPluginInstructions;
-  /** Fetch a digital asset (mint + metadata + edition) by mint address. */
   fetchDigitalAsset: <TMint extends string = string>(
     mint: Address<TMint>,
     config?: FetchAccountConfig
   ) => Promise<DigitalAsset<TMint>>;
-  /** Fetch a digital asset by metadata address. */
   fetchDigitalAssetByMetadata: (
     metadataAddress: Address,
     config?: FetchAccountConfig
   ) => Promise<DigitalAsset>;
-  /** Fetch multiple digital assets by mint addresses. */
   fetchAllDigitalAsset: (mints: Address[], config?: FetchAccountsConfig) => Promise<DigitalAsset[]>;
-  /** Fetch a digital asset together with a specific token account. */
   fetchDigitalAssetWithToken: (
     mint: Address,
     token: Address,
     config?: FetchAccountConfig
   ) => Promise<DigitalAssetWithToken>;
-  /** Fetch a digital asset together with the owner's ATA. */
+  /** Fetches a digital asset together with the owner's associated token account. */
   fetchDigitalAssetWithAssociatedToken: (
     mint: Address,
     owner: Address,
@@ -92,25 +81,26 @@ export function mplTokenMetadataProgram() {
           createAndMint: (input) =>
             addSelfPlanAndSendFunctions(
               client,
-              createAndMint({ payer: client.payer, ...input }).then((ixs) =>
+              createAndMint({ ...input, payer: input.payer ?? client.payer }).then((ixs) =>
                 sequentialInstructionPlan(ixs)
               )
             ),
           createNft: (input) =>
             addSelfPlanAndSendFunctions(
               client,
-              createNft({ payer: client.payer, ...input }).then((ixs) =>
+              createNft({ ...input, payer: input.payer ?? client.payer }).then((ixs) =>
                 sequentialInstructionPlan(ixs)
               )
             ),
           createProgrammableNft: (input) =>
             addSelfPlanAndSendFunctions(
               client,
-              createProgrammableNft({ payer: client.payer, ...input }).then((ixs) =>
+              createProgrammableNft({ ...input, payer: input.payer ?? client.payer }).then((ixs) =>
                 sequentialInstructionPlan(ixs)
               )
             ),
         },
+        // `config?` is load-bearing: `satisfies` does not widen the inferred literal.
         fetchDigitalAsset: (mint, config?) => fetchDigitalAsset(client.rpc, mint, config),
         fetchDigitalAssetByMetadata: (metadataAddress, config?) =>
           fetchDigitalAssetByMetadata(client.rpc, metadataAddress, config),

--- a/clients/js-kit/src/plugin.ts
+++ b/clients/js-kit/src/plugin.ts
@@ -85,7 +85,7 @@ export function mplTokenMetadataProgram() {
   return <T extends MplTokenMetadataPluginRequirements>(client: T) => {
     return pipe(client, generatedMplTokenMetadataProgram(), (c) => ({
       ...c,
-      mplTokenMetadata: <MplTokenMetadataPlugin>{
+      mplTokenMetadata: {
         ...c.mplTokenMetadata,
         instructions: {
           ...c.mplTokenMetadata.instructions,
@@ -111,15 +111,15 @@ export function mplTokenMetadataProgram() {
               )
             ),
         },
-        fetchDigitalAsset: (mint, config) => fetchDigitalAsset(client.rpc, mint, config),
-        fetchDigitalAssetByMetadata: (metadataAddress, config) =>
+        fetchDigitalAsset: (mint, config?) => fetchDigitalAsset(client.rpc, mint, config),
+        fetchDigitalAssetByMetadata: (metadataAddress, config?) =>
           fetchDigitalAssetByMetadata(client.rpc, metadataAddress, config),
-        fetchAllDigitalAsset: (mints, config) => fetchAllDigitalAsset(client.rpc, mints, config),
-        fetchDigitalAssetWithToken: (mint, token, config) =>
+        fetchAllDigitalAsset: (mints, config?) => fetchAllDigitalAsset(client.rpc, mints, config),
+        fetchDigitalAssetWithToken: (mint, token, config?) =>
           fetchDigitalAssetWithToken(client.rpc, mint, token, config),
-        fetchDigitalAssetWithAssociatedToken: (mint, owner, config) =>
+        fetchDigitalAssetWithAssociatedToken: (mint, owner, config?) =>
           fetchDigitalAssetWithAssociatedToken(client.rpc, mint, owner, config),
-      },
+      } satisfies MplTokenMetadataPlugin,
     }));
   };
 }

--- a/clients/js-kit/test/_setup.ts
+++ b/clients/js-kit/test/_setup.ts
@@ -3,7 +3,22 @@
  */
 
 import type { Address } from '@solana/kit';
-import { createSolanaRpc, createSolanaRpcSubscriptions, airdropFactory, lamports, type Rpc, type RpcSubscriptions, type SolanaRpcApi, type SolanaRpcSubscriptionsApi } from '@solana/kit';
+import {
+  createClient,
+  createSolanaRpc,
+  createSolanaRpcSubscriptions,
+  airdropFactory,
+  lamports,
+  type Rpc,
+  type RpcSubscriptions,
+  type SolanaRpcApi,
+  type SolanaRpcSubscriptionsApi,
+} from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+import { systemProgram } from '@solana-program/system';
+import { tokenProgram } from '@solana-program/token';
+import { mplTokenMetadataProgram } from '../src';
 
 // Re-export transaction utilities
 export { sendAndConfirm, sendAndConfirmInstructions } from './_transaction';
@@ -57,6 +72,20 @@ To run these tests:
 
 The validator should be running at ${LOCAL_VALIDATOR_URL}
 `.trim();
+}
+
+/**
+ * Create a localhost client preloaded with the system, token, and mpl-token-metadata
+ * program plugins. Generates and funds a fresh payer.
+ */
+export async function createMplClient() {
+  return createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(10_000_000_000n)))
+    .use(systemProgram())
+    .use(tokenProgram())
+    .use(mplTokenMetadataProgram());
 }
 
 export async function airdrop(

--- a/clients/js-kit/test/_setup.ts
+++ b/clients/js-kit/test/_setup.ts
@@ -79,7 +79,7 @@ The validator should be running at ${LOCAL_VALIDATOR_URL}
  * program plugins. Generates and funds a fresh payer.
  */
 export async function createMplClient() {
-  return createClient()
+  return await createClient()
     .use(generatedSigner())
     .use(solanaLocalRpc())
     .use(airdropSigner(lamports(10_000_000_000n)))

--- a/clients/js-kit/test/fetchDigitalAsset.test.ts
+++ b/clients/js-kit/test/fetchDigitalAsset.test.ts
@@ -13,10 +13,14 @@
  */
 
 import test from 'ava';
-import { TokenStandard } from '../src/generated/types';
-import { getCreateV1InstructionAsync } from '../src/generated/instructions';
+import { TokenStandard, type PrintSupply } from '../src/generated/types';
+import {
+  getCreateV1InstructionAsync,
+  getMintV1InstructionAsync,
+  getPrintV1InstructionAsync,
+} from '../src/generated/instructions';
 import { findMetadataPda } from '../src/generated/pdas';
-import { SPL_TOKEN_PROGRAM_ADDRESS } from './_setup';
+import { SPL_TOKEN_PROGRAM_ADDRESS, findAssociatedTokenPda } from './_setup';
 import {
   fetchDigitalAsset,
   fetchDigitalAssetByMetadata,
@@ -62,10 +66,7 @@ test('it can fetch a NonFungible digital asset', async (t) => {
     tokenStandard: TokenStandard.NonFungible,
   });
 
-  await sendAndConfirm(rpc, rpcSubscriptions, createInstruction, [
-    mint,
-    authority,
-  ]);
+  await sendAndConfirm(rpc, rpcSubscriptions, createInstruction, [mint, authority]);
 
   // Fetch the digital asset
   const digitalAsset = await fetchDigitalAsset(rpc, mint.address);
@@ -78,11 +79,9 @@ test('it can fetch a NonFungible digital asset', async (t) => {
   t.is(digitalAsset.metadata.uri, 'https://example.com/nft.json');
   t.is(digitalAsset.metadata.sellerFeeBasisPoints, basisPoints(5.5));
 
-  // Note: Edition data may or may not be present immediately after creation
-  // depending on whether the master edition has been initialized
-  // Just verify the core metadata structure is correct
-
-  t.pass('Successfully fetched NonFungible digital asset');
+  // createV1 with NonFungible always initializes the master edition.
+  t.truthy(digitalAsset.edition);
+  t.is(digitalAsset.edition?.isOriginal, true);
 });
 
 /**
@@ -114,10 +113,7 @@ test('it can fetch a digital asset by metadata address', async (t) => {
     tokenStandard: TokenStandard.NonFungible,
   });
 
-  await sendAndConfirm(rpc, rpcSubscriptions, createInstruction, [
-    mint,
-    authority,
-  ]);
+  await sendAndConfirm(rpc, rpcSubscriptions, createInstruction, [mint, authority]);
 
   // Get metadata address
   const [metadataAddress] = await findMetadataPda({ mint: mint.address });
@@ -162,10 +158,7 @@ test('it can fetch a Fungible digital asset without edition', async (t) => {
     tokenStandard: TokenStandard.Fungible,
   });
 
-  await sendAndConfirm(rpc, rpcSubscriptions, createInstruction, [
-    mint,
-    authority,
-  ]);
+  await sendAndConfirm(rpc, rpcSubscriptions, createInstruction, [mint, authority]);
 
   // Fetch the digital asset
   const digitalAsset = await fetchDigitalAsset(rpc, mint.address);
@@ -212,10 +205,7 @@ test('it can fetch multiple digital assets in a batch', async (t) => {
       tokenStandard: TokenStandard.NonFungible,
     });
 
-    await sendAndConfirm(rpc, rpcSubscriptions, createInstruction, [
-      mint,
-      authority,
-    ]);
+    await sendAndConfirm(rpc, rpcSubscriptions, createInstruction, [mint, authority]);
   }
 
   // Fetch all three at once
@@ -234,10 +224,8 @@ test('it can fetch multiple digital assets in a batch', async (t) => {
     t.truthy(asset.metadata);
     t.is(asset.metadata.name, `Batch NFT ${index + 1}`);
     t.is(asset.metadata.uri, `https://example.com/batch${index + 1}.json`);
-    // Note: Edition data may or may not be present depending on initialization
+    t.is(asset.edition?.isOriginal, true);
   }
-
-  t.pass('Successfully batch fetched multiple digital assets');
 });
 
 /**
@@ -258,4 +246,67 @@ test('it returns empty array when fetching with no mints', async (t) => {
 
   t.is(digitalAssets.length, 0);
   t.pass('Successfully handled empty mint array');
+});
+
+test('it returns isOriginal:false for a printed edition', async (t) => {
+  const canRun = await canRunTests();
+  if (!canRun) {
+    t.log(getSkipMessage());
+    t.pass('Skipped - validator not running');
+    return;
+  }
+
+  const rpc = createRpc();
+  const rpcSubscriptions = createRpcSubscriptions();
+  const masterMint = await createKeypair();
+  const masterOwner = await createKeypair();
+
+  await airdrop(rpc, masterOwner.address);
+
+  const createIx = await getCreateV1InstructionAsync({
+    mint: masterMint,
+    authority: masterOwner,
+    payer: masterOwner,
+    name: 'Master',
+    uri: 'https://example.com/master.json',
+    sellerFeeBasisPoints: basisPoints(0),
+    tokenStandard: TokenStandard.NonFungible,
+    printSupply: { __kind: 'Limited', fields: [10n] } as PrintSupply,
+  });
+  await sendAndConfirm(rpc, rpcSubscriptions, createIx, [masterMint, masterOwner]);
+
+  const [masterTokenAddress] = await findAssociatedTokenPda({
+    mint: masterMint.address,
+    owner: masterOwner.address,
+  });
+  const mintIx = await getMintV1InstructionAsync({
+    mint: masterMint.address,
+    authority: masterOwner,
+    payer: masterOwner,
+    token: masterTokenAddress,
+    tokenOwner: masterOwner.address,
+    tokenStandard: TokenStandard.NonFungible,
+    amount: 1n,
+  });
+  await sendAndConfirm(rpc, rpcSubscriptions, mintIx, [masterOwner]);
+
+  const editionMint = await createKeypair();
+  const editionOwner = await createKeypair();
+  await airdrop(rpc, editionOwner.address);
+
+  const printIx = await getPrintV1InstructionAsync({
+    masterEditionMint: masterMint.address,
+    masterTokenAccountOwner: masterOwner,
+    editionMint,
+    editionTokenAccountOwner: editionOwner.address,
+    editionNumber: 1n,
+    tokenStandard: TokenStandard.NonFungible,
+    payer: editionOwner,
+    updateAuthority: masterOwner.address,
+  });
+  await sendAndConfirm(rpc, rpcSubscriptions, printIx, [editionMint, editionOwner, masterOwner]);
+
+  const printed = await fetchDigitalAsset(rpc, editionMint.address);
+  t.truthy(printed.edition);
+  t.is(printed.edition?.isOriginal, false);
 });

--- a/clients/js-kit/test/plugin.test.ts
+++ b/clients/js-kit/test/plugin.test.ts
@@ -188,10 +188,7 @@ test('plugin: fetchAllDigitalAsset batches multiple mints', async (t) => {
       .sendTransaction();
   }
 
-  const assets = await client.mplTokenMetadata.fetchAllDigitalAsset([
-    mint1.address,
-    mint2.address,
-  ]);
+  const assets = await client.mplTokenMetadata.fetchAllDigitalAsset([mint1.address, mint2.address]);
   t.is(assets.length, 2);
   t.is(assets[0].metadata.name, 'Batch NFT 1');
   t.is(assets[1].metadata.name, 'Batch NFT 2');
@@ -297,9 +294,7 @@ test('plugin: raw generated instruction (signMetadata) is wired through overlay'
   const metadata = await client.mplTokenMetadata.accounts.metadata.fetch(metadataPda);
   t.is(metadata.data.creators.__option, 'Some');
   if (metadata.data.creators.__option === 'Some') {
-    const signer = metadata.data.creators.value.find(
-      (c) => c.address === client.payer.address
-    );
+    const signer = metadata.data.creators.value.find((c) => c.address === client.payer.address);
     t.truthy(signer);
     t.is(signer?.verified, true);
   }

--- a/clients/js-kit/test/plugin.test.ts
+++ b/clients/js-kit/test/plugin.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Plugin tests for the @solana/kit overlay surface
+ *
+ * Exercises `mplTokenMetadataProgram()` via `createLocalClient`:
+ * - generated account fetchers via `client.mplTokenMetadata.accounts.*`
+ * - generated PDA helpers via `client.mplTokenMetadata.pdas.*`
+ * - hand-written `createNft` / `createAndMint` helpers
+ * - hand-written `fetchDigitalAsset*` aggregators
+ */
+
+import test from 'ava';
+import { TokenStandard } from '../src/generated/types';
+import { createKeypair, createMplClient, basisPoints, canRunTests, getSkipMessage } from './_setup';
+
+test('plugin: createNft + fetchMetadata via plugin surface', async (t) => {
+  if (!(await canRunTests())) {
+    t.log(getSkipMessage());
+    t.pass('Skipped - validator not running');
+    return;
+  }
+
+  const client = await createMplClient();
+  const mint = await createKeypair();
+
+  await client.mplTokenMetadata.instructions
+    .createNft({
+      mint,
+      name: 'Plugin NFT',
+      uri: 'https://example.com/plugin.json',
+      sellerFeeBasisPoints: basisPoints(5),
+      tokenOwner: client.payer.address,
+    })
+    .sendTransaction();
+
+  const [metadataPda] = await client.mplTokenMetadata.pdas.metadata({
+    mint: mint.address,
+  });
+  const metadata = await client.mplTokenMetadata.accounts.metadata.fetch(metadataPda);
+  t.is(metadata.data.mint, mint.address);
+  t.is(metadata.data.name, 'Plugin NFT');
+  t.is(metadata.data.sellerFeeBasisPoints, 500);
+});
+
+test('plugin: createAndMint + fetchDigitalAsset', async (t) => {
+  if (!(await canRunTests())) {
+    t.log(getSkipMessage());
+    t.pass('Skipped - validator not running');
+    return;
+  }
+
+  const client = await createMplClient();
+  const mint = await createKeypair();
+
+  await client.mplTokenMetadata.instructions
+    .createAndMint({
+      mint,
+      name: 'Plugin Combined',
+      uri: 'https://example.com/combined.json',
+      sellerFeeBasisPoints: basisPoints(2.5),
+      tokenStandard: TokenStandard.NonFungible,
+      amount: 1,
+      tokenOwner: client.payer.address,
+    })
+    .sendTransaction();
+
+  const asset = await client.mplTokenMetadata.fetchDigitalAsset(mint.address);
+  t.is(asset.address, mint.address);
+  t.is(asset.metadata.name, 'Plugin Combined');
+  t.truthy(asset.edition);
+  t.is(asset.edition?.isOriginal, true);
+});
+
+test('plugin: fetchDigitalAssetWithAssociatedToken returns token state', async (t) => {
+  if (!(await canRunTests())) {
+    t.log(getSkipMessage());
+    t.pass('Skipped - validator not running');
+    return;
+  }
+
+  const client = await createMplClient();
+  const mint = await createKeypair();
+
+  await client.mplTokenMetadata.instructions
+    .createNft({
+      mint,
+      name: 'Owned NFT',
+      uri: 'https://example.com/owned.json',
+      sellerFeeBasisPoints: basisPoints(0),
+      tokenOwner: client.payer.address,
+    })
+    .sendTransaction();
+
+  const owned = await client.mplTokenMetadata.fetchDigitalAssetWithAssociatedToken(
+    mint.address,
+    client.payer.address
+  );
+  t.is(owned.token.mint, mint.address);
+  t.is(owned.token.owner, client.payer.address);
+  t.is(owned.token.amount, 1n);
+});

--- a/clients/js-kit/test/plugin.test.ts
+++ b/clients/js-kit/test/plugin.test.ts
@@ -130,6 +130,7 @@ test('plugin: createProgrammableNft + fetchDigitalAsset', async (t) => {
   const asset = await client.mplTokenMetadata.fetchDigitalAsset(mint.address);
   t.is(asset.address, mint.address);
   t.is(asset.metadata.name, 'Plugin PNFT');
+  t.is(asset.metadata.tokenStandard.__option, 'Some');
   if (asset.metadata.tokenStandard.__option === 'Some') {
     t.is(asset.metadata.tokenStandard.value, TokenStandard.ProgrammableNonFungible);
   }

--- a/clients/js-kit/test/plugin.test.ts
+++ b/clients/js-kit/test/plugin.test.ts
@@ -10,7 +10,15 @@
 
 import test from 'ava';
 import { TokenStandard } from '../src/generated/types';
-import { createKeypair, createMplClient, basisPoints, canRunTests, getSkipMessage } from './_setup';
+import {
+  createKeypair,
+  createMplClient,
+  basisPoints,
+  canRunTests,
+  getSkipMessage,
+  findAssociatedTokenPda,
+  airdrop,
+} from './_setup';
 
 test('plugin: createNft + fetchMetadata via plugin surface', async (t) => {
   if (!(await canRunTests())) {
@@ -97,4 +105,202 @@ test('plugin: fetchDigitalAssetWithAssociatedToken returns token state', async (
   t.is(owned.token.mint, mint.address);
   t.is(owned.token.owner, client.payer.address);
   t.is(owned.token.amount, 1n);
+});
+
+test('plugin: createProgrammableNft + fetchDigitalAsset', async (t) => {
+  if (!(await canRunTests())) {
+    t.log(getSkipMessage());
+    t.pass('Skipped - validator not running');
+    return;
+  }
+
+  const client = await createMplClient();
+  const mint = await createKeypair();
+
+  await client.mplTokenMetadata.instructions
+    .createProgrammableNft({
+      mint,
+      name: 'Plugin PNFT',
+      uri: 'https://example.com/pnft.json',
+      sellerFeeBasisPoints: basisPoints(7.5),
+      tokenOwner: client.payer.address,
+    })
+    .sendTransaction();
+
+  const asset = await client.mplTokenMetadata.fetchDigitalAsset(mint.address);
+  t.is(asset.address, mint.address);
+  t.is(asset.metadata.name, 'Plugin PNFT');
+  if (asset.metadata.tokenStandard.__option === 'Some') {
+    t.is(asset.metadata.tokenStandard.value, TokenStandard.ProgrammableNonFungible);
+  }
+  t.truthy(asset.edition);
+  t.is(asset.edition?.isOriginal, true);
+});
+
+test('plugin: fetchDigitalAssetByMetadata returns asset by metadata pda', async (t) => {
+  if (!(await canRunTests())) {
+    t.log(getSkipMessage());
+    t.pass('Skipped - validator not running');
+    return;
+  }
+
+  const client = await createMplClient();
+  const mint = await createKeypair();
+
+  await client.mplTokenMetadata.instructions
+    .createNft({
+      mint,
+      name: 'By Metadata',
+      uri: 'https://example.com/by-metadata.json',
+      sellerFeeBasisPoints: basisPoints(1),
+      tokenOwner: client.payer.address,
+    })
+    .sendTransaction();
+
+  const [metadataPda] = await client.mplTokenMetadata.pdas.metadata({
+    mint: mint.address,
+  });
+  const asset = await client.mplTokenMetadata.fetchDigitalAssetByMetadata(metadataPda);
+  t.is(asset.address, mint.address);
+  t.is(asset.metadata.name, 'By Metadata');
+});
+
+test('plugin: fetchAllDigitalAsset batches multiple mints', async (t) => {
+  if (!(await canRunTests())) {
+    t.log(getSkipMessage());
+    t.pass('Skipped - validator not running');
+    return;
+  }
+
+  const client = await createMplClient();
+  const mint1 = await createKeypair();
+  const mint2 = await createKeypair();
+
+  for (const [index, mint] of [mint1, mint2].entries()) {
+    await client.mplTokenMetadata.instructions
+      .createNft({
+        mint,
+        name: `Batch NFT ${index + 1}`,
+        uri: `https://example.com/batch${index + 1}.json`,
+        sellerFeeBasisPoints: basisPoints(1),
+        tokenOwner: client.payer.address,
+      })
+      .sendTransaction();
+  }
+
+  const assets = await client.mplTokenMetadata.fetchAllDigitalAsset([
+    mint1.address,
+    mint2.address,
+  ]);
+  t.is(assets.length, 2);
+  t.is(assets[0].metadata.name, 'Batch NFT 1');
+  t.is(assets[1].metadata.name, 'Batch NFT 2');
+});
+
+test('plugin: fetchDigitalAssetWithToken returns explicit token state', async (t) => {
+  if (!(await canRunTests())) {
+    t.log(getSkipMessage());
+    t.pass('Skipped - validator not running');
+    return;
+  }
+
+  const client = await createMplClient();
+  const mint = await createKeypair();
+
+  await client.mplTokenMetadata.instructions
+    .createNft({
+      mint,
+      name: 'Explicit Token NFT',
+      uri: 'https://example.com/explicit.json',
+      sellerFeeBasisPoints: basisPoints(0),
+      tokenOwner: client.payer.address,
+    })
+    .sendTransaction();
+
+  const [tokenAddress] = await findAssociatedTokenPda({
+    mint: mint.address,
+    owner: client.payer.address,
+  });
+  const owned = await client.mplTokenMetadata.fetchDigitalAssetWithToken(
+    mint.address,
+    tokenAddress
+  );
+  t.is(owned.address, mint.address);
+  t.is(owned.token.mint, mint.address);
+  t.is(owned.token.owner, client.payer.address);
+  t.is(owned.token.amount, 1n);
+});
+
+test('plugin: explicit payer overrides client.payer fallback', async (t) => {
+  if (!(await canRunTests())) {
+    t.log(getSkipMessage());
+    t.pass('Skipped - validator not running');
+    return;
+  }
+
+  const client = await createMplClient();
+  const mint = await createKeypair();
+  const altPayer = await createKeypair();
+  await airdrop(client.rpc, altPayer.address);
+
+  await client.mplTokenMetadata.instructions
+    .createNft({
+      mint,
+      payer: altPayer,
+      authority: altPayer,
+      name: 'Alt Payer NFT',
+      uri: 'https://example.com/alt-payer.json',
+      sellerFeeBasisPoints: basisPoints(1),
+      tokenOwner: altPayer.address,
+    })
+    .sendTransaction();
+
+  const [metadataPda] = await client.mplTokenMetadata.pdas.metadata({
+    mint: mint.address,
+  });
+  const metadata = await client.mplTokenMetadata.accounts.metadata.fetch(metadataPda);
+  t.is(metadata.data.updateAuthority, altPayer.address);
+  t.not(metadata.data.updateAuthority, client.payer.address);
+});
+
+test('plugin: raw generated instruction (signMetadata) is wired through overlay', async (t) => {
+  if (!(await canRunTests())) {
+    t.log(getSkipMessage());
+    t.pass('Skipped - validator not running');
+    return;
+  }
+
+  const client = await createMplClient();
+  const mint = await createKeypair();
+
+  await client.mplTokenMetadata.instructions
+    .createNft({
+      mint,
+      name: 'Sign Me',
+      uri: 'https://example.com/sign-me.json',
+      sellerFeeBasisPoints: basisPoints(0),
+      tokenOwner: client.payer.address,
+    })
+    .sendTransaction();
+
+  const [metadataPda] = await client.mplTokenMetadata.pdas.metadata({
+    mint: mint.address,
+  });
+
+  await client.mplTokenMetadata.instructions
+    .signMetadata({
+      metadata: metadataPda,
+      creator: client.payer,
+    })
+    .sendTransaction();
+
+  const metadata = await client.mplTokenMetadata.accounts.metadata.fetch(metadataPda);
+  t.is(metadata.data.creators.__option, 'Some');
+  if (metadata.data.creators.__option === 'Some') {
+    const signer = metadata.data.creators.value.find(
+      (c) => c.address === client.payer.address
+    );
+    t.truthy(signer);
+    t.is(signer?.verified, true);
+  }
 });

--- a/clients/js-kit/test/printV1.test.ts
+++ b/clients/js-kit/test/printV1.test.ts
@@ -11,16 +11,14 @@
  */
 
 import test from 'ava';
+import { getSetComputeUnitLimitInstruction } from '@solana-program/compute-budget';
 import { TokenStandard, PrintSupply } from '../src/generated/types';
 import {
   getCreateV1InstructionAsync,
   getMintV1InstructionAsync,
   getPrintV1InstructionAsync,
 } from '../src/generated/instructions';
-import {
-  findMetadataPda,
-  findMasterEditionPda,
-} from '../src/generated/pdas';
+import { findMetadataPda, findMasterEditionPda } from '../src/generated/pdas';
 import { findAssociatedTokenPda } from './_setup';
 import { fetchMetadata, fetchMasterEdition } from '../src/generated/accounts';
 import {
@@ -195,7 +193,12 @@ test('it can print a new edition from a ProgrammableNonFungible', async (t) => {
     updateAuthority: masterOwner.address,
   });
 
-  await sendAndConfirm(rpc, rpcSubscriptions, printIx, [editionMint, editionOwner, masterOwner]);
+  await sendAndConfirmInstructions(
+    rpc,
+    rpcSubscriptions,
+    [getSetComputeUnitLimitInstruction({ units: 400_000 }), printIx],
+    [editionMint, editionOwner, masterOwner]
+  );
 
   // Verify the master edition supply was incremented
   const [masterEditionAddress] = await findMasterEditionPda({

--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "public:sync": "./configs/public-sync.sh"
   },
   "devDependencies": {
-    "@codama/nodes-from-anchor": "^1.3.9",
+    "@codama/nodes-from-anchor": "^1.4.1",
     "@codama/renderers": "^1.0.34",
-    "@codama/renderers-js": "^2.1.0",
+    "@codama/renderers-js": "^2.2.0",
     "@metaplex-foundation/amman": "^0.12.1",
     "@metaplex-foundation/kinobi": "1.0.0-alpha.0",
     "@metaplex-foundation/shank-js": "^0.1.0",
-    "codama": "^1.5.1",
+    "codama": "^1.6.0",
     "typescript": "^4.9.4"
   },
   "packageManager": "pnpm@8.9.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,14 +6,14 @@ settings:
 
 devDependencies:
   '@codama/nodes-from-anchor':
-    specifier: ^1.3.9
-    version: 1.3.9(fastestsmallesttextencoderdecoder@1.0.22)(typescript@4.9.5)
+    specifier: ^1.4.1
+    version: 1.4.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@4.9.5)
   '@codama/renderers':
     specifier: ^1.0.34
     version: 1.0.34(fastestsmallesttextencoderdecoder@1.0.22)(typescript@4.9.5)
   '@codama/renderers-js':
-    specifier: ^2.1.0
-    version: 2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@4.9.5)
+    specifier: ^2.2.0
+    version: 2.2.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@4.9.5)
   '@metaplex-foundation/amman':
     specifier: ^0.12.1
     version: 0.12.1(typescript@4.9.5)
@@ -24,8 +24,8 @@ devDependencies:
     specifier: ^0.1.0
     version: 0.1.0
   codama:
-    specifier: ^1.5.1
-    version: 1.5.1
+    specifier: ^1.6.0
+    version: 1.6.0
   typescript:
     specifier: ^4.9.4
     version: 4.9.5
@@ -39,14 +39,14 @@ packages:
       regenerator-runtime: 0.13.11
     dev: true
 
-  /@codama/cli@1.5.0:
-    resolution: {integrity: sha512-+q62IvEA6o7ji/mcnGgAvyPWyiFx3cojVGrFNG8NSm0zFXrBk1lT3n/qg+2Ag8C8aHwno9boXgDTxV+P5VCDYw==}
+  /@codama/cli@1.5.1:
+    resolution: {integrity: sha512-Cn9SokOi0IpixbdW1Aus61Qt0GCJhWE/+q1OdcvRBAQ4V0NacCpdf7N9aF9HR/H7AD+LWJa3JtK7pEs69ywM6Q==}
     hasBin: true
     dependencies:
-      '@codama/nodes': 1.5.1
-      '@codama/visitors': 1.5.1
-      '@codama/visitors-core': 1.5.1
-      commander: 14.0.2
+      '@codama/nodes': 1.6.0
+      '@codama/visitors': 1.6.0
+      '@codama/visitors-core': 1.6.0
+      commander: 14.0.3
       picocolors: 1.1.1
       prompts: 2.4.2
     dev: true
@@ -65,7 +65,16 @@ packages:
     hasBin: true
     dependencies:
       '@codama/node-types': 1.5.1
-      commander: 14.0.2
+      commander: 14.0.3
+      picocolors: 1.1.1
+    dev: true
+
+  /@codama/errors@1.6.0:
+    resolution: {integrity: sha512-Evj9wO5lqvxvbjxG856ITY5lhRN7SqoYfRX4tMMBjs8J/kT+pKQ8qL0hz9OynOOv/5mWn9Q/sPCNzQ6CUscibQ==}
+    hasBin: true
+    dependencies:
+      '@codama/node-types': 1.6.0
+      commander: 14.0.3
       picocolors: 1.1.1
     dev: true
 
@@ -77,12 +86,16 @@ packages:
     resolution: {integrity: sha512-jMGz93MSszb1iXAAyWWa0i7RQbLxGihLKRZ+zr9aBsjaFFmhXhONfTFeSXzbEfc05cajpd/gW2QI7xmQHlUDKQ==}
     dev: true
 
-  /@codama/nodes-from-anchor@1.3.9(fastestsmallesttextencoderdecoder@1.0.22)(typescript@4.9.5):
-    resolution: {integrity: sha512-7/E6vjy8GfdckZV6aRTt6YR8FjK8Fwt74au4p53uoocQ8zFWk9D1+d3WSxpKMNPKeFnAfI9hta/nT36XQ5MrGg==}
+  /@codama/node-types@1.6.0:
+    resolution: {integrity: sha512-atIJW2/3MjPYey0bNlE86W9Gvq9aq8bud7zT7PMyyhj98mbmLqPwT4wclPdbFua0fROLkq17z3bXaaJy5FqSEw==}
+    dev: true
+
+  /@codama/nodes-from-anchor@1.4.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@4.9.5):
+    resolution: {integrity: sha512-2RuLk/pCn+KXYSZoSA1k/sP1C4VzlbNFtMu2AxiBMXyyR8WYKFkrRghjI4IR+otwhknV7QhdFr8h5tuD+TSQ4g==}
     dependencies:
-      '@codama/errors': 1.5.1
-      '@codama/nodes': 1.5.1
-      '@codama/visitors': 1.5.1
+      '@codama/errors': 1.6.0
+      '@codama/nodes': 1.6.0
+      '@codama/visitors': 1.6.0
       '@noble/hashes': 2.0.1
       '@solana/codecs': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@4.9.5)
     transitivePeerDependencies:
@@ -102,6 +115,13 @@ packages:
     dependencies:
       '@codama/errors': 1.5.1
       '@codama/node-types': 1.5.1
+    dev: true
+
+  /@codama/nodes@1.6.0:
+    resolution: {integrity: sha512-F6Hy3REfl+Ih5R3jldPqEMjFqaPj871iBWX/LV0EtNK0xn7E4DG/3XCK4wlbHrOT9Z1NsiA70e0M1uChzmIrsw==}
+    dependencies:
+      '@codama/errors': 1.6.0
+      '@codama/node-types': 1.6.0
     dev: true
 
   /@codama/renderers-core@1.2.1:
@@ -130,7 +150,7 @@ packages:
       '@codama/visitors-core': 1.3.6
       '@solana/codecs-strings': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@4.9.5)
       nunjucks: 3.2.4
-      prettier: 3.6.2
+      prettier: 3.8.1
     transitivePeerDependencies:
       - chokidar
       - fastestsmallesttextencoderdecoder
@@ -145,20 +165,20 @@ packages:
       '@codama/renderers-core': 1.2.1
       '@codama/visitors-core': 1.3.6
       '@solana/codecs-strings': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@4.9.5)
-      prettier: 3.6.2
+      prettier: 3.8.1
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
     dev: true
 
-  /@codama/renderers-js@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@4.9.5):
-    resolution: {integrity: sha512-Zs9avEFb1+Y4GDPIBTEv/bhHCdjRkAkisWSqNo9edxQyfPj4GzV+0/FtE0AfR+yFkxQVHANlaEpo2dtdS0UPbA==}
+  /@codama/renderers-js@2.2.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@4.9.5):
+    resolution: {integrity: sha512-/GWVnB329kMkeqlOqX+NWQAmd1k6yybVOp7C5X+LEvrZ2A5w1saQwWFbBMCq/EQPqnFU+CRFoG/+7KubAEa73Q==}
     engines: {node: '>=20.18.0'}
     dependencies:
-      '@codama/errors': 1.5.1
-      '@codama/nodes': 1.5.1
+      '@codama/errors': 1.6.0
+      '@codama/nodes': 1.6.0
       '@codama/renderers-core': 1.3.6
-      '@codama/visitors-core': 1.5.1
+      '@codama/visitors-core': 1.6.0
       '@solana/codecs-strings': 6.5.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@4.9.5)
       prettier: 3.8.1
       semver: 7.7.4
@@ -202,12 +222,12 @@ packages:
       '@codama/visitors-core': 1.3.6
     dev: true
 
-  /@codama/validators@1.5.1:
-    resolution: {integrity: sha512-aUXl39AMa091CBWpYiK2XCXP/uyKOOtAT399TzRld3z8dIH9E0fGyu4ocP+IhQKXWXDPsh7V3qPmqsdyevOPcQ==}
+  /@codama/validators@1.6.0:
+    resolution: {integrity: sha512-QlLIQt6EpZ7sQvVOz8NFKtrzWLAwYzle0tet2Q0DDU8+4LO654lj+oAwjXzY3eAfTesqBqOgMCPtQe0EpGWk3g==}
     dependencies:
-      '@codama/errors': 1.5.1
-      '@codama/nodes': 1.5.1
-      '@codama/visitors-core': 1.5.1
+      '@codama/errors': 1.6.0
+      '@codama/nodes': 1.6.0
+      '@codama/visitors-core': 1.6.0
     dev: true
 
   /@codama/visitors-core@1.3.6:
@@ -226,12 +246,20 @@ packages:
       json-stable-stringify: 1.3.0
     dev: true
 
-  /@codama/visitors@1.5.1:
-    resolution: {integrity: sha512-8WcGP1tJKtqBfZ4mJsBRPjZ/H6+SPLWmiUoDTXRrVePQE4X4Yb04o6BoX2Uc3heZbfEc0rXdM1w8HTFvXBX4/A==}
+  /@codama/visitors-core@1.6.0:
+    resolution: {integrity: sha512-YG0rExvLbBCDAzXnZX6Imu4KwDoZrZz9NF232/nzs9Dr8uQuEWJ81x4VR9UxIcANHcF0+XwJzHamSwhZroAtjQ==}
     dependencies:
-      '@codama/errors': 1.5.1
-      '@codama/nodes': 1.5.1
-      '@codama/visitors-core': 1.5.1
+      '@codama/errors': 1.6.0
+      '@codama/nodes': 1.6.0
+      json-stable-stringify: 1.3.0
+    dev: true
+
+  /@codama/visitors@1.6.0:
+    resolution: {integrity: sha512-11/adC2WiH3+iMWluXkb+ae46sjoDm2xztI+CBEeIcBQd6mm4iuJTTRS0yrGfDwAJE1XzI/nc2MrR0Pvn+Rvvw==}
+    dependencies:
+      '@codama/errors': 1.6.0
+      '@codama/nodes': 1.6.0
+      '@codama/visitors-core': 1.6.0
     dev: true
 
   /@hapi/hoek@9.3.0:
@@ -315,7 +343,7 @@ packages:
     resolution: {integrity: sha512-hWd2JPrnt2/nJzkBpZD3Y6ZfCUlJujv2K7qUfsxdS0jSwLrSrOvYwmNWFw6mc3lbULj6VP4WDyuy9W5/CHU/lQ==}
     dependencies:
       debug: 4.3.4
-      semver: 7.3.8
+      semver: 7.7.4
       text-table: 0.2.0
       toml: 3.0.0
     transitivePeerDependencies:
@@ -954,15 +982,15 @@ packages:
       wrap-ansi: 7.0.0
     dev: true
 
-  /codama@1.5.1:
-    resolution: {integrity: sha512-kZbYgesIxwGNZ1JsYIWFzAsLtBuLZy/S1pCxJZgYaE13NJwDzi+bsEYqRSOUQ9ISN7FJR3SCyAE+vgzvcJpg2A==}
+  /codama@1.6.0:
+    resolution: {integrity: sha512-JKydzwNYJkGjkZ98ipehd3hJksLQU6nYS7x0GPjOwD0wih+xP8q7WCKgleN8LM2sRuC75rfpr3uXLXSpQpBYKA==}
     hasBin: true
     dependencies:
-      '@codama/cli': 1.5.0
-      '@codama/errors': 1.5.1
-      '@codama/nodes': 1.5.1
-      '@codama/validators': 1.5.1
-      '@codama/visitors': 1.5.1
+      '@codama/cli': 1.5.1
+      '@codama/errors': 1.6.0
+      '@codama/nodes': 1.6.0
+      '@codama/validators': 1.6.0
+      '@codama/visitors': 1.6.0
     dev: true
 
   /color-convert@2.0.1:
@@ -1484,13 +1512,6 @@ packages:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: true
 
-  /lru-cache@6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
-    dependencies:
-      yallist: 4.0.0
-    dev: true
-
   /make-synchronized@0.4.2:
     resolution: {integrity: sha512-EwEJSg8gSGLicKXp/VzNi1tvzhdmNBxOzslkkJSoNUCQFZKH/NIUIp7xlfN+noaHrz4BJDN73gne8IHnjl/F/A==}
     dev: true
@@ -1699,14 +1720,6 @@ packages:
     resolution: {integrity: sha512-DyL/pLbb9poQNQOVndVohclAO8lq+6gEBW8q3H9c2fX+ODkugQMvjBilPjw09lrIuVRFRQ/nwhLdzn60sFh9lQ==}
     dependencies:
       tokenize-whitespace: 0.0.1
-    dev: true
-
-  /semver@7.3.8:
-    resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
     dev: true
 
   /semver@7.7.4:
@@ -2043,10 +2056,6 @@ packages:
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
-    dev: true
-
-  /yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: true
 
   /yargs-parser@21.1.1:

--- a/trees/codama.json
+++ b/trees/codama.json
@@ -1,7 +1,7 @@
 {
   "kind": "rootNode",
   "standard": "codama",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "program": {
     "kind": "programNode",
     "name": "mplTokenMetadata",
@@ -31402,6 +31402,7 @@
         ]
       }
     ],
+    "events": [],
     "errors": [
       {
         "kind": "errorNode",


### PR DESCRIPTION
Adds `mplTokenMetadataProgram()` plugin overlay for existing codama-generated plugin (ref #182).
- Expose convenience instruction plans:
  - `createAndMint`
  - `createNft`
  - `createProgrammableNft`
- Expose aggregate asset fetchers:
  - `fetchDigitalAsset`
  - `fetchDigitalAssetByMetadata`
  - `fetchAllDigitalAsset`
  - `fetchDigitalAssetWithToken`
  - `fetchDigitalAssetWithAssociatedToken`
- Update js-kit dependencies around `@solana/kit@6.8.0` and plugin test utilities.
- Add plugin tests covering create/mint, generated fetchers, PDA helpers, and digital asset fetchers.
- Stabilize the PNFT `printV1` js-kit test by setting an explicit compute unit limit.

## Sample Client Code

```ts
import { createClient, generateKeyPairSigner, lamports } from '@solana/kit';
import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
import { systemProgram } from '@solana-program/system';
import { tokenProgram } from '@solana-program/token';
import { mplTokenMetadataProgram } from '@metaplex-foundation/mpl-token-metadata-kit';

const client = createClient()
  .use(generatedSigner())
  .use(solanaLocalRpc())
  .use(airdropSigner(lamports(10_000_000_000n)))
  .use(systemProgram())
  .use(tokenProgram())
  .use(mplTokenMetadataProgram());

const mint = await generateKeyPairSigner();

await client.mplTokenMetadata.instructions
  .createNft({
    mint,
    name: 'Plugin NFT',
    uri: 'https://example.com/nft.json',
    sellerFeeBasisPoints: 500,
    tokenOwner: client.payer.address,
  })
  .sendTransaction();

const asset = await client.mplTokenMetadata.fetchDigitalAsset(mint.address);

console.log(asset.metadata.name);
console.log(asset.edition?.isOriginal);
```

## Test Plan

```sh
cd clients/js-kit
pnpm build
pnpm test -- test/plugin.test.ts
pnpm test -- test/printV1.test.ts
pnpm test
```
